### PR TITLE
[DC-544]/[DC-512] Generalizing Participant PIIState when EHR records …

### DIFF
--- a/data_steward/deid/config/ids/config.json
+++ b/data_steward/deid/config/ids/config.json
@@ -3,46 +3,75 @@
         "_id":"generalize",
         "RACE": [
             {
-                "comment": "perform aggregation first",
+                "comment": [
+                    "aggregate multi-race answers before generalizing ",
+                    "single race answers.  treat HLS as an ethnicity, ",
+                    "not a race."
+                ],
                 "apply": "SQL",
                 "statement": [
-                    "(select count(obs.person_id) ",
-                    "from :idataset.:table as obs ",
-                    "where obs.person_id = :table.person_id and obs.value_source_concept_id IN (1586141, 1586142, 1586143, 1586144, 1586145, 1586146) ",
-                    "group by obs.person_id ) "
+                    "(SELECT COUNT(obs.person_id) ",
+                    "FROM :idataset.:table AS obs ",
+                    "WHERE obs.person_id = :table.person_id ",
+                    "AND obs.value_source_concept_id IN (1586141, 1586142, 1586143, 1586144, 1586145, 1586146) ",
+                    "GROUP BY obs.person_id ) "
                 ],
-                "qualifier": " > 1 and value_source_concept_id != 1586147 ",
+                "qualifier": " > 1 AND value_source_concept_id != 1586147 ",
                 "into": 2000000008
             },
             {
                 "comment": "generalize single race values",
-                "values":[1586141, 1586144, 1586145],
-                "into":2000000001,
-                "qualifier":"IN"
+                "values": [1586141, 1586144, 1586145],
+                "into": 2000000001,
+                "qualifier": "IN"
             }
         ],
         "STATE": [
             {
-                "comment": "generalize states with a low number of participants",
+                "comment": [
+                    "generalize participant state when PIIState doesn't match ",
+                    "participant EHR state.  requires the reference tables ",
+                    "_mapping_person_src_hpos and _mapping_src_hpos_to_allowed_states ",
+                    "to be built during initialization."
+                ],
+                "apply": "SQL",
+                "statement": [
+                    "observation_id IN (SELECT observation_id FROM ( ",
+                    "SELECT DISTINCT src_hpo_id, obs.person_id, value_source_concept_id, observation_id ",
+                    "FROM :idataset._mapping_person_src_hpos AS person_hpos ",
+                    "JOIN :idataset.observation AS obs ",
+                    "USING (person_id) ",
+                    "LEFT JOIN :idataset._mapping_src_hpos_to_allowed_states ",
+                    "USING (src_hpo_id, value_source_concept_id) ",
+                    "WHERE observation_source_concept_id = 1585249  AND state IS NULL))"
+                ],
+                "into": 2000000011
+            },
+            {
+                "comment": "generalize the PIIState for participants with a low participant total",
                 "qualifier": "IN",
-                "values": [1585262, 1585263, 1585270, 1585271, 1585274, 1585275, 1585284, 1585299, 1585291, 1585300, 1585306, 1585304, 1585307, 1585309, 1585315, 1585313, 1585409, 1585411],
+                "values": [
+                    1585262, 1585263, 1585270, 1585271, 1585274, 1585275,
+                    1585284, 1585299, 1585291, 1585300, 1585304, 1585306,
+                    1585307, 1585309, 1585313, 1585315, 1585409, 1585411
+                ],
                 "into": 2000000011
             }
         ],
         "SEXUAL-ORIENTATION":[
             {
-                "comment": "generalize any answer that is not straight",
-                "qualifier":"IN",
-                "values":[903096, 903079, 1585901, 1585902, 1585903, 1585904],
-                "into":2000000003
+                "comment": "generalize any response that is not straight",
+                "qualifier": "IN",
+                "values": [903096, 903079, 1585901, 1585902, 1585903, 1585904],
+                "into": 2000000003
             }
         ],
         "SEX-AT-BIRTH":[
             {
-                "comment": "generalizing not male and not female responses",
-                "qualifier":"IN",
-                "values":[903096, 903079, 1585848, 1585849],
-                "into":2000000009
+                "comment": "generalize any response that is not male and not female",
+                "qualifier": "IN",
+                "values": [903096, 903079, 1585848, 1585849],
+                "into": 2000000009
             }
         ],
         "GENDER":[
@@ -204,7 +233,7 @@
             }
         ],
         "FILTERS":[
-            {"filter":"person_id IN (SELECT DISTINCT person_id FROM :idataset.deid_map)"}
+            {"filter":"person_id IN (SELECT DISTINCT person_id FROM :idataset._deid_map)"}
         ],
         "ICD-9":[
             {"apply":"REGEXP", "values":["^E8[0-4"],"description":"rare accidents"},
@@ -230,13 +259,13 @@
     },
     {
         "_id": "compute",
-        "id": ["(SELECT research_id FROM :idataset.deid_map WHERE deid_map.person_id = :value_field) as :FIELD"],
+        "id": ["(SELECT research_id FROM :idataset._deid_map WHERE _deid_map.person_id = :value_field) as :FIELD"],
         "response_id": [
             "(SELECT ",
             "CASE WHEN :value_field IS NULL THEN NULL ",
             "ELSE (",
                 "SELECT dqrm.research_response_id ",
-                "FROM :idataset.deid_questionnaire_response_map AS dqrm ",
+                "FROM :idataset._deid_questionnaire_response_map AS dqrm ",
                 "WHERE dqrm.questionnaire_response_id = :value_field) ",
             "END ) AS :FIELD"
         ],

--- a/data_steward/deid/config/ids/tables/observation.json
+++ b/data_steward/deid/config/ids/tables/observation.json
@@ -13,8 +13,15 @@
             "copy_to": ["value_as_concept_id"]
         },
         {
+            "comment": "IN PROGRESS.  intermediate commit here.",
             "rules": "@generalize.STATE",
             "fields": ["value_source_concept_id"],
+            "dataset": ":idataset",
+            "table": "observation",
+            "alias": "state_table",
+            "key_field": "state_table.person_id",
+            "key_row": "state_table.value_source_concept_id",
+            "value_field": "observation.person_id",
             "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585249)) ",
             "copy_to": ["value_as_concept_id"]
         },

