### PR TITLE
Adjust date shift inverval

### DIFF
--- a/data_steward/deid/src/deid.py
+++ b/data_steward/deid/src/deid.py
@@ -692,7 +692,7 @@ def initialization(client,dataset):
 
         #Create the date shift
         sql = """    
-        SELECT person_id, CAST (365*rand() AS INT64) as date_shift
+        SELECT person_id, CAST(CEIL(365*rand()) AS INT64) as date_shift
         FROM :i_dataset.person 
         """.replace(":i_dataset",dataset)
         job = bq.QueryJobConfig()


### PR DESCRIPTION
This change alters the implicit "round()" performed by the cast to an explicit "ceil()" so that the result is a uniform [1,365] date_shift instead of the mostly uniform [0,365] date_shift.