### PR TITLE
Add 'git bash for windows' compatibility for notebooks/start.sh

### DIFF
--- a/data_steward/notebooks/bq.py
+++ b/data_steward/notebooks/bq.py
@@ -1,4 +1,11 @@
+import os
+
+from google import datalab
 from google.datalab import bigquery
+
+# In Windows we found that datalab project_id resolution prioritizes an obscure config.json over env vars
+# APPLICATION_ID or PROJECT_ID. This explicitly sets it to env var PROJECT_ID.
+datalab.Context.default().set_project_id(project_id=os.getenv('PROJECT_ID'))
 
 
 # Wrapper so we can more easily swap to whatever client library we prefer in the future

--- a/data_steward/notebooks/start.sh
+++ b/data_steward/notebooks/start.sh
@@ -20,10 +20,8 @@ fi
 # Determine separator to use for directories and PYTHONPATH
 # only tested on Git Bash for Windows
 SEP=':'
-PATHSEP='/'
 if [[ "$OSTYPE" == "msys" ]]; then
   SEP=';'
-  PATHSEP='\'
 fi
 
 NOTEBOOKS_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
@@ -32,10 +30,7 @@ export PYTHONPATH="${PYTHONPATH}${SEP}${NOTEBOOKS_DIR}${SEP}${BASE_DIR}"
 export GOOGLE_APPLICATION_CREDENTIALS="${KEY_FILE}"
 
 export APPLICATION_ID=$(cat ${KEY_FILE} | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["project_id"]);')
-
-if [[ "$OSTYPE" == "msys" ]]; then
-  export PROJECT_ID="${APPLICATION_ID}"
-fi
+export PROJECT_ID="${APPLICATION_ID}"
 
 ACCOUNT=$(cat ${KEY_FILE} | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["client_email"]);')
 
@@ -73,11 +68,11 @@ python -m pip install -U -r "${NOTEBOOKS_DIR}/requirements.txt"
 # The path set to /c/path/to/file gets converted to C:\\c\\path\\to\\file
 # instead of C:\\path\\to\\file, requiring the following fix for Git Bash for Windows
 if [[ "$OSTYPE" == "msys" ]]; then
-  for i in $(echo $PYTHONPATH | sed "s/;/ /g")
+  for i in $(echo "${PYTHONPATH//;/ }")
   do
-      PATH_VAR="$(echo ${i} | tail -c +3)"
-      echo "${PATH_VAR}"
+      PATH_VAR="$(echo "${i}" | tail -c +3)"
       export PYTHONPATH="${PYTHONPATH}${SEP}${PATH_VAR}"
+      echo "Added path ${PATH_VAR}"
   done
 fi
 

--- a/data_steward/notebooks/start.sh
+++ b/data_steward/notebooks/start.sh
@@ -16,12 +16,27 @@ then
   echo "Usage: $USAGE"
   exit 1
 fi
+
+# Determine separator to use for directories and PYTHONPATH
+# only tested on Git Bash for Windows
+SEP=':'
+PATHSEP='/'
+if [[ "$OSTYPE" == "msys" ]]; then
+  SEP=';'
+  PATHSEP='\'
+fi
+
 NOTEBOOKS_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 BASE_DIR="$( cd "${NOTEBOOKS_DIR}" && cd .. && pwd )"
-export PYTHONPATH="${PYTHONPATH}:${NOTEBOOKS_DIR}:${BASE_DIR}"
+export PYTHONPATH="${PYTHONPATH}${SEP}${NOTEBOOKS_DIR}${SEP}${BASE_DIR}"
 export GOOGLE_APPLICATION_CREDENTIALS="${KEY_FILE}"
 
 export APPLICATION_ID=$(cat ${KEY_FILE} | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["project_id"]);')
+
+if [[ "$OSTYPE" == "msys" ]]; then
+  export PROJECT_ID="${APPLICATION_ID}"
+fi
+
 ACCOUNT=$(cat ${KEY_FILE} | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["client_email"]);')
 
 echo "Activating service account ${ACCOUNT} for application ID ${APPLICATION_ID}..."
@@ -54,6 +69,18 @@ source "${BIN_PATH}/activate"
 echo "Which python: $(which python)"
 python -m pip install -U pip
 python -m pip install -U -r "${NOTEBOOKS_DIR}/requirements.txt"
+
+# The path set to /c/path/to/file gets converted to C:\\c\\path\\to\\file
+# instead of C:\\path\\to\\file, requiring the following fix for Git Bash for Windows
+if [[ "$OSTYPE" == "msys" ]]; then
+  for i in $(echo $PYTHONPATH | sed "s/;/ /g")
+  do
+      PATH_VAR="$(echo ${i} | tail -c +3)"
+      echo "${PATH_VAR}"
+      export PYTHONPATH="${PYTHONPATH}${SEP}${PATH_VAR}"
+  done
+fi
+
 jupyter nbextension enable --py --sys-prefix qgrid
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
 jupyter notebook --notebook-dir=${BASE_DIR}


### PR DESCRIPTION
* Add path separator for windows
* Add PROJECT_ID environment variable for google.datalab
* Fix paths added to PYTHONPATH (/c/path/) to (C:\\path)