### PR TITLE
[DC-595] participant match datetime parsing failure

### DIFF
--- a/data_steward/constants/validation/participants/identity_match.py
+++ b/data_steward/constants/validation/participants/identity_match.py
@@ -20,7 +20,7 @@ MISMATCH = "no_match"
 MISSING = "missing"
 
 # Date format strings
-DATE = '%Y-%m-%d'
+DATE_FORMAT = '%Y-%m-%d'
 DRC_DATE_FORMAT = '%Y%m%d'
 DRC_DATE_REGEX = '\d{8}'
 
@@ -34,6 +34,14 @@ PII_ADDRESS_TABLE = '_pii_address'
 PII_NAME_TABLE = '_pii_name'
 EHR_PERSON_TABLE_SUFFIX = '_person'
 VALIDATION_TABLE_SUFFIX = '_identity_match'
+
+# Field types
+DATE_TYPE = 'date'
+DATETIME_TYPE = 'datetime'
+TIMESTAMP_TYPE = 'timestamp'
+INTEGER_TYPE = 'integer'
+STRING_TYPE = 'string'
+FLOAT_TYPE = 'float'
 
 # Field names
 PERSON_ID_FIELD = 'person_id'

--- a/data_steward/constants/validation/participants/readers.py
+++ b/data_steward/constants/validation/participants/readers.py
@@ -53,3 +53,11 @@ STRING_VALUE_FIELD = 'value_as_string'
 
 # HPO dictionary keys
 HPO_ID = 'hpo_id'
+
+DATE_FORMAT = id_match.DATE_FORMAT
+DATE_TYPE = id_match.DATE_TYPE
+DATETIME_TYPE = id_match.DATETIME_TYPE
+FLOAT_TYPE = id_match.FLOAT_TYPE
+INTEGER_TYPE = id_match.INTEGER_TYPE
+STRING_TYPE = id_match.STRING_TYPE
+TIMESTAMP_TYPE = id_match.TIMESTAMP_TYPE

--- a/data_steward/test/unit_test/data_steward/validation/participants/readers_test.py
+++ b/data_steward/test/unit_test/data_steward/validation/participants/readers_test.py
@@ -61,9 +61,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_ehr_person_values_with_duplicate_keys(self, mock_query, mock_response):
+    def test_get_ehr_person_values_with_duplicate_keys(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         column_name = 'birth_datetime'
@@ -90,6 +91,8 @@ class ReadersTest(unittest.TestCase):
             },
         ]
 
+        mock_fields.return_value = [{'name': column_name, 'type': consts.DATE_TYPE}]
+
         # test
         actual = reader.get_ehr_person_values('project-foo', 'ehr-bar', 'table-doh', column_name)
 
@@ -111,9 +114,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_ehr_person_values(self, mock_query, mock_response):
+    def test_get_ehr_person_values(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         column_name = 'gender_concept_id'
@@ -132,6 +136,8 @@ class ReadersTest(unittest.TestCase):
             },
         ]
 
+        mock_fields.return_value = [{'name': column_name, 'type': consts.DATE_TYPE}]
+
         # test
         actual = reader.get_ehr_person_values('project-foo', 'ehr-bar', 'table-doh', column_name)
 
@@ -153,9 +159,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_rdr_match_values(self, mock_query, mock_response):
+    def test_get_rdr_match_values(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         mock_response.return_value = [
@@ -172,6 +179,8 @@ class ReadersTest(unittest.TestCase):
                 consts.STRING_VALUE_FIELD: 'MaTiLdA'
             },
         ]
+
+        mock_fields.return_value = [{'name': consts.STRING_VALUE_FIELD, 'type': consts.STRING_TYPE}]
 
         # test
         actual = reader.get_rdr_match_values('project-foo', 'rdr-bar', 'table-oye', 12345)
@@ -193,9 +202,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_rdr_match_values_with_duplicates(self, mock_query, mock_response):
+    def test_get_rdr_match_values_with_duplicates(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         mock_response.return_value = [
@@ -221,6 +231,8 @@ class ReadersTest(unittest.TestCase):
             },
         ]
 
+        mock_fields.return_value = [{'name': consts.STRING_VALUE_FIELD, 'type': consts.STRING_TYPE}]
+
         # test
         actual = reader.get_rdr_match_values('project-foo', 'rdr-bar', 'table-oye', 12345)
 
@@ -241,9 +253,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_pii_values(self, mock_query, mock_response):
+    def test_get_pii_values(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         mock_response.return_value = [
@@ -260,6 +273,8 @@ class ReadersTest(unittest.TestCase):
                 12345: 'MaTiLdA'
             },
         ]