--- a/data_steward/deid/rules.py
+++ b/data_steward/deid/rules.py
@@ -18,13 +18,18 @@
     Compute:
         Computed fields stored
 """
-import json
+# Python imports
 import logging
 
+# Third party imports
 import numpy as np
 
+# Project imports
 from parser import Parse
 from resources import fields_for
+
+LOGGER = logging.getLogger(__name__)
+
 
 def _get_case_condition_syntax(cond, regex, gen_value, rule, rules, syntax):
     """
@@ -159,9 +164,6 @@ class Deid(Rules):
     def aggregate(self, sql, **args):
         pass
 
-    def log(self, **args):
-        logging.info(json.dumps(args))
-
     def generalize(self, **args):
         """
         Apply generalizations given a set of rules.
@@ -191,7 +193,11 @@ class Deid(Rules):
                     # This will call a built-in SQL function (non-aggregate)'
                     # qualifier = rule['qualifier'] if 'qualifier' in rule else ''
                     fillter = args.get('filter', name)
-                    self.log(module='generalize', label=label.split('.')[1], on=name, type=rule['apply'])
+                    LOGGER.info('generalizing with SQL aggregates label:\t%s\t\t'
+                                'on:\t%s\t\ttype:\t%s\t\t',
+                                label.split('.')[1],
+                                name,
+                                rule['apply'])
 
                     if 'apply' not in self.store_syntax[store_id]:
                         regex = [rule['apply'], "(", fillter, " , '", "|".join(rule['values']), "') ", qualifier]
@@ -271,7 +277,10 @@ class Deid(Rules):
                     # @TODO: Document what is going on here
                     #   - An if or else type of generalization given a list of values or function
                     #   - IF <filter> IN <values>, THEN <generalized-value> else <attribute>
-                    self.log(module='generalize', label=label.split('.')[1], on=name, type='inline')
+                    LOGGER.info('generalizing inline arguments label:\t%s\t\t'
+                                'on:\t%s\t\ttype:\tinline',
+                                label.split('.')[1],
+                                name)
                     fillter = args.get('filter', name)
                     qualifier = rule.get('qualifier', '')
                     gen_value = args.get('into', rule.get('into', ''))
@@ -368,7 +377,7 @@ class Deid(Rules):
                             value = "0 AS " + name
 
                     out.append({"name": name, "apply": value, "label": label})
-                    self.log(module='suppression', label=label.split('.')[1], type='columns')
+                    LOGGER.info('suppress fields(columns) for:\t%s', label.split('.')[1])
                 else:
                     #
                     # If we have alist of fields to be removed, The following code will figure out which ones apply
@@ -390,7 +399,7 @@ class Deid(Rules):
                                     else:
                                         value = "0 AS " + name
                                 out.append({"name": name, "apply": (value), "label": label})
-            self.log(module='suppress', label=label.split('.')[1], on=fields, type='columns')
+            LOGGER.info('suppress fields(columns):\t%s\t\tfor:\t%s', label.split('.')[1], fields)
 
         else:
             #

--- a/data_steward/tools/deid_runner.sh
+++ b/data_steward/tools/deid_runner.sh
@@ -96,7 +96,7 @@ python "${DATA_STEWARD_DIR}/cdm.py" --component vocabulary "${cdr_deid}"
 "${DATA_STEWARD_DIR}"/tools/table_copy.sh --source_app_id "${APP_ID}" --target_app_id "${APP_ID}" --source_dataset "${vocab_dataset}" --target_dataset "${cdr_deid}"
 
 # apply deidentification on combined dataset
-python "${DATA_STEWARD_DIR}/tools/run_deid.py" --idataset "${cdr_id}" -p "${key_file}" -a submit --interactive | tee -a deid_output.txt
+python "${DATA_STEWARD_DIR}/tools/run_deid.py" --idataset "${cdr_id}" -p "${key_file}" -a submit --interactive  -c
 
 # generate ext tables in deid dataset
 python "${DATA_STEWARD_DIR}/tools/generate_ext_tables.py" -p "${APP_ID}" -d "${cdr_deid}" -c "${cdr_id}" -s

--- a/data_steward/tools/run_deid.py
+++ b/data_steward/tools/run_deid.py
@@ -3,6 +3,7 @@ Deid runner.
 
 A central script to execute deid for each table needing de-identification.
 """
