### PR TITLE
[DC-143] Improperly CaSeD cdm file names should generate warnings

### DIFF
--- a/data_steward/test/test_data/bad_file_names_warnings.csv
+++ b/data_steward/test/test_data/bad_file_names_warnings.csv
@@ -1,0 +1,3 @@
+"file_name","message"
+"MEASUREMENT.csv","Unknown file"
+"PERSON.csv","Unknown file"

--- a/data_steward/test/unit_test/test_util.py
+++ b/data_steward/test/unit_test/test_util.py
@@ -14,6 +14,7 @@ ALL_FILES_UNPARSEABLE_VALIDATION_RESULT = os.path.join(TEST_DATA_PATH, 'all_file
 ALL_FILES_UNPARSEABLE_VALIDATION_RESULT_NO_HPO_JSON = os.path.join(TEST_DATA_PATH, 'all_files_unparseable_validation_result_no_hpo.json')
 BAD_PERSON_FILE_BQ_LOAD_ERRORS_CSV = os.path.join(TEST_DATA_PATH, 'bq_errors_bad_person.csv')
 EMPTY_WARNINGS_CSV = os.path.join(TEST_DATA_PATH, 'empty_warnings.csv')
+BAD_FILE_NAMES_WARNINGS_CSV = os.path.join(TEST_DATA_PATH, 'bad_file_names_warnings.csv')
 
 # Test files for five person sample
 FIVE_PERSONS_PATH = os.path.join(TEST_DATA_PATH, 'five_persons')

--- a/data_steward/test/unit_test/validation_test.py
+++ b/data_steward/test/unit_test/validation_test.py
@@ -310,6 +310,21 @@ class ValidationTest(unittest.TestCase):
                 expected = f.read()
                 self.assertEqual(expected, actual_result)
 
+    @mock.patch('api_util.check_cron')
+    def test_warnings_file(self, mock_check_cron):
+        folder_prefix = 'dummy-prefix-2018-03-22/'
+        test_util.write_cloud_str(self.hpo_bucket, folder_prefix + 'PERSON.csv', contents_str='.')
+        test_util.write_cloud_str(self.hpo_bucket, folder_prefix + 'MEASUREMENT.csv', contents_str='.')
+
+        main.app.testing = True
+        with main.app.test_client() as c:
+            c.get(test_util.VALIDATE_HPO_FILES_URL)
+            actual_result = test_util.read_cloud_file(self.hpo_bucket, folder_prefix + common.WARNINGS_CSV)
+            with open(test_util.BAD_FILE_NAMES_WARNINGS_CSV, 'r') as f:
+                expected = f.read()
+                self.assertEqual(expected, actual_result)
+
+
     def tearDown(self):
         self._empty_bucket()
         bucket_nyc = gcs_utils.get_hpo_bucket('nyc')

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -371,7 +371,7 @@ def _get_to_process_list(bucket, bucket_items, force_process=False):
 
 
 def _is_cdm_file(gcs_file_name):
-    return gcs_file_name.lower() in common.CDM_FILES
+    return gcs_file_name in common.CDM_FILES
 
 
 @api_util.auth_required_cron


### PR DESCRIPTION
Fixed handling of the improper casing of filenames. Any files that aren't in lower case will be reported in the warnings.csv as unknown files.