+
+        mock_fields.return_value = [{'name': consts.PERSON_ID_FIELD, 'type': consts.INTEGER_TYPE}]
 
         # test
         actual = reader.get_pii_values('project-foo', 'pii-bar', 'zeta', '_sea', 12345)
@@ -282,9 +297,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_pii_values_with_duplicates(self, mock_query, mock_response):
+    def test_get_pii_values_with_duplicates(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         mock_response.return_value = [
@@ -310,6 +326,8 @@ class ReadersTest(unittest.TestCase):
             },
         ]
 
+        mock_fields.return_value = [{'name': consts.PERSON_ID_FIELD, 'type': consts.INTEGER_TYPE}]
+
         # test
         actual = reader.get_pii_values('project-foo', 'pii-bar', 'zeta', '_sea', 12345)
 
@@ -331,9 +349,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    def test_get_location_pii(self, mock_query, mock_response):
+    def test_get_location_pii(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         mock_response.side_effect = [
@@ -367,6 +386,8 @@ class ReadersTest(unittest.TestCase):
             ]
         ]
 
+        mock_fields.return_value = [{'name': consts.LOCATION_ID_FIELD, 'type': consts.INTEGER_TYPE}]
+
         # test
         actual = reader.get_location_pii('project-foo', 'rdr-bar', 'pii-baz', 'chi', '_sky', 12345)
 
@@ -387,10 +408,10 @@ class ReadersTest(unittest.TestCase):
             None
         )
 
+    @patch('validation.participants.readers.rc.fields_for')
     @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
     @patch('validation.participants.readers.bq_utils.query')
-    @unittest.expectedFailure
-    def test_get_ehr_person_values_birthdates(self, mock_query, mock_response):
+    def test_get_ehr_person_values_birthdates(self, mock_query, mock_response, mock_fields):
         # pre conditions
         mock_query.return_value = {}
         column_name = 'birth_datetime'
@@ -409,11 +430,51 @@ class ReadersTest(unittest.TestCase):
             },
         ]
 
+        mock_fields.return_value = [{'name': column_name, 'type': consts.TIMESTAMP_TYPE}]
+
         # test
         actual = reader.get_ehr_person_values('project-foo', 'ehr-bar', 'table-doh', column_name)
 
         # post-conditions
         expected = {1: '1970-07-11', 2: '1949-01-01', 3: '1970-05-25'}
+        self.assertEqual(actual, expected)
+
+        self.assertEqual(mock_query.call_count, 1)
+        self.assertEqual(mock_response.call_count, 1)
+        self.assertEqual(
+            mock_query.assert_called_with(
+                consts.EHR_PERSON_VALUES.format(
+                    project='project-foo',
+                    dataset='ehr-bar',
+                    table='table-doh',
+                    field=column_name
+                )
+            ),
+            None
+        )
+
+    @patch('validation.participants.readers.rc.fields_for')
+    @patch('validation.participants.readers.bq_utils.large_response_to_rowlist')
+    @patch('validation.participants.readers.bq_utils.query')
+    def test_get_ehr_person_values_bytes(self, mock_query, mock_response, mock_fields):
+        # pre conditions
+        mock_query.return_value = {}
+        column_name = 'foo_field'
+        column_value = b'hello'
+        mock_response.return_value = [
+            {
+                consts.PERSON_ID_FIELD: 1,
+                column_name: column_value,
+            },
+        ]
+
+        mock_fields.return_value = [{'name': column_name, 'type': consts.STRING_TYPE}]
+
+        # test
+        actual = reader.get_ehr_person_values('project-foo', 'ehr-bar', 'table-doh', column_name)
+
+        # post-conditions
+        expected = {1: 'hello'}
         self.assertEqual(actual, expected)
 
         self.assertEqual(mock_query.call_count, 1)

--- a/data_steward/validation/participants/identity_match.py
+++ b/data_steward/validation/participants/identity_match.py
@@ -682,8 +682,8 @@ def _compare_birth_dates(
                 rdr_date = parse(rdr_birthdate)
                 ehr_date = parse(ehr_birthdate)
                 # convert datetime objects to Year/month/day strings and compare
-                rdr_string = rdr_date.strftime(consts.DATE)
-                ehr_string = ehr_date.strftime(consts.DATE)
+                rdr_string = rdr_date.strftime(consts.DATE_FORMAT)
+                ehr_string = ehr_date.strftime(consts.DATE_FORMAT)
 
                 match_str = consts.MATCH if rdr_string == ehr_string else consts.MISMATCH
                 match_values[person_id] = match_str


### PR DESCRIPTION
A fix for transforming float values whose field types are defined as date, datetime, or timestamp to a string.
Updates unit tests.
Adds a unit test to verify byte string conversions.