### PR TITLE
Set datetime fields to nullable rather than required

### DIFF
--- a/tools/bq/schemas/condition_occurrence.json
+++ b/tools/bq/schemas/condition_occurrence.json
@@ -22,7 +22,7 @@
     {
         "type": "timestamp", 
         "name": "condition_start_datetime", 
-        "mode": "required"
+        "mode": "nullable"
     }, 
     {
         "type": "date", 

--- a/tools/bq/schemas/device_exposure.json
+++ b/tools/bq/schemas/device_exposure.json
@@ -22,7 +22,7 @@
     {
         "type": "timestamp", 
         "name": "device_exposure_start_datetime", 
-        "mode": "required"
+        "mode": "nullable"
     }, 
     {
         "type": "date", 

--- a/tools/bq/schemas/drug_exposure.json
+++ b/tools/bq/schemas/drug_exposure.json
@@ -22,7 +22,7 @@
     {
         "type": "timestamp", 
         "name": "drug_exposure_start_datetime", 
-        "mode": "required"
+        "mode": "nullable"
     }, 
     {
         "type": "date", 

--- a/tools/bq/schemas/observation_period.json
+++ b/tools/bq/schemas/observation_period.json
@@ -17,7 +17,7 @@
     {
         "type": "timestamp", 
         "name": "observation_period_start_datetime", 
-        "mode": "required"
+        "mode": "nullable"
     }, 
     {
         "type": "date", 
@@ -27,7 +27,7 @@
     {
         "type": "timestamp", 
         "name": "observation_period_end_datetime", 
-        "mode": "required"
+        "mode": "nullable"
     }, 
     {
         "type": "integer", 

--- a/tools/bq/schemas/procedure_occurrence.json
+++ b/tools/bq/schemas/procedure_occurrence.json
@@ -22,7 +22,7 @@
     {
         "type": "timestamp", 
         "name": "procedure_datetime", 
-        "mode": "required"
+        "mode": "nullable"
     }, 
     {
         "type": "integer", 


### PR DESCRIPTION
 * As defined by OMOP spec (see https://github.com/OHDSI/CommonDataModel)
 * Datetimes in observation_period will likely be removed (see https://github.com/OHDSI/CommonDataModel/pull/64)