### PR TITLE
[DC-544]\[DC-513] fix generalization copies

### DIFF
--- a/data_steward/deid/config/ids/config.json
+++ b/data_steward/deid/config/ids/config.json
@@ -3,37 +3,22 @@
         "_id":"generalize",
         "RACE": [
             {
-                "comment": "trying to force a case statement in this rule only",
+                "comment": "perform aggregation first",
                 "apply": "SQL",
                 "statement": [
-                    "case ",
-                    "when ",
                     "(select count(obs.person_id) ",
                     "from :idataset.:table as obs ",
                     "where obs.person_id = :table.person_id and obs.value_source_concept_id IN (1586141, 1586142, 1586143, 1586144, 1586145, 1586146) ",
-                    "group by obs.person_id ",
-                    ") > 1 and value_source_concept_id <> 1586147 then 2000000008 ",
-                    "when value_source_concept_id IN (1586141, 1586144, 1586145) then 2000000001 ",
-                    "else value_source_concept_id ",
-                    "end "
-                ]
-            }
-        ],
-        "RACE_USING_IF_ELSE":[
-            {
-                "comment":"multi racial generalization rule, the values the count is limited to is provided by the 'on' key",
-                "apply":"COUNT-DISTINCT",
-                "into":2000000008,
-                "qualifier":"> 1",
-                "distinct": "value_source_concept_id",
-                "on": "value_source_concept_id = 1586141 or value_source_concept_id = 1586142 or value_source_concept_id = 1586143 or value_source_concept_id = 1586144 or value_source_concept_id = 1586145 or value_source_concept_id = 1586146"
+                    "group by obs.person_id ) "
+                ],
+                "qualifier": " > 1 and value_source_concept_id != 1586147 ",
+                "into": 2000000008
             },
             {
-                "comment":"generalizing minorities into a group",
+                "comment": "generalize single race values",
                 "values":[1586141, 1586144, 1586145],
                 "into":2000000001,
                 "qualifier":"IN"
-
             }
         ],
         "STATE": [
@@ -62,32 +47,31 @@
         ],
         "GENDER":[
             {
-                "comment":"multi gender generalization rule, the values the count is limited to is provided by the 'on' key",
-                "apply":"COUNT-DISTINCT",
-                "into":2000000002,
-                "qualifier":"> 1",
-                "distinct": "value_source_concept_id",
-                "on": "value_source_concept_id = 1585839 or value_source_concept_id = 1585840 or value_source_concept_id = 1585841 or value_source_concept_id = 1585842 or value_source_concept_id = 1585843"
+                "comment": "multi gender generalization rule, the values the count is limited to is provided by the 'on' key",
+                "apply": "COUNT",
+                "into": 2000000002,
+                "qualifier": "> 1",
+                "values": [1585839, 1585840, 1585841, 1585842, 1585843]
             },
             {
-                "comment":"values that are not male or female will be generalized into other",
-                "qualifier":"IN",
-                "values":[903096, 903079, 1585843, 1585841,1585842],
+                "comment": "values that are not male or female will be generalized into other",
+                "qualifier": "IN",
+                "values": [903096, 903079, 1585843, 1585841,1585842],
                 "into": 2000000002
             }
         ],
         "EDUCATION":[
             {
-                "comment":"generalizing to no highschool degree",
+                "comment": "generalizing to no highschool degree",
                 "qualifier": "IN",
                 "values": [1585941, 1585942, 1585943, 1585944],
                 "into": 2000000007
             },
             {
-                "comment":"generalizing to above highschool degree",
+                "comment": "generalizing to above highschool degree",
                 "into": 2000000006,
-                "values":[1585947, 1585948],
-                "qualifier":"IN"
+                "values": [1585947, 1585948],
+                "qualifier": "IN"
             }
         ],
         "EMPLOYMENT":[

--- a/data_steward/deid/config/ids/tables/observation.json
+++ b/data_steward/deid/config/ids/tables/observation.json
@@ -9,23 +9,27 @@
             "key_field": "my_table.person_id",
             "key_row": "my_table.value_source_concept_id",
             "value_field": "observation.person_id",
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1586140)) "
+            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1586140)) ",
+            "copy_to": ["value_as_concept_id"]
         },
         {
             "rules": "@generalize.STATE",
             "fields": ["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585249)) "
+            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585249)) ",
+            "copy_to": ["value_as_concept_id"]
         },
         {
             "rules":"@generalize.SEXUAL-ORIENTATION",
             "fields":["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585899)) "
+            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585899)) ",
+            "copy_to": ["value_as_concept_id"]
         },
 
          {
              "rules":"@generalize.SEX-AT-BIRTH",
              "fields":["value_source_concept_id"],
-             "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585845)) "
+             "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585845)) ",
+            "copy_to": ["value_as_concept_id"]
          },
         {
             "rules":"@generalize.GENDER",
@@ -36,17 +40,20 @@
             "key_field":"find_gender.person_id",
             "key_row": "find_gender.value_source_concept_id",
             "value_field":"observation.person_id",
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585838)) "
+            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585838)) ",
+            "copy_to": ["value_as_concept_id"]
         },
         {
             "rules":"@generalize.EDUCATION",
             "fields":["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585940)) "
+            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585940)) ",
+            "copy_to": ["value_as_concept_id"]
         },
          {
             "rules":"@generalize.EMPLOYMENT",
             "fields":["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585952)) "
+            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585952)) ",
+            "copy_to": ["value_as_concept_id"]
          }
     ],
     "compute": [


### PR DESCRIPTION
This patch replaces if/else statements with CASE statements for generalizing the values of particular fields.
For the generalized "copy_to" feature, it ensures a generalized value is only copied if a generalization actually happens on the source field.  If a generalization doesn't
happen, the field that would be copied over instead retains its original value.