+from datetime import datetime
 import logging
 import os
 from argparse import ArgumentParser
@@ -30,7 +31,9 @@ def add_console_logging(add_handler):
     This config should be done in a separate module, but that can wait
     until later.  Useful for debugging.
     """
-    logging.basicConfig(level=logging.INFO,
+    name = datetime.now().strftime('logs/run_deid-%Y-%m-%d.log')
+    logging.basicConfig(filename=name,
+                        level=logging.INFO,
                         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
     if add_handler:
@@ -38,7 +41,7 @@ def add_console_logging(add_handler):
         handler.setLevel(logging.INFO)
         formatter = logging.Formatter('%(levelname)s - %(name)s - %(message)s')
         handler.setFormatter(formatter)
-        LOGGER.addHandler(handler)
+        logging.getLogger('').addHandler(handler)
 
 
 def get_known_tables(field_path):
@@ -158,6 +161,10 @@ def parse_args(raw_args=None):
                         help=('Execute queries in INTERACTIVE mode.  Defaults to '
                               'execute queries in BATCH mode.')
                         )
+    parser.add_argument('-c', '--console-log', dest='console_log', action='store_true',
+                        required=False,
+                        help=('Log to the console as well as to a file.')
+                       )
     parser.add_argument('--version', action='version', version='deid-02')
     return parser.parse_args(raw_args)
 
@@ -168,8 +175,8 @@ def main(raw_args=None):
 
     Responsible for aggregating the tables deid will execute on and calling deid.
     """
-    add_console_logging(False)
     args = parse_args(raw_args)
+    add_console_logging(args.console_log)
     known_tables = get_known_tables(fields_path)
     configured_tables = get_known_tables('../deid/config/ids/tables')
     tables = get_output_tables(args.input_dataset, known_tables, args.skip_tables, args.tables)


### PR DESCRIPTION
…are from another state

Uses standard python logging in favor of the current logging defined for the AOU class only.
Moves supporting table creation out of the intialization module to support maintainability.
Allows skipping supporting table creation if not needed to be applied to a table (tables
for observation de-identification only need to be created when de-identifying the observation table).
Creates a working case statement for state generalizations.
The config file creates a rule that can be successfully
applied to de-identify the PIIState for participants whose
EHR source state does not match their PIIState.