### PR TITLE
[DC-544] Add the ability to run DML statements on de-identified tables

### DIFF
--- a/data_steward/deid/config/ids/config.json
+++ b/data_steward/deid/config/ids/config.json
@@ -17,7 +17,8 @@
                     "GROUP BY obs.person_id ) "
                 ],
                 "qualifier": " > 1 AND value_source_concept_id != 1586147 ",
-                "into": 2000000008
+                "into": 2000000008,
+                "drop_duplicates": "True"
             },
             {
                 "comment": "generalize single race values",
@@ -84,7 +85,8 @@
                 "apply": "COUNT",
                 "into": 2000000002,
                 "qualifier": "> 1",
-                "values": [1585839, 1585840, 1585841, 1585842, 1585843]
+                "values": [1585839, 1585840, 1585841, 1585842, 1585843],
+                "drop_duplicates": "True"
             },
             {
                 "comment": [
@@ -133,13 +135,15 @@
                 "comment":"this will generalize values to unemployed or not employed",
                 "qualifier":"IN",
                 "values":[1585955, 1585956, 1585957, 1585958, 1585959, 1585960],
-                "into":2000000005
+                "into":2000000005,
+                "drop_duplicates": "True"
             },
             {
                 "comment":"generalizing to currently employed",
                 "qualifier":"IN",
                 "values":[1585953, 1585954],
-                "into":2000000004
+                "into":2000000004,
+                "drop_duplicates": "True"
             }
         ]
 
@@ -275,10 +279,11 @@
             }
         ]
     },
-    {"_id":"shift",
-        "day":"SELECT date_shift from :table where :key_field=:key_value ",
-        "date":"DATE_SUB( CAST(:FIELD AS DATE), INTERVAL (:SHIFT) DAY) AS :FIELD",
-        "datetime":"TIMESTAMP_SUB( CAST(:FIELD AS TIMESTAMP), INTERVAL (:SHIFT) DAY) AS :FIELD"
+    {
+        "_id": "shift",
+        "day": "SELECT date_shift from :table where :key_field=:key_value ",
+        "date": "DATE_SUB( CAST(:FIELD AS DATE), INTERVAL (:SHIFT) DAY) AS :FIELD",
+        "datetime": "TIMESTAMP_SUB( CAST(:FIELD AS TIMESTAMP), INTERVAL (:SHIFT) DAY) AS :FIELD"
 
 
     },
@@ -297,5 +302,43 @@
         "month": ["EXTRACT (MONTH FROM :value_field) AS :FIELD"],
         "day": ["EXTRACT (DAY FROM :value_field) AS :FIELD"],
         "year": ["EXTRACT (YEAR FROM :value_field) AS :FIELD"]
+    },
+    {
+        "_id": "dml_statements",
+        "comment": [
+            "A place to define Data Manipulation Statments to execute after creating ",
+            "a de-identified table.  The statements are defined as a list of dictionaries ",
+            "containing a comment about the intent of each statement and an SQL DML statement."
+        ],
+        "observation": [
+            {
+                "comment": [
+                    "SQL to delete extra rows created by generalization rules. ",
+                    "This can happen when questions with multiple possible answers are ",
+                    "generalized.  The exact delete statement to use will depend on the ",
+                    "table receiving the generalization and its available fields."
+                ],
+                "name": "drop_generalized_duplicates",
+                "label": "cleaning_query",
+                "statement": [
+                    "DELETE FROM",
+                    ":odataset.observation AS o ",
+                    "WHERE observation_id in (",
+                      "SELECT observation_id FROM (",
+                         "SELECT DENSE_RANK() OVER(PARTITION BY person_id, observation_source_concept_id, value_source_concept_id ",
+                          "ORDER BY observation_datetime DESC, observation_id DESC) AS rank_order, ",
+                          "observation_id ",
+                          "FROM :odataset.observation ",
+                          "JOIN :idataset._mapping_observation AS map ",
+                          "USING (observation_id) ",
+                          "WHERE observation_source_concept_id IN (:key_values) ",
+                          "AND value_source_concept_id IN (:generalized_values) ",
+                          "AND map.src_hpo_id like \"rdr\"",
+                      ") o ",
+                      "WHERE o.rank_order <> 1 ",
+                    ")"
+                ]
+            }
+        ]
     }
 ]

