### PR TITLE
[DC-551] Update app_base.yaml and gcloudignore for GAE py3

### DIFF
--- a/data_steward/.gcloudignore
+++ b/data_steward/.gcloudignore
@@ -80,13 +80,7 @@ ipython_config.py
 .python-version
 
 # Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
+*_env/
 
 # Ignored by the build system
 /setup.cfg

--- a/data_steward/.gcloudignore
+++ b/data_steward/.gcloudignore
@@ -93,3 +93,6 @@ config/
 test/
 *.sh
 dev_requirements.txt
+
+logs/
+LOGS/

--- a/data_steward/.gcloudignore
+++ b/data_steward/.gcloudignore
@@ -93,6 +93,5 @@ venv.bak/
 ci/
 config/
 test/
-tools/
 *.sh
 dev_requirements.txt

--- a/data_steward/.gcloudignore
+++ b/data_steward/.gcloudignore
@@ -1,0 +1,98 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+.git
+.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+.pytest_cache/
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Ignored by the build system
+/setup.cfg
+ci/
+config/
+test/
+tools/
+*.sh
+dev_requirements.txt

--- a/data_steward/.gcloudignore
+++ b/data_steward/.gcloudignore
@@ -10,6 +10,10 @@
 .git
 .gitignore
 
+# Duplicating .gitignore entries below because
+# the gcloudignore include directive does not accept paths (i.e. "../.gitignore")
+# and to reduce potential issues with *ignore inconsistencies
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/data_steward/app_base.yaml
+++ b/data_steward/app_base.yaml
@@ -13,6 +13,5 @@ handlers:
 #    script: auto
 
   - url: /.*
-    script: validation.main.app
     secure: always
     script: auto

--- a/data_steward/app_base.yaml
+++ b/data_steward/app_base.yaml
@@ -1,8 +1,11 @@
+service: ehr
+version: py3
 runtime: python37
+env: standard
 instance_class: B8
 basic_scaling:
+  idle_timeout: 3600s
   max_instances: 10
-  idle_timeout: 60m
 
 handlers:
 

--- a/data_steward/app_base.yaml
+++ b/data_steward/app_base.yaml
@@ -1,29 +1,16 @@
-runtime: python27
-api_version: 1
-threadsafe: yes
+runtime: python37
 instance_class: B8
 basic_scaling:
   max_instances: 10
   idle_timeout: 60m
 
-skip_files:
-  - ^(.*/)?#.*#$
-  - ^(.*/)?.*~$
-  - ^(.*/)?.*\.py[co]$
-  - ^(.*/)?.*\.sh$
-  - ^(.*/)?.*/RCS/.*$
-  - ^(.*/)?\..*$
-  - ci/
-  - config/
-  - test/
-  - tools/
-
 handlers:
 
-  - url: /admin/.*
-    script: admin.admin_api.app
-    secure: always
-    script: auto
+#  TODO set up handler for Admin API in py3
+#  - url: /admin/.*
+#    script: admin.admin_api.app
+#    secure: always
+#    script: auto
 
   - url: /.*
     script: validation.main.app

--- a/data_steward/app_base.yaml
+++ b/data_steward/app_base.yaml
@@ -1,5 +1,4 @@
 service: ehr
-version: py3
 runtime: python37
 env: standard
 instance_class: B8


### PR DESCRIPTION
 * Set runtime to python37
 * Remove obsolete directives: api_version, threadsafe and skip_files
 * Add .gcloudignore file to replace skip_files directive
 * Remove admin handler because multiple script keys not permitted,
   still must set up handler for it