### PR TITLE
Check whether tables exist when generating queries for EHR union

### DIFF
--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -13,7 +13,8 @@ import time
 import logging
 
 BQ_DEFAULT_RETRY_COUNT = 10
-LIST_TABLES_MAX_RESULTS = 100
+# Maximum results returned by list_tables (API has a low default value)
+LIST_TABLES_MAX_RESULTS = 2000
 
 
 class InvalidOperationError(RuntimeError):


### PR DESCRIPTION
 * Exclude from mapping and load logic any references to tables missing from input dataset
 * Increase maximum results returned by bq_utils.list_tables (prod has >1000 tables)