--- a/data_steward/deid/config/ids/tables/observation.json
+++ b/data_steward/deid/config/ids/tables/observation.json
@@ -1,5 +1,5 @@
 {
-    "generalize":[
+    "generalize": [
         {
             "rules": "@generalize.RACE",
             "fields": ["value_source_concept_id"],
@@ -9,7 +9,11 @@
             "key_field": "my_table.person_id",
             "key_row": "my_table.value_source_concept_id",
             "value_field": "observation.person_id",
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1586140)) ",
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1586140]
+            },
             "copy_to": ["value_as_concept_id"]
         },
         {
@@ -22,44 +26,68 @@
             "key_field": "state_table.person_id",
             "key_row": "state_table.value_source_concept_id",
             "value_field": "observation.person_id",
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585249)) ",
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1585249]
+            },
             "copy_to": ["value_as_concept_id"]
         },
         {
-            "rules":"@generalize.SEXUAL-ORIENTATION",
-            "fields":["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585899)) ",
+            "rules": "@generalize.SEXUAL-ORIENTATION",
+            "fields": ["value_source_concept_id"],
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1585899]
+            },
             "copy_to": ["value_as_concept_id"]
         },
 
          {
-             "rules":"@generalize.SEX-AT-BIRTH",
-             "fields":["value_source_concept_id"],
-             "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585845)) ",
+            "rules": "@generalize.SEX-AT-BIRTH",
+            "fields": ["value_source_concept_id"],
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1585845]
+            },
             "copy_to": ["value_as_concept_id"]
          },
         {
-            "rules":"@generalize.GENDER",
-            "fields":["value_source_concept_id"],
+            "rules": "@generalize.GENDER",
+            "fields": ["value_source_concept_id"],
             "dataset": ":idataset",
             "table": "observation",
             "alias": "find_gender",
-            "key_field":"find_gender.person_id",
+            "key_field": "find_gender.person_id",
             "key_row": "find_gender.value_source_concept_id",
-            "value_field":"observation.person_id",
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585838)) ",
+            "value_field": "observation.person_id",
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1585838]
+            },
             "copy_to": ["value_as_concept_id"]
         },
         {
-            "rules":"@generalize.EDUCATION",
-            "fields":["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585940)) ",
+            "rules": "@generalize.EDUCATION",
+            "fields": ["value_source_concept_id"],
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1585940]
+            },
             "copy_to": ["value_as_concept_id"]
         },
          {
-            "rules":"@generalize.EMPLOYMENT",
-            "fields":["value_source_concept_id"],
-            "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (1585952)) ",
+            "rules": "@generalize.EMPLOYMENT",
+            "fields": ["value_source_concept_id"],
+            "on": {
+                "field": "observation_source_concept_id",
+                "qualifier": "in",
+                "values": [1585952]
+            },
             "copy_to": ["value_as_concept_id"]
          }
     ],
@@ -72,13 +100,13 @@
             "value_field": "observation.questionnaire_response_id"
         }
     ],
