### PR TITLE
Changing import_rdr_omop to set up any table with person_id 

### DIFF
--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -104,16 +104,8 @@ def load_csv(schema_path, gcs_object_path, project_id, dataset_id, table_id, wri
             'writeDisposition': 'WRITE_TRUNCATE',
             'allowJaggedRows': allow_jagged_rows
             }
-    field_names = [field['name'] for field in fields]
-    if 'person_id' in field_names:
-        load['clustering'] = {
-            'fields': ['person_id']
-        }
-        load['timePartitioning'] = {
-            'type': 'DAY'
-        }
     job_body = {'configuration': {
-        'load': load
+            'load': load
         }
     }
     insert_job = bq_service.jobs().insert(projectId=project_id, body=job_body)

--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -273,38 +273,6 @@ def merge_tables(source_dataset_id,
     return True, ""
 
 
-def query_table(query_string):
-    """run a query job
-    :param query_string:    query command in SQL language.
-                            should contaon fully qualified ; dataset.table
-    :returns: query result (for details see
-                            https://https://goo.gl/xrXidw)
-    """
-    bq_service = create_service()
-
-    app_id = app_identity.get_application_id()
-
-    job_body = {
-        'configuration': {
-            "query": {
-                "query": query_string,
-            }
-        }
-    }
-
-    bq_service = create_service()
-    insert_result = bq_service.jobs().insert(projectId=app_id,
-                                             body=job_body).execute(num_retries=BQ_DEFAULT_RETRY_COUNT)
-    job_id = insert_result['jobReference']['jobId']
-    incomplete_jobs = wait_on_jobs([job_id])
-    if len(incomplete_jobs) > 0:
-        return None
-    # TODO if error we may not want to query
-    query_result = bq_service.jobs().getQueryResults(projectId=app_id,
-                                                     jobId=job_id).execute(num_retries=BQ_DEFAULT_RETRY_COUNT)
-    return query_result
-
-
 def query(q, use_legacy_sql=False, destination_table_id=None, retry_count=BQ_DEFAULT_RETRY_COUNT,
           write_disposition='WRITE_EMPTY', destination_dataset_id=None):
     """

--- a/data_steward/resources/fields/concept.json
+++ b/data_steward/resources/fields/concept.json
@@ -42,13 +42,13 @@
         "description": "The concept code represents the identifier of the Concept in the source vocabulary, such as SNOMED-CT concept IDs, RxNorm RXCUIs etc. Note that concept codes are not unique across vocabularies."
     }, 
     {
-        "type": "date", 
+        "type": "string", 
         "name": "valid_start_date", 
         "mode": "required", 
         "description": "The date when the Concept was first recorded. The default value is 1-Jan-1970, meaning, the Concept has no (known) date of inception."
     }, 
     {
-        "type": "date", 
+        "type": "string", 
         "name": "valid_end_date", 
         "mode": "required", 
         "description": "The date when the Concept became invalid because it was deleted or superseded (updated) by a new concept. The default value is 31-Dec-2099, meaning, the Concept is valid until it becomes deprecated."

--- a/data_steward/test/unit_test/bq_utils_test.py
+++ b/data_steward/test/unit_test/bq_utils_test.py
@@ -91,7 +91,6 @@ class BqUtilsTest(unittest.TestCase):
         table_info = bq_utils.get_table_info(table_id)
         num_rows = table_info.get('numRows')
         self.assertEqual(num_rows, '5')
-        self._table_has_clustering(table_info)
 
     def test_load_cdm_csv_error_on_bad_table_name(self):
         with self.assertRaises(ValueError) as cm:
@@ -194,13 +193,13 @@ class BqUtilsTest(unittest.TestCase):
 
     def test_create_table(self):
         table_id = 'some_random_table_id'
-        fields = [dict(name='id', type='integer', mode='required'),
+        fields = [dict(name='person_id', type='integer', mode='required'),
                   dict(name='name', type='string', mode='nullable')]
         result = bq_utils.create_table(table_id, fields)
         self.assertTrue('kind' in result)
         self.assertEqual(result['kind'], 'bigquery#table')
-        # sanity check
-        self.assertTrue(bq_utils.table_exists(table_id))
+        table_info = bq_utils.get_table_info(table_id)
+        self._table_has_clustering(table_info)
 
     def test_create_existing_table_without_drop_raises_error(self):
         table_id = 'some_random_table_id'

--- a/data_steward/test/unit_test/validation_test.py
+++ b/data_steward/test/unit_test/validation_test.py
@@ -4,8 +4,10 @@ import unittest
 import mock
 from google.appengine.ext import testbed
 
-import common
+import json
 import os
+import common
+import bq_utils
 import gcs_utils
 import resources
 import test_util
@@ -195,8 +197,7 @@ class ValidationTest(unittest.TestCase):
             self.assertListEqual(expected_result_items, actual_result_items)
             self.assertTrue(main.all_required_files_loaded(test_util.FAKE_HPO_ID, folder_prefix=prefix))
 
-        import bq_utils
-        import json
+        # check tables exist and are clustered as expected
         for table in expected_tables:
             fields_file = os.path.join(resources.fields_path, table + '.json')
             table_id = bq_utils.get_table_id(test_util.FAKE_HPO_ID, table)

--- a/data_steward/tools/import_rdr_omop.sh
+++ b/data_steward/tools/import_rdr_omop.sh
@@ -30,8 +30,12 @@ do
   table_name="${filename%.*}"
   echo "Importing ${DATA_SET}.${table_name}..."
   bq rm -f ${DATA_SET}.${table_name}
-  schema_name="${table_name}"
-  bq load --allow_quoted_newlines --skip_leading_rows=1 ${DATA_SET}.${table_name} $file resources/fields/${schema_name}.json
+  CLUSTERING_ARGS=
+  if grep -q person_id resources/fields/${table_name}.json
+  then
+    CLUSTERING_ARGS="--time_partitioning_type=DAY --clustering_fields person_id "
+  fi
+  bq load --allow_quoted_newlines ${CLUSTERING_ARGS}--skip_leading_rows=1 ${DATA_SET}.${table_name} $file resources/fields/${table_name}.json
 done
 
 echo "Done."


### PR DESCRIPTION
as clustered on it. (This currently requires the project to be whitelisted.)

Dropping RDR-specific observation table logic.

Changing concept date columns to be strings (as this is more convenient when exporting data to Cloud SQL later.)