### PR TITLE
[DC-336]  Load rdr etl into bigquery

### DIFF
--- a/data_steward/resources/fields/observation_period.json
+++ b/data_steward/resources/fields/observation_period.json
@@ -1,42 +1,42 @@
 [
     {
-        "type": "integer", 
-        "name": "observation_period_id", 
-        "mode": "required", 
+        "type": "integer",
+        "name": "observation_period_id",
+        "mode": "required",
         "description": "A unique identifier for each observation period."
-    }, 
+    },
     {
-        "type": "integer", 
-        "name": "person_id", 
-        "mode": "required", 
+        "type": "integer",
+        "name": "person_id",
+        "mode": "required",
         "description": "A foreign key identifier to the person for whom the observation period is defined. The demographic details of that person are stored in the person table."
-    }, 
+    },
     {
-        "type": "date", 
-        "name": "observation_period_start_date", 
-        "mode": "required", 
+        "type": "date",
+        "name": "observation_period_start_date",
+        "mode": "required",
         "description": "The start date of the observation period for which data are available from the data source."
-    }, 
+    },
     {
-        "type": "timestamp", 
-        "name": "observation_period_start_datetime", 
-        "mode": "required"
-    }, 
-    {
-        "type": "date", 
-        "name": "observation_period_end_date", 
-        "mode": "required", 
+        "type": "date",
+        "name": "observation_period_end_date",
+        "mode": "required",
         "description": "The end date of the observation period for which data are available from the data source."
-    }, 
+    },
     {
-        "type": "timestamp", 
-        "name": "observation_period_end_datetime", 
-        "mode": "required"
-    }, 
-    {
-        "type": "integer", 
-        "name": "period_type_concept_id", 
-        "mode": "required", 
+        "type": "integer",
+        "name": "period_type_concept_id",
+        "mode": "required",
         "description": "A foreign key identifier to the predefined concept in the Standardized Vocabularies reflecting the source of the observation period information"
+    },
+    {
+        "type": "timestamp",
+        "name": "observation_period_start_datetime",
+        "mode": "nullable"
+    },
+    {
+        "type": "timestamp",
+        "name": "observation_period_end_datetime",
+        "mode": "nullable"
     }
 ]

--- a/data_steward/tools/import_rdr_omop.sh
+++ b/data_steward/tools/import_rdr_omop.sh
@@ -35,7 +35,12 @@ do
   then
     CLUSTERING_ARGS="--time_partitioning_type=DAY --clustering_fields person_id "
   fi
-  bq load --allow_quoted_newlines ${CLUSTERING_ARGS}--skip_leading_rows=1 ${DATA_SET}.${table_name} $file resources/fields/${table_name}.json
+  JAGGED_ROWS=
+  if [ "${filename}" = "observation_period.csv" ]
+  then
+    JAGGED_ROWS="--allow_jagged_rows "
+  fi
+  bq load --allow_quoted_newlines ${JAGGED_ROWS}${CLUSTERING_ARGS}--skip_leading_rows=1 ${DATA_SET}.${table_name} $file resources/fields/${table_name}.json
 done
 
 echo "Done."


### PR DESCRIPTION
While loading the rdr data into bigquery, the observation_period
csv broke the script.  This updates the script to allow jagged
line csvs with trailing nullable fields for the observation_period
csv.  It moves the nullable timestamp field definitions to the end
of the json definition file and updates the command line as needed.