-    "shift":[
-        {"rules":"@shift.date",
-         "fields":["observation_date"]},
-        {"rules":"@shift.datetime",
-         "fields":["observation_datetime"]}
+    "shift": [
+        {"rules": "@shift.date",
+         "fields": ["observation_date"]},
+        {"rules": "@shift.datetime",
+         "fields": ["observation_datetime"]}
     ],
-    "suppress":[
+    "suppress": [
         {
             "comment": "removing specific ICD9CM and ICD10CM codes based on the value_source_concept_id field",
             "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and value_source_concept_id in (select concept_id from `:idataset.concept` where (vocabulary_id='ICD9CM' and (concept_code like 'E80%' OR concept_code like 'E81%' OR concept_code like 'E82%' OR concept_code like 'E83%' OR concept_code like 'E84%' OR concept_code like 'E913%' OR concept_code like 'E910%' OR concept_code like 'E928.0' OR concept_code like 'E95%' OR concept_code like 'E96%' OR concept_code like 'E97%' OR concept_code like 'E99%' OR concept_code = '799.9' OR concept_code = '799' OR concept_code = '798' OR concept_code like 'V3%' OR concept_code like '764%' OR concept_code like '765%' OR concept_code like '766%' OR concept_code like '767%' OR concept_code like '768%' OR concept_code like '769%' OR concept_code like '770%' OR concept_code like '771%' OR concept_code like '772%' OR concept_code like '773%' OR concept_code like '774%' OR concept_code like '775%' OR concept_code like '776%' OR concept_code like '777%' OR concept_code like '778%' OR concept_code like '779%')) OR (vocabulary_id='ICD10CM' and (concept_code like 'P%' OR concept_code like 'Z38%' OR concept_code = 'R99' OR concept_code like 'Y36%' OR concept_code like 'Y36%' OR concept_code like 'Y37%' OR concept_code like 'Y35%' OR concept_code like 'Y38%' OR concept_code like 'X52%' OR concept_code like 'V*' OR concept_code like 'W65%' OR concept_code like 'W66%' OR concept_code like 'W67%' OR concept_code like 'W68%' OR concept_code like 'W69%' OR concept_code like 'W70%' OR concept_code like 'W71%' OR concept_code like 'W72%' OR concept_code like 'W73%' OR concept_code like 'W74%' OR concept_code like 'X92%' OR concept_code like 'X93%' OR concept_code like 'X94%' OR concept_code like 'X95%' OR concept_code like 'X96%' OR concept_code like 'X97%' OR concept_code like 'X98%' OR concept_code like 'X99%' OR concept_code like 'Y00%' OR concept_code like 'Y01%' OR concept_code like 'Y02%' OR concept_code like 'Y03%' OR concept_code like 'Y04%' OR concept_code like 'Y05%' OR concept_code like 'Y06%' OR concept_code like 'Y07%' OR concept_code like 'Y08%' OR concept_code like 'Y09%'))))"
@@ -87,8 +115,8 @@
             "comment": "removing specific ICD9CM and ICD10CM codes based on the observation_source_concept_id field",
             "on": " exists (select * from `:idataset.observation` as record2 where :join_tablename.observation_id = record2.observation_id and observation_source_concept_id in (select concept_id from `:idataset.concept` where (vocabulary_id='ICD9CM' and (concept_code like 'E80%' OR concept_code like 'E81%' OR concept_code like 'E82%' OR concept_code like 'E83%' OR concept_code like 'E84%' OR concept_code like 'E913%' OR concept_code like 'E910%' OR concept_code like 'E928.0' OR concept_code like 'E95%' OR concept_code like 'E96%' OR concept_code like 'E97%' OR concept_code like 'E99%' OR concept_code = '799.9' OR concept_code = '799' OR concept_code = '798' OR concept_code like 'V3%' OR concept_code like '764%' OR concept_code like '765%' OR concept_code like '766%' OR concept_code like '767%' OR concept_code like '768%' OR concept_code like '769%' OR concept_code like '770%' OR concept_code like '771%' OR concept_code like '772%' OR concept_code like '773%' OR concept_code like '774%' OR concept_code like '775%' OR concept_code like '776%' OR concept_code like '777%' OR concept_code like '778%' OR concept_code like '779%')) OR (vocabulary_id='ICD10CM' and (concept_code like 'P%' OR concept_code like 'Z38%' OR concept_code = 'R99' OR concept_code like 'Y36%' OR concept_code like 'Y36%' OR concept_code like 'Y37%' OR concept_code like 'Y35%' OR concept_code like 'Y38%' OR concept_code like 'X52%' OR concept_code like 'V*' OR concept_code like 'W65%' OR concept_code like 'W66%' OR concept_code like 'W67%' OR concept_code like 'W68%' OR concept_code like 'W69%' OR concept_code like 'W70%' OR concept_code like 'W71%' OR concept_code like 'W72%' OR concept_code like 'W73%' OR concept_code like 'W74%' OR concept_code like 'X92%' OR concept_code like 'X93%' OR concept_code like 'X94%' OR concept_code like 'X95%' OR concept_code like 'X96%' OR concept_code like 'X97%' OR concept_code like 'X98%' OR concept_code like 'X99%' OR concept_code like 'Y00%' OR concept_code like 'Y01%' OR concept_code like 'Y02%' OR concept_code like 'Y03%' OR concept_code like 'Y04%' OR concept_code like 'Y05%' OR concept_code like 'Y06%' OR concept_code like 'Y07%' OR concept_code like 'Y08%' OR concept_code like 'Y09%'))))"
         },
-        {   "comment":"removing ethnic groups, alternative race and fields (data has redundancies)",
-             "on":"observation_concept_id in (4013886, 4271761, 4135376)"
+        {   "comment": "removing ethnic groups, alternative race and fields (data has redundancies)",
+             "on": "observation_concept_id in (4013886, 4271761, 4135376)"
         },
         {
             "comment": "remove nullable rows fix for the nullable based rule",

--- a/data_steward/deid/parser.py
+++ b/data_steward/deid/parser.py
@@ -56,13 +56,25 @@ class Parse(object):
     @staticmethod
     def suppress(row, cache, tablename):
         """
-        setup suppression rules to be applied the the given 'row' i.e entry
+        setup suppression rules to be applied to the 'row' i.e entry
         """
         return Parse.init('suppress', row, cache, tablename)
 
     @staticmethod
     def compute(row, cache, tablename):
+        """
+        Compute fields.
+
+        This includes shifting dates and mapping values.
+        """
         return Parse.init('compute', row, cache, tablename)
+
+    @staticmethod
+    def dml_statements(row, cache, tablename):
+        """
+        When indicated, it will create dml statements to execute after all other de-identifications.
+        """
+        return Parse.init('dml_statements', row, cache, tablename)
 
 
 # This is the pythonic way to parse system arguments

--- a/data_steward/deid/press.py
+++ b/data_steward/deid/press.py
@@ -1,20 +1,37 @@
 """
     This class applies rules and meta data to yield a certain outpout
 """
+# Project imports
 import codecs
 from datetime import datetime
 import json
 import logging
 import os
 
+# Third party imports
 import pandas as pd
 import numpy as np
 
-from rules import Deid
+# Project imports
+import bq_utils
+from resources import fields_for
+from rules import Deid, create_on_string
+
 
 LOGGER = logging.getLogger(__name__)
 
+
 def set_up_logging(log_path, idataset):
+    """
+    Set up python logging, if not previously set up.
+
+    If not previously set up, creates a python logger.  If python logging exists,
+    adds a file handler for deid.
+
+    :param log_path: desired string path of the log file.
+    :param idataset:  input dataset string name.  addded to the log_path to create
+        the output log file location.
+    """
     output_log_path = os.path.join(log_path, idataset)
     try:
         os.makedirs(output_log_path)
@@ -63,12 +80,12 @@ class Press(object):
         self.pipeline = args.get('pipeline', ['generalize', 'suppress', 'shift', 'compute'])
         try:
             with codecs.open(self.tablepath, 'r') as config:
-                self.info = json.loads(config.read())
+                self.table_info = json.loads(config.read())
         except StandardError:
             # In case a table name is not provided, we will apply default rules on he table
             #   I.e physical field suppression and row filter
             #   Date Shifting
-            self.info = {}
+            self.table_info = {}
 
         if isinstance(self.deid_rules, list):
             cache = {}
@@ -98,13 +115,29 @@ class Press(object):
         #
         # Let us update and see if the default filters apply at all
         dfilters = []
-        columns = self.get_dataframe(limit=1).columns.tolist()
+        columns = self.get_table_columns(self.tablename)
+
         for row in self.deid_rules['suppress']['FILTERS']:
             if set(columns) & set(row['filter'].split(' ')):
                 dfilters.append(row)
         self.deid_rules['suppress']['FILTERS'] = dfilters
 
-    def get(self, **args):
+
+    def get_table_columns(self, tablename):
+        """
+        Return a list of columns for the given table name.
+        """
+        info = bq_utils.get_table_info(tablename, dataset_id=self.idataset)
+        schema = info.get('schema', {})
+        fields = schema.get('fields')
+
+        field_names = []
+        for field in fields:
+            field_names.append(field.get('name'))
+
+        return field_names
+
+    def get_dataframe(self, sql=None, limit=None):
         """
         This function will execute an SQL statement and return the meta data for a given table
         """
@@ -128,44 +161,46 @@ class Press(object):
         """
         self.update_rules()
         d = Deid(pipeline=self.pipeline, rules=self.deid_rules, parent=self)
-        _info = self.info
 
-        p = d.apply(_info, self.store, self.get_tablename())
+        p = d.apply(self.table_info, self.store, self.get_tablename())
 
         is_meta = np.sum([1*('on' in _item) for _item in p]) != 0
-        LOGGER.info('table:\t%s\t\tis a meta table:\t%s', self.get_tablename(), int(is_meta))
+        LOGGER.info('table:\t%s\t\tis a meta table:\t%s', self.get_tablename(), is_meta)
         if not is_meta:
-            sql = self.to_sql(p)
+            sql = [self.to_sql(p)]
             _rsql = None
+            dml_sql = []
         else:
             #
             # Processing meta tables
             sql = []
             relational_cols = [col for col in p if 'on' not in col]
             meta_cols = [col for col in p if 'on' in col]
+
             _map = {}
             for col in meta_cols:
-                if col['on'] not in _map:
-                    _map[col['on']] = []
-                _map[col['on']] += [col]
+                on_string, _ = create_on_string(col['on'])
+                if on_string not in _map:
+                    _map[on_string] = {'specification': [], 'on': {}}
+                _map[on_string]['specification'] += [col]
+                _map[on_string]['on'] = col['on']
+
             fillter = []
             for filter_id in _map:
+                item = _map.get(filter_id, {}).get('specification', [])
+                item_filter = _map.get(filter_id, {}).get('on', {})
+                fillter.append(item_filter)
 
-                _item = _map[filter_id]
-                fillter.append(filter_id)
-
-                _sql = self.to_sql(_item + relational_cols)  + ' AND ' + filter_id
+                _sql = self.to_sql(item + relational_cols)  + ' AND ' + filter_id
 
                 sql.append(_sql)
 
-            _rsql = self.to_sql(relational_cols) + ' AND ' + ' AND '.join(fillter).replace(' IN ', ' NOT IN ')
-            _rsql = _rsql.replace(' exists ', ' NOT EXISTS ')
-            _rsql = _rsql.replace(' not NOT ', ' NOT ')
-            #
-            # @TODO: filters may need to be adjusted (add a conditional statement)
-            #
+            _rsql = self.gather_unfiltered_records(relational_cols, fillter)
 
             sql.append(_rsql)
+
+            # create additional SQL cleaning statements
+            dml_sql = self.gather_dml_queries(p)
 
             for index, segment in enumerate(sql):
                 formatted = segment.replace(':idataset', self.idataset)
@@ -180,9 +215,17 @@ class Press(object):
                 final_sql = "\n\nAppend these results to previous results\n\n".join(sql)
                 sql_file.write(final_sql)
 
+                if dml_sql:
+                    sql_file.write('\n\nDML SQL statements to execute on de-identified table data\n\n')
+                    final_sql = '\n\n  ----------------------------------\n\n'.join(dml_sql)
+                    sql_file.write(final_sql)
+
             if 'submit' in self.action:
                 for index, statement in enumerate(sql):
                     self.submit(statement, not index)
+
+                for statement in dml_sql:
+                    self.submit(statement, False, dml=True)
 
             if 'simulate' in self.action:
                 #
@@ -313,16 +356,18 @@ class Press(object):
 
     def to_sql(self, info):
         """
+        Create an SQL query from table information and config rules.
+
         :info   payload with information of the process to be performed
+
+        :return: An SQL query
         """
         table_name = self.get_tablename()
-        fields = self.get_dataframe(limit=1).columns.tolist()
+        fields = self.get_table_columns(self.tablename)
         columns = list(fields)
         sql_list = []
         LOGGER.info('generating-sql for table:\t%s\t\tfields:\t%s', table_name, fields)
-        #
-        # @NOTE:
-        #   If we are dealing with a meta-table we should
+
         for rule_id in self.pipeline:
             for row in info:
                 name = row['name']
@@ -338,6 +383,7 @@ class Press(object):
 
         if 'suppress' in self.deid_rules and 'FILTERS' in self.deid_rules['suppress']:
             suppression_filters = self.deid_rules['suppress']['FILTERS']
+
             if suppression_filters:
                 sql_list.append('WHERE')
             for row in suppression_filters:
@@ -345,7 +391,90 @@ class Press(object):
                     continue
 
                 sql_list.append(row['filter'])
-                if suppression_filters.index(row) < len(suppression_filters) - 1:
+                # add conjunction if not the last item in the filter list
+                if row != suppression_filters[-1]:
                     sql_list.append('AND')
 
-        return '\t'.join(sql_list).replace(":idataset", self.idataset)
+        return ' '.join(sql_list).replace(":idataset", self.idataset)
+
+    def gather_unfiltered_records(self, relational_cols, filter_list):
+        """
+        Gather all the records that are not generalized or suppressed.
+
+        Generalization only gathers those records a generalization applies to.
+        Any record that is unaltered, needs to be gathered via SQL statements
+        and added to the output table.  This uses the conditional clauses of
+        the rules to determine which records need to be sent to output without
+        generalizing or suppressing.  The mapped, shifted, and computed fields
+        are still mapped, shifted, and computed as in the other queries used to
+        create this table.
+
+        :param relational_cols: a list of columns that are always changed
+        :param filter_list: a list of filters applied to generalized columns
+        """
+        sql = self.to_sql(relational_cols)
+        sql += ' AND '
+
+        filter_list = self.create_filter_list(filter_list)
+        filter_string = ' AND '.join(filter_list)
+        filter_string = filter_string.replace(' in ', ' NOT IN ')
+        filter_string = filter_string.replace(' exists ', ' NOT EXISTS ')
+        filter_string = filter_string.replace(' not NOT ', ' NOT ')
+        return sql + filter_string
+
+    def create_filter_list(self, filter_list):
+        """
+        Create a list of filter expressions.
+
+        :param filter_list: a list of dictionaries representing the filter
+            expression to be used as part of an SQL WHERE clause
+
+        :return: a list of strings representing the expressions.
+        """
+        field_definitions = {}
+        for field_def in fields_for(self.tablename):
+            field_definitions[field_def.get('name')] = field_def
+
+        string_list = []
+        for item in filter_list:
+            string, field = create_on_string(item)
+
+            field_definition = field_definitions.get(field)
+            field_mode = field_definition.get('mode').lower()
+
+            # if based on a nullable field, make sure to use the exists function
+            if field_mode.lower() == 'nullable':
+                item['qualifier'] = item['qualifier'].upper()
+                string, _ = create_on_string(item)
+                nullable_str = (' exists (SELECT * FROM `:idataset.observation` AS record2 '
+                                'WHERE :join_tablename.observation_id = record2.observation_id '
+                                'AND {conditional})')
+                string = nullable_str.format(conditional=string)
+
+            string_list.append(string)
+
+        return string_list
+
+    def gather_dml_queries(self, info):
+        """
+        Gather DML statements to run on the output table.
+
+        Allows additional cleaning to happen on the table.  DML statements use
+        a different job config, so the statements must be separate from the
+        selection statements.
+
+        :param info:  A list of dictionaries containing queries, or query build
+            instructions
+
+        :return:  A list of SQL statements to execute.
+        """
+        sql_list = []
+
+        # add dml sql rules:  update, delete, insert, etc.
+        for rule in info:
+            if rule.get('dml_statement', False):
+                query = rule.get('apply')
+                LOGGER.info('adding dml statement:  %s', rule.get('name'))
+                sql_list.append(query)
+
+        return sql_list

--- a/data_steward/deid/press.py
+++ b/data_steward/deid/press.py
@@ -143,7 +143,7 @@ class Press(object):
         """
         return None
 
-    def submit(self, **args):
+    def submit(self, sql, create, dml=None):
         """
         Should be overridden by subclasses.
         """

--- a/data_steward/test/unit_test/data_steward/deid/press_test.py
+++ b/data_steward/test/unit_test/data_steward/deid/press_test.py
@@ -1,0 +1,76 @@
+# Python imports
+import unittest
+
+# Third party imports
+from mock import Mock, patch
+
+# Project imports
+from deid.press import Press 
+
+
+class PressTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    @patch('deid.press.json.loads')
+    @patch('deid.press.set_up_logging')
+    @patch('deid.press.codecs.open')
+    def setUp(self, mock_open, mock_logging, mock_file):
+        # set up mocks for initialization
+        mock_logging = Mock()
+        mock_open = Mock()
+        mock_open.side_effect = [[], StandardError]
+        mock_file = Mock()
+        mock_file.side_effect = [[], []]
+
+        # input parameters expected by the class
+        self.input_dataset = 'foo_input'
+        self.tablename = 'bar_table'
+        self.log_path = 'deid-fake.log'
+        self.rules_path = 'fake/config/path.json'
+        self.pipeline = None
+        self.action = 'submit'
+
+        self.press_obj = Press(
+            idataset=self.input_dataset,
+            table=self.tablename,
+            logs=self.log_path,
+            rules=self.rules_path,
+            pipeline=self.pipeline,
+            action=self.action)
+
+    def test_gather_dml_queries(self):
+        # pre-conditions
+        table_path = self.input_dataset + self.tablename
+        info = [
+            {
+                # This is the only statement that should be returned
+                'apply': 'delete * from ' + table_path,
+                'name': 'bogus_delete_dml',
+                'label': 'dropping table contents',
+                'dml_statement': True
+            },
+            {
+                'apply': 'select count(*) from ' + table_path,
+                'name': 'bogus_count_statement',
+                'label': 'getting a count'
+                # leave dml_statement out to make sure it defaults to False
+            },
+            {
+                'apply': 'select * from ' + table_path,
+                # leave name out to make sure it doesn't break
+                'label': 'select all contents',
+                'dml_statement': False
+            }
+        ]
+
+        # test
+        result = self.press_obj.gather_dml_queries(info)
+
+        # post conditions
+        expected = ['delete * from ' + table_path]
+        self.assertEqual(result, expected)

--- a/data_steward/test/unit_test/data_steward/deid/press_test.py
+++ b/data_steward/test/unit_test/data_steward/deid/press_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 # Third party imports
-from mock import Mock, patch
+from mock import patch
 
 # Project imports
 # uncomment the following line when move to python 3 environment is complete


### PR DESCRIPTION
* Builds in the ability to run a DML statement to remove duplicate
records after performing a generalization on data with multiple
answer choices.
* Refactors how default rules are processed, making it easier to identify which rules
are manipulated and how.
* Allows easier where clause conditions and automatically incorporates fixes for
conditions on nullable columns.  This should allow the clause to be read
so that a duplicate drop clause can be created from the existing information.
* Adding query configuration dictionary to avoid possible SQL injection messages thrown by Codacy.
* Using bq_utils to get fields, instead of a query.
* This should allow multiple dml statements to be created and executed.
There will likely need to be some code around the rules as they run,
but the configuration is in place.
* Adds a single unit test as a beginning point for unit testing deid.