### PR TITLE
Use env var GOOGLE_CLOUD_PROJECT rather than GAE_APPLICATION

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,6 @@ jobs:
       - run: sudo apt install software-properties-common
       # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
       - run: mkdir -p $CIRCLE_ARTIFACTS
-      # This is based on our 1.0 configuration file or project settings
-      - run:
-          command: ./init_env.sh
       - run:
           command: echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run:
@@ -36,6 +33,8 @@ jobs:
           command: ./ci/activate_creds.sh ${HOME}/gcloud-credentials-key.json
       - run:
           command: echo "export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-credentials-key.json" >> ${BASH_ENV}
+      - run:
+          command: ./init_env.sh
       - run:
           command: ./ci/setup.sh
       # Dependencies

--- a/data_steward/app_identity.py
+++ b/data_steward/app_identity.py
@@ -1,11 +1,13 @@
 import os
 
-GAE_APPLICATION = 'GAE_APPLICATION'
+GOOGLE_CLOUD_PROJECT = 'GOOGLE_CLOUD_PROJECT'
 
 
 def get_application_id():
     """
-    Get the ID of the app engine application
+    Get the associated Google Cloud Project ID
+
     :return:
     """
-    return os.environ.get(GAE_APPLICATION)
+    # NOTE: Google interchangeably refers to this identifier as application_id or project_id
+    return os.environ.get(GOOGLE_CLOUD_PROJECT)

--- a/data_steward/init_env.sh
+++ b/data_steward/init_env.sh
@@ -7,8 +7,11 @@ then
     CONFIG=$1
 fi
 
+export KEY_FILE=${HOME}/gcloud-credentials-key.json
+export APPLICATION_ID=$(cat ${KEY_FILE} | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["project_id"]);')
+export GOOGLE_CLOUD_PROJECT=${APPLICATION_ID}
+
 # Require username in GH_USERNAME or CIRCLE_USERNAME
-export APPLICATION_ID="aou-res-curation-$CONFIG"
 export USERNAME=$(echo "${GH_USERNAME:-${CIRCLE_USERNAME:-}}" | tr '[:upper:]' '[:lower:]')
 
 if [ -z "${USERNAME}" ]
@@ -50,6 +53,7 @@ export UNIONED_DATASET_ID="${DATASET_PREFIX}_unioned"
 if [ -n "CIRCLECI" ]
 then
   echo "export APPLICATION_ID=${APPLICATION_ID}" >> $BASH_ENV
+  echo "export GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}" >> $BASH_ENV
   echo "export USERNAME=${USERNAME}" >> $BASH_ENV
   echo "export DRC_BUCKET_NAME=${DRC_BUCKET_NAME}" >> $BASH_ENV
   echo "export BUCKET_NAME_FAKE=${BUCKET_NAME_FAKE}" >> $BASH_ENV


### PR DESCRIPTION
GAE_APPLICATION which has region code

 * Reorder commands in build so circle derives it from key file and we do not need a new variable configured