### PR TITLE
[DC-621] Rate limit exceeded on Achilles test and Achilles heel test

### DIFF
--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -800,7 +800,8 @@ def load_table_from_csv(project_id, dataset_id, table_name, csv_path=None, field
 
     if fields is None:
         fields_filename = os.path.join(resources.fields_path, table_name + '.json')
-        fields = json.load(open(fields_filename, 'r'))
+        with open(fields_filename, 'r') as f:
+            fields = json.load(f)
     field_names = ', '.join([field['name'] for field in fields])
     row_exprs = [csv_line_to_sql_row_expr(t, fields) for t in table_list]
     formatted_mapping_list = ', '.join(row_exprs)

--- a/data_steward/resources/achilles_analysis.csv
+++ b/data_steward/resources/achilles_analysis.csv
@@ -1,0 +1,216 @@
+analysis_id,analysis_name,stratum_1_name,stratum_2_name,stratum_3_name,stratum_4_name,stratum_5_name
+0,"Source name",NULL,NULL,NULL,NULL,NULL
+1,"Number of persons",NULL,NULL,NULL,NULL,NULL
+2,"Number of persons by gender","gender_concept_id",NULL,NULL,NULL,NULL
+3,"Number of persons by year of birth","year_of_birth",NULL,NULL,NULL,NULL
+4,"Number of persons by race","race_concept_id",NULL,NULL,NULL,NULL
+5,"Number of persons by ethnicity","ethnicity_concept_id",NULL,NULL,NULL,NULL
+7,"Number of persons with invalid provider_id",NULL,NULL,NULL,NULL,NULL
+8,"Number of persons with invalid location_id",NULL,NULL,NULL,NULL,NULL
+9,"Number of persons with invalid care_site_id",NULL,NULL,NULL,NULL,NULL
+10,"Number of all persons by year of birth by gender","year_of_birth","gender_concept_id",NULL,NULL,NULL
+11,"Number of non-deceased persons by year of birth by gender","year_of_birth","gender_concept_id",NULL,NULL,NULL
+12,"Number of persons by race and ethnicity","race_concept_id","ethnicity_concept_id",NULL,NULL,NULL
+101,"Number of persons by age,with age at first observation period","age",NULL,NULL,NULL,NULL
+102,"Number of persons by gender by age,with age at first observation period","gender_concept_id","age",NULL,NULL,NULL
+103,"Distribution of age at first observation period",NULL,NULL,NULL,NULL,NULL
+104,"Distribution of age at first observation period by gender","gender_concept_id",NULL,NULL,NULL,NULL
+105,"Length of observation (days) of first observation period",NULL,NULL,NULL,NULL,NULL
+106,"Length of observation (days) of first observation period by gender","gender_concept_id",NULL,NULL,NULL,NULL
+107,"Length of observation (days) of first observation period by age decile","age decile",NULL,NULL,NULL,NULL
+108,"Number of persons by length of observation period,in 30d increments","Observation period length 30d increments",NULL,NULL,NULL,NULL
+109,"Number of persons with continuous observation in each year","calendar year",NULL,NULL,NULL,NULL
+110,"Number of persons with continuous observation in each month","calendar month",NULL,NULL,NULL,NULL
+111,"Number of persons by observation period start month","calendar month",NULL,NULL,NULL,NULL
+112,"Number of persons by observation period end month","calendar month",NULL,NULL,NULL,NULL
+113,"Number of persons by number of observation periods","number of observation periods",NULL,NULL,NULL,NULL
+114,"Number of persons with observation period before year-of-birth",NULL,NULL,NULL,NULL,NULL
+115,"Number of persons with observation period end < observation period start",NULL,NULL,NULL,NULL,NULL
+116,"Number of persons with at least one day of observation in each year by gender and age decile","calendar year","gender_concept_id","age decile",NULL,NULL
+117,"Number of persons with at least one day of observation in each month","calendar month",NULL,NULL,NULL,NULL
+118,"Number of observation periods with invalid person_id",NULL,NULL,NULL,NULL,NULL
+119,"Number of observation period records by period_type_concept_id","period_type_concept_id",NULL,NULL,NULL,NULL
+200,"Number of persons with at least one visit occurrence,by visit_concept_id","visit_concept_id",NULL,NULL,NULL,NULL
+201,"Number of visit occurrence records,by visit_concept_id","visit_concept_id",NULL,NULL,NULL,NULL
+202,"Number of persons by visit occurrence start month,by visit_concept_id","visit_concept_id","calendar month",NULL,NULL,NULL
+203,"Number of distinct visit occurrence concepts per person",NULL,NULL,NULL,NULL,NULL
+204,"Number of persons with at least one visit occurrence,by visit_concept_id by calendar year by gender by age decile","visit_concept_id","calendar year","gender_concept_id","age decile",NULL
+206,"Distribution of age by visit_concept_id","visit_concept_id","gender_concept_id",NULL,NULL,NULL
+207,"Number of visit records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+208,"Number of visit records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+209,"Number of visit records with end date < start date",NULL,NULL,NULL,NULL,NULL
+210,"Number of visit records with invalid care_site_id",NULL,NULL,NULL,NULL,NULL
+211,"Distribution of length of stay by visit_concept_id","visit_concept_id",NULL,NULL,NULL,NULL
+212,"Number of persons with at least one visit occurrence,by calendar year by gender by age decile","calendar year","gender_concept_id","age decile",NULL,NULL
+220,"Number of visit occurrence records by visit occurrence start month","calendar month",NULL,NULL,NULL,NULL
+221,"Number of persons by visit start year","calendar year",NULL,NULL,NULL,NULL
+300,"Number of providers",NULL,NULL,NULL,NULL,NULL
+301,"Number of providers by specialty concept_id","specialty_concept_id",NULL,NULL,NULL,NULL
+302,"Number of providers with invalid care site id",NULL,NULL,NULL,NULL,NULL
+400,"Number of persons with at least one condition occurrence,by condition_concept_id","condition_concept_id",NULL,NULL,NULL,NULL
+401,"Number of condition occurrence records,by condition_concept_id","condition_concept_id",NULL,NULL,NULL,NULL
+402,"Number of persons by condition occurrence start month,by condition_concept_id","condition_concept_id","calendar month",NULL,NULL,NULL
+403,"Number of distinct condition occurrence concepts per person",NULL,NULL,NULL,NULL,NULL
+404,"Number of persons with at least one condition occurrence,by condition_concept_id by calendar year by gender by age decile","condition_concept_id","calendar year","gender_concept_id","age decile",NULL
+405,"Number of condition occurrence records,by condition_concept_id by condition_type_concept_id","condition_concept_id","condition_type_concept_id",NULL,NULL,NULL
+406,"Distribution of age by condition_concept_id","condition_concept_id","gender_concept_id",NULL,NULL,NULL
+409,"Number of condition occurrence records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+410,"Number of condition occurrence records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+411,"Number of condition occurrence records with end date < start date",NULL,NULL,NULL,NULL,NULL
+412,"Number of condition occurrence records with invalid provider_id",NULL,NULL,NULL,NULL,NULL
+413,"Number of condition occurrence records with invalid visit_id",NULL,NULL,NULL,NULL,NULL
+420,"Number of condition occurrence records by condition occurrence start month","calendar month",NULL,NULL,NULL,NULL
+500,"Number of persons with death,by cause_concept_id","cause_concept_id",NULL,NULL,NULL,NULL
+501,"Number of records of death,by cause_concept_id","cause_concept_id",NULL,NULL,NULL,NULL
+502,"Number of persons by death month","calendar month",NULL,NULL,NULL,NULL
+504,"Number of persons with a death,by calendar year by gender by age decile","calendar year","gender_concept_id","age decile",NULL,NULL
+505,"Number of death records,by death_type_concept_id","death_type_concept_id",NULL,NULL,NULL,NULL
+506,"Distribution of age at death by gender","gender_concept_id",NULL,NULL,NULL,NULL
+509,"Number of death records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+510,"Number of death records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+511,"Distribution of time from death to last condition",NULL,NULL,NULL,NULL,NULL
+512,"Distribution of time from death to last drug",NULL,NULL,NULL,NULL,NULL
+513,"Distribution of time from death to last visit",NULL,NULL,NULL,NULL,NULL
+514,"Distribution of time from death to last procedure",NULL,NULL,NULL,NULL,NULL
+515,"Distribution of time from death to last observation",NULL,NULL,NULL,NULL,NULL
+600,"Number of persons with at least one procedure occurrence,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+601,"Number of procedure occurrence records,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+602,"Number of persons by procedure occurrence start month,by procedure_concept_id","procedure_concept_id","calendar month",NULL,NULL,NULL
+603,"Number of distinct procedure occurrence concepts per person",NULL,NULL,NULL,NULL,NULL
+604,"Number of persons with at least one procedure occurrence,by procedure_concept_id by calendar year by gender by age decile","procedure_concept_id","calendar year","gender_concept_id","age decile",NULL
+605,"Number of procedure occurrence records,by procedure_concept_id by procedure_type_concept_id","procedure_concept_id","procedure_type_concept_id",NULL,NULL,NULL
+606,"Distribution of age by procedure_concept_id","procedure_concept_id","gender_concept_id",NULL,NULL,NULL
+609,"Number of procedure occurrence records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+610,"Number of procedure occurrence records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+612,"Number of procedure occurrence records with invalid provider_id",NULL,NULL,NULL,NULL,NULL
+613,"Number of procedure occurrence records with invalid visit_id",NULL,NULL,NULL,NULL,NULL
+620,"Number of procedure occurrence records by procedure occurrence start month","calendar month",NULL,NULL,NULL,NULL
+691,"Number of persons that have at least x procedures","procedure_id","procedure_count",NULL,NULL,NULL
+700,"Number of persons with at least one drug exposure,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+701,"Number of drug exposure records,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+702,"Number of persons by drug exposure start month,by drug_concept_id","drug_concept_id","calendar month",NULL,NULL,NULL
+703,"Number of distinct drug exposure concepts per person",NULL,NULL,NULL,NULL,NULL
+704,"Number of persons with at least one drug exposure,by drug_concept_id by calendar year by gender by age decile","drug_concept_id","calendar year","gender_concept_id","age decile",NULL
+705,"Number of drug exposure records,by drug_concept_id by drug_type_concept_id","drug_concept_id","drug_type_concept_id",NULL,NULL,NULL
+706,"Distribution of age by drug_concept_id","drug_concept_id","gender_concept_id",NULL,NULL,NULL
+709,"Number of drug exposure records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+710,"Number of drug exposure records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+711,"Number of drug exposure records with end date < start date",NULL,NULL,NULL,NULL,NULL
+712,"Number of drug exposure records with invalid provider_id",NULL,NULL,NULL,NULL,NULL
+713,"Number of drug exposure records with invalid visit_id",NULL,NULL,NULL,NULL,NULL
+715,"Distribution of days_supply by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+716,"Distribution of refills by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+717,"Distribution of quantity by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+720,"Number of drug exposure records by drug exposure start month","calendar month",NULL,NULL,NULL,NULL
+791,"Number of persons that have at least x drug exposures","drug_concept_id","drug_count",NULL,NULL,NULL
+800,"Number of persons with at least one observation occurrence,by observation_concept_id","observation_concept_id",NULL,NULL,NULL,NULL
+801,"Number of observation occurrence records,by observation_concept_id","observation_concept_id",NULL,NULL,NULL,NULL
+802,"Number of persons by observation occurrence start month,by observation_concept_id","observation_concept_id","calendar month",NULL,NULL,NULL
+803,"Number of distinct observation occurrence concepts per person",NULL,NULL,NULL,NULL,NULL
+804,"Number of persons with at least one observation occurrence,by observation_concept_id by calendar year by gender by age decile","observation_concept_id","calendar year","gender_concept_id","age decile",NULL
+805,"Number of observation occurrence records,by observation_concept_id by observation_type_concept_id","observation_concept_id","observation_type_concept_id",NULL,NULL,NULL
+806,"Distribution of age by observation_concept_id","observation_concept_id","gender_concept_id",NULL,NULL,NULL
+807,"Number of observation occurrence records,by observation_concept_id and unit_concept_id","observation_concept_id","unit_concept_id",NULL,NULL,NULL
+809,"Number of observation records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+810,"Number of observation records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+812,"Number of observation records with invalid provider_id",NULL,NULL,NULL,NULL,NULL
+813,"Number of observation records with invalid visit_id",NULL,NULL,NULL,NULL,NULL
+814,"Number of observation records with no value (numeric,string,or concept)",NULL,NULL,NULL,NULL,NULL
+815,"Distribution of numeric values,by observation_concept_id and unit_concept_id",NULL,NULL,NULL,NULL,NULL
+820,"Number of observation records by observation start month","calendar month",NULL,NULL,NULL,NULL
+891,"Number of persons that have at least x observations","observation_concept_id","observation_count",NULL,NULL,NULL
+900,"Number of persons with at least one drug era,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+901,"Number of drug era records,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+902,"Number of persons by drug era start month,by drug_concept_id","drug_concept_id","calendar month",NULL,NULL,NULL
+903,"Number of distinct drug era concepts per person",NULL,NULL,NULL,NULL,NULL
+904,"Number of persons with at least one drug era,by drug_concept_id by calendar year by gender by age decile","drug_concept_id","calendar year","gender_concept_id","age decile",NULL
+906,"Distribution of age by drug_concept_id","drug_concept_id","gender_concept_id",NULL,NULL,NULL
+907,"Distribution of drug era length,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+908,"Number of drug eras without valid person",NULL,NULL,NULL,NULL,NULL
+909,"Number of drug eras outside valid observation period",NULL,NULL,NULL,NULL,NULL
+910,"Number of drug eras with end date < start date",NULL,NULL,NULL,NULL,NULL
+920,"Number of drug era records by drug era start month","calendar month",NULL,NULL,NULL,NULL
+1000,"Number of persons with at least one condition era,by condition_concept_id","condition_concept_id",NULL,NULL,NULL,NULL
+1001,"Number of condition era records,by condition_concept_id","condition_concept_id",NULL,NULL,NULL,NULL
+1002,"Number of persons by condition era start month,by condition_concept_id","condition_concept_id","calendar month",NULL,NULL,NULL
+1003,"Number of distinct condition era concepts per person",NULL,NULL,NULL,NULL,NULL
+1004,"Number of persons with at least one condition era,by condition_concept_id by calendar year by gender by age decile","condition_concept_id","calendar year","gender_concept_id","age decile",NULL
+1006,"Distribution of age by condition_concept_id","condition_concept_id","gender_concept_id",NULL,NULL,NULL
+1007,"Distribution of condition era length,by condition_concept_id","condition_concept_id",NULL,NULL,NULL,NULL
+1008,"Number of condition eras without valid person",NULL,NULL,NULL,NULL,NULL
+1009,"Number of condition eras outside valid observation period",NULL,NULL,NULL,NULL,NULL
+1010,"Number of condition eras with end date < start date",NULL,NULL,NULL,NULL,NULL
+1020,"Number of condition era records by condition era start month","calendar month",NULL,NULL,NULL,NULL
+1100,"Number of persons by location 3-digit zip","3-digit zip",NULL,NULL,NULL,NULL
+1101,"Number of persons by location state","state",NULL,NULL,NULL,NULL
+1102,"Number of care sites by location 3-digit zip","3-digit zip",NULL,NULL,NULL,NULL
+1103,"Number of care sites by location state","state",NULL,NULL,NULL,NULL
+1200,"Number of persons by place of service","place_of_service_concept_id",NULL,NULL,NULL,NULL
+1201,"Number of visits by place of service","place_of_service_concept_id",NULL,NULL,NULL,NULL
+1202,"Number of care sites by place of service","place_of_service_concept_id",NULL,NULL,NULL,NULL
+1406,"Length of payer plan (days) of first payer plan period by gender","gender_concept_id",NULL,NULL,NULL,NULL
+1407,"Length of payer plan (days) of first payer plan period by age decile","age_decile",NULL,NULL,NULL,NULL
+1408,"Number of persons by length of payer plan period,in 30d increments","payer plan period length 30d increments",NULL,NULL,NULL,NULL
+1409,"Number of persons with continuous payer plan in each year","calendar year",NULL,NULL,NULL,NULL
+1410,"Number of persons with continuous payer plan in each month","calendar month",NULL,NULL,NULL,NULL
+1411,"Number of persons by payer plan period start month","calendar month",NULL,NULL,NULL,NULL
+1412,"Number of persons by payer plan period end month","calendar month",NULL,NULL,NULL,NULL
+1413,"Number of persons by number of payer plan periods","number of payer plan periods",NULL,NULL,NULL,NULL
+1414,"Number of persons with payer plan period before year-of-birth",NULL,NULL,NULL,NULL,NULL
+1415,"Number of persons with payer plan period end < payer plan period start",NULL,NULL,NULL,NULL,NULL
+1500,"Number of drug cost records with invalid drug exposure id",NULL,NULL,NULL,NULL,NULL
+1501,"Number of drug cost records with invalid payer plan period id",NULL,NULL,NULL,NULL,NULL
+1502,"Distribution of paid copay,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1503,"Distribution of paid coinsurance,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1504,"Distribution of paid toward deductible,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1505,"Distribution of paid by payer,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1506,"Distribution of paid by coordination of benefit,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1507,"Distribution of total out-of-pocket,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1508,"Distribution of total paid,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1509,"Distribution of ingredient_cost,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1510,"Distribution of dispensing fee,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1511,"Distribution of average wholesale price,by drug_concept_id","drug_concept_id",NULL,NULL,NULL,NULL
+1600,"Number of procedure cost records with invalid procedure occurrence id",NULL,NULL,NULL,NULL,NULL
+1601,"Number of procedure cost records with invalid payer plan period id",NULL,NULL,NULL,NULL,NULL
+1602,"Distribution of paid copay,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1603,"Distribution of paid coinsurance,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1604,"Distribution of paid toward deductible,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1605,"Distribution of paid by payer,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1606,"Distribution of paid by coordination of benefit,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1607,"Distribution of total out-of-pocket,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1608,"Distribution of total paid,by procedure_concept_id","procedure_concept_id",NULL,NULL,NULL,NULL
+1610,"Number of records by revenue_code_concept_id","revenue_code_concept_id",NULL,NULL,NULL,NULL
+1700,"Number of records by cohort_concept_id","cohort_concept_id",NULL,NULL,NULL,NULL
+1701,"Number of records with cohort end date < cohort start date",NULL,NULL,NULL,NULL,NULL
+1800,"Number of persons with at least one measurement occurrence,by measurement_concept_id","measurement_concept_id",NULL,NULL,NULL,NULL
+1801,"Number of measurement occurrence records,by measurement_concept_id","measurement_concept_id",NULL,NULL,NULL,NULL
+1802,"Number of persons by measurement occurrence start month,by measurement_concept_id","measurement_concept_id","calendar month",NULL,NULL,NULL
+1803,"Number of distinct mesurement occurrence concepts per person",NULL,NULL,NULL,NULL,NULL
+1804,"Number of persons with at least one mesurement occurrence,by measurement_concept_id by calendar year by gender by age decile","measurement_concept_id","calendar year","gender_concept_id","age decile",NULL
+1805,"Number of measurement occurrence records,by measurement_concept_id by measurement_type_concept_id","measurement_concept_id","measurement_type_concept_id",NULL,NULL,NULL
+1806,"Distribution of age by measurement_concept_id","measurement_concept_id","gender_concept_id",NULL,NULL,NULL
+1807,"Number of measurement occurrence records,by measurement_concept_id and unit_concept_id","measurement_concept_id","unit_concept_id",NULL,NULL,NULL
+1809,"Number of measurement records with invalid person_id",NULL,NULL,NULL,NULL,NULL
+1810,"Number of measurement records outside valid observation period",NULL,NULL,NULL,NULL,NULL
+1812,"Number of measurement records with invalid provider_id",NULL,NULL,NULL,NULL,NULL
+1813,"Number of measurement records with invalid visit_id",NULL,NULL,NULL,NULL,NULL
+1814,"Number of measurement records with no value (numeric,string,or concept)",NULL,NULL,NULL,NULL,NULL
+1815,"Distribution of numeric values,by measurement_concept_id and unit_concept_id",NULL,NULL,NULL,NULL,NULL
+1816,"Distribution of low range,by measurement_concept_id and unit_concept_id",NULL,NULL,NULL,NULL,NULL
+1817,"Distribution of high range,by observation_concept_id and unit_concept_id",NULL,NULL,NULL,NULL,NULL
+1818,"Number of measurement records below/within/above normal range,by measurement_concept_id and unit_concept_id",NULL,NULL,NULL,NULL,NULL
+1820,"Number of measurement records by measurement start month","calendar month",NULL,NULL,NULL,NULL
+1821,"Number of measurement records with no numeric value",NULL,NULL,NULL,NULL,NULL
+1891,"Number of persons that have at least x measurements","measurement_concept_id","measurement_count",NULL,NULL,NULL
+1900,"Source values mapped to concept_id 0 by table,by source_value","table_name","source_value",NULL,NULL,NULL
+2000,"Number of patients with at least 1 Dx and 1 Rx",NULL,NULL,NULL,NULL,NULL
+2001,"Number of patients with at least 1 Dx and 1 Proc",NULL,NULL,NULL,NULL,NULL
+2002,"Number of patients with at least 1 Meas,1 Dx and 1 Rx",NULL,NULL,NULL,NULL,NULL
+2003,"Number of patients with at least 1 Visit",NULL,NULL,NULL,NULL,NULL
+2100,"Number of persons with at least one device exposure,by device_concept_id","device_concept_id",NULL,NULL,NULL,NULL
+2101,"Number of device exposure records,by device_concept_id","device_concept_id",NULL,NULL,NULL,NULL
+2102,"Number of persons by device records start month,by device_concept_id","device_concept_id","calendar month",NULL,NULL,NULL
+2104,"Number of persons with at least one device exposure,by device_concept_id by calendar year by gender by age decile","device_concept_id","calendar year","gender_concept_id","age decile",NULL
+2105,"Number of device exposure records,by device_concept_id by device_type_concept_id","device_concept_id","device_type_concept_id",NULL,NULL,NULL
+2200,"Number of persons with at least one note by note_type_concept_id","note_type_concept_id",NULL,NULL,NULL,NULL
+2201,"Number of note records,by note_type_concept_id","note_type_concept_id",NULL,NULL,NULL,NULL

--- a/data_steward/resources/achilles_dml.sql
+++ b/data_steward/resources/achilles_dml.sql
@@ -1,515 +1,3 @@
---populate the tables with names of analyses
-insert into synpuf_100.achilles_analysis (
-    analysis_id,
-    analysis_name,
-    stratum_1_name,
-    stratum_2_name,
-    stratum_3_name,
-    stratum_4_name
-)
-VALUES
-(0, 'Source name', NULL, NULL, NULL, NULL),
---000. PERSON statistics
-(1, 'Number of persons', NULL, NULL, NULL, NULL),
-(2, 'Number of persons by gender', 'gender_concept_id', NULL, NULL, NULL),
-(3, 'Number of persons by year of birth', 'year_of_birth', NULL, NULL, NULL),
-(4, 'Number of persons by race', 'race_concept_id', NULL, NULL, NULL),
-(5, 'Number of persons by ethnicity', 'ethnicity_concept_id', NULL, NULL, NULL),
-(7, 'Number of persons with invalid provider_id', NULL, NULL, NULL, NULL),
-(8, 'Number of persons with invalid location_id', NULL, NULL, NULL, NULL),
-(9, 'Number of persons with invalid care_site_id', NULL, NULL, NULL, NULL),
-(10, 'Number of all persons by year of birth by gender', 'year_of_birth', 'gender_concept_id', NULL, NULL),
-(11, 'Number of non-deceased persons by year of birth by gender', 'year_of_birth', 'gender_concept_id', NULL, NULL),
-(12, 'Number of persons by race and ethnicity', 'race_concept_id', 'ethnicity_concept_id', NULL, NULL),
---100. OBSERVATION_PERIOD (joined to PERSON)
-(101, 'Number of persons by age, with age at first observation period', 'age', NULL, NULL, NULL),
-(102,
-    'Number of persons by gender by age, with age at first observation period',
-    'gender_concept_id',
-    'age',
-    NULL,
-    NULL
-),
-(103, 'Distribution of age at first observation period', NULL, NULL, NULL, NULL),
-(104, 'Distribution of age at first observation period by gender', 'gender_concept_id', NULL, NULL, NULL),
-(105, 'Length of observation (days) of first observation period', NULL, NULL, NULL, NULL),
-(106, 'Length of observation (days) of first observation period by gender', 'gender_concept_id', NULL, NULL, NULL),
-(107, 'Length of observation (days) of first observation period by age decile', 'age decile', NULL, NULL, NULL),
-(108,
-    'Number of persons by length of observation period, in 30d increments',
-    'Observation period length 30d increments',
-    NULL,
-    NULL,
-    NULL
-),
-(109, 'Number of persons with continuous observation in each year', 'calendar year', NULL, NULL, NULL),
-(110, 'Number of persons with continuous observation in each month', 'calendar month', NULL, NULL, NULL),
-(111, 'Number of persons by observation period start month', 'calendar month', NULL, NULL, NULL),
-(112, 'Number of persons by observation period end month', 'calendar month', NULL, NULL, NULL),
-(113, 'Number of persons by number of observation periods', 'number of observation periods', NULL, NULL, NULL),
-(114, 'Number of persons with observation period before year-of-birth', NULL, NULL, NULL, NULL),
-(115, 'Number of persons with observation period end < observation period start', NULL, NULL, NULL, NULL),
-(116,
-    'Number of persons with at least one day of observation in each year by gender and age decile',
-    'calendar year',
-    'gender_concept_id',
-    'age decile',
-    NULL
-),
-(117, 'Number of persons with at least one day of observation in each month', 'calendar month', NULL, NULL, NULL),
-(118, 'Number of observation periods with invalid person_id', NULL, NULL, NULL, NULL),
-(119, 'Number of observation period records by period_type_concept_id', 'period_type_concept_id', NULL, NULL, NULL),
---200- VISIT_OCCURRENCE
-(200, 'Number of persons with at least one visit occurrence, by visit_concept_id', 'visit_concept_id', NULL, NULL, NULL),
-(201, 'Number of visit occurrence records, by visit_concept_id', 'visit_concept_id', NULL, NULL, NULL),
-(202,
-    'Number of persons by visit occurrence start month, by visit_concept_id',
-    'visit_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(203, 'Number of distinct visit occurrence concepts per person', NULL, NULL, NULL, NULL),
-(204,
-    'Number of persons with at least one visit occurrence, by visit_concept_id by calendar year by gender by age decile',
-    'visit_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(206, 'Distribution of age by visit_concept_id', 'visit_concept_id', 'gender_concept_id', NULL, NULL),
-(207, 'Number of visit records with invalid person_id', NULL, NULL, NULL, NULL),
-(208, 'Number of visit records outside valid observation period', NULL, NULL, NULL, NULL),
-(209, 'Number of visit records with end date < start date', NULL, NULL, NULL, NULL),
-(210, 'Number of visit records with invalid care_site_id', NULL, NULL, NULL, NULL),
-(211, 'Distribution of length of stay by visit_concept_id', 'visit_concept_id', NULL, NULL, NULL),
-(212,
-    'Number of persons with at least one visit occurrence, by calendar year by gender by age decile',
-    'calendar year',
-    'gender_concept_id',
-    'age decile',
-    NULL
-),
-(220, 'Number of visit occurrence records by visit occurrence start month', 'calendar month', NULL, NULL, NULL),
-(221, 'Number of persons by visit start year', 'calendar year', NULL, NULL, NULL),
---300- PROVIDER
-(300, 'Number of providers', NULL, NULL, NULL, NULL),
-(301, 'Number of providers by specialty concept_id', 'specialty_concept_id', NULL, NULL, NULL),
-(302, 'Number of providers with invalid care site id', NULL, NULL, NULL, NULL),
---400- CONDITION_OCCURRENCE
-(400,
-    'Number of persons with at least one condition occurrence, by condition_concept_id',
-    'condition_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(401, 'Number of condition occurrence records, by condition_concept_id', 'condition_concept_id', NULL, NULL, NULL),
-(402,
-    'Number of persons by condition occurrence start month, by condition_concept_id',
-    'condition_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(403, 'Number of distinct condition occurrence concepts per person', NULL, NULL, NULL, NULL),
-(404,
-    'Number of persons with at least one condition occurrence, by condition_concept_id by calendar year by gender by age decile',
-    'condition_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(405,
-    'Number of condition occurrence records, by condition_concept_id by condition_type_concept_id',
-    'condition_concept_id',
-    'condition_type_concept_id',
-    NULL,
-    NULL
-),
-(406, 'Distribution of age by condition_concept_id', 'condition_concept_id', 'gender_concept_id', NULL, NULL),
-(409, 'Number of condition occurrence records with invalid person_id', NULL, NULL, NULL, NULL),
-(410, 'Number of condition occurrence records outside valid observation period', NULL, NULL, NULL, NULL),
-(411, 'Number of condition occurrence records with end date < start date', NULL, NULL, NULL, NULL),
-(412, 'Number of condition occurrence records with invalid provider_id', NULL, NULL, NULL, NULL),
-(413, 'Number of condition occurrence records with invalid visit_id', NULL, NULL, NULL, NULL),
-(420, 'Number of condition occurrence records by condition occurrence start month', 'calendar month', NULL, NULL, NULL),
---500- DEATH
-(500, 'Number of persons with death, by cause_concept_id', 'cause_concept_id', NULL, NULL, NULL),
-(501, 'Number of records of death, by cause_concept_id', 'cause_concept_id', NULL, NULL, NULL),
-(502, 'Number of persons by death month', 'calendar month', NULL, NULL, NULL),
-(504,
-    'Number of persons with a death, by calendar year by gender by age decile',
-    'calendar year',
-    'gender_concept_id',
-    'age decile',
-    NULL
-),
-(505, 'Number of death records, by death_type_concept_id', 'death_type_concept_id', NULL, NULL, NULL),
-(506, 'Distribution of age at death by gender', 'gender_concept_id', NULL, NULL, NULL),
-(509, 'Number of death records with invalid person_id', NULL, NULL, NULL, NULL),
-(510, 'Number of death records outside valid observation period', NULL, NULL, NULL, NULL),
-(511, 'Distribution of time from death to last condition', NULL, NULL, NULL, NULL),
-(512, 'Distribution of time from death to last drug', NULL, NULL, NULL, NULL),
-(513, 'Distribution of time from death to last visit', NULL, NULL, NULL, NULL),
-(514, 'Distribution of time from death to last procedure', NULL, NULL, NULL, NULL),
-(515, 'Distribution of time from death to last observation', NULL, NULL, NULL, NULL),
---600- PROCEDURE_OCCURRENCE
-(600,
-    'Number of persons with at least one procedure occurrence, by procedure_concept_id',
-    'procedure_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(601, 'Number of procedure occurrence records, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
-(602,
-    'Number of persons by procedure occurrence start month, by procedure_concept_id',
-    'procedure_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(603, 'Number of distinct procedure occurrence concepts per person', NULL, NULL, NULL, NULL),
-(604,
-    'Number of persons with at least one procedure occurrence, by procedure_concept_id by calendar year by gender by age decile',
-    'procedure_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(605,
-    'Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id',
-    'procedure_concept_id',
-    'procedure_type_concept_id',
-    NULL,
-    NULL
-),
-(606, 'Distribution of age by procedure_concept_id', 'procedure_concept_id', 'gender_concept_id', NULL, NULL),
-(609, 'Number of procedure occurrence records with invalid person_id', NULL, NULL, NULL, NULL),
-(610, 'Number of procedure occurrence records outside valid observation period', NULL, NULL, NULL, NULL),
-(612, 'Number of procedure occurrence records with invalid provider_id', NULL, NULL, NULL, NULL),
-(613, 'Number of procedure occurrence records with invalid visit_id', NULL, NULL, NULL, NULL),
-(620, 'Number of procedure occurrence records  by procedure occurrence start month', 'calendar month', NULL, NULL, NULL),
-(691, 'Number of persons that have at least x procedures', 'procedure_id', 'procedure_count', NULL, NULL),
---700- DRUG_EXPOSURE
-(700, 'Number of persons with at least one drug exposure, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(701, 'Number of drug exposure records, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(702,
-    'Number of persons by drug exposure start month, by drug_concept_id',
-    'drug_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(703, 'Number of distinct drug exposure concepts per person', NULL, NULL, NULL, NULL),
-(704,
-    'Number of persons with at least one drug exposure, by drug_concept_id by calendar year by gender by age decile',
-    'drug_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(705,
-    'Number of drug exposure records, by drug_concept_id by drug_type_concept_id',
-    'drug_concept_id',
-    'drug_type_concept_id',
-    NULL,
-    NULL
-),
-(706, 'Distribution of age by drug_concept_id', 'drug_concept_id', 'gender_concept_id', NULL, NULL),
-(709, 'Number of drug exposure records with invalid person_id', NULL, NULL, NULL, NULL),
-(710, 'Number of drug exposure records outside valid observation period', NULL, NULL, NULL, NULL),
-(711, 'Number of drug exposure records with end date < start date', NULL, NULL, NULL, NULL),
-(712, 'Number of drug exposure records with invalid provider_id', NULL, NULL, NULL, NULL),
-(713, 'Number of drug exposure records with invalid visit_id', NULL, NULL, NULL, NULL),
-(715, 'Distribution of days_supply by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(716, 'Distribution of refills by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(717, 'Distribution of quantity by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(720, 'Number of drug exposure records  by drug exposure start month', 'calendar month', NULL, NULL, NULL),
-(791, 'Number of persons that have at least x drug exposures', 'drug_concept_id', 'drug_count', NULL, NULL),
---800- OBSERVATION
-(800,
-    'Number of persons with at least one observation occurrence, by observation_concept_id',
-    'observation_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(801, 'Number of observation occurrence records, by observation_concept_id', 'observation_concept_id', NULL, NULL, NULL),
-(802,
-    'Number of persons by observation occurrence start month, by observation_concept_id',
-    'observation_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(803, 'Number of distinct observation occurrence concepts per person', NULL, NULL, NULL, NULL),
-(804,
-    'Number of persons with at least one observation occurrence, by observation_concept_id by calendar year by gender by age decile',
-    'observation_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(805,
-    'Number of observation occurrence records, by observation_concept_id by observation_type_concept_id',
-    'observation_concept_id',
-    'observation_type_concept_id',
-    NULL,
-    NULL
-),
-(806, 'Distribution of age by observation_concept_id', 'observation_concept_id', 'gender_concept_id', NULL, NULL),
-(807,
-    'Number of observation occurrence records, by observation_concept_id and unit_concept_id',
-    'observation_concept_id',
-    'unit_concept_id',
-    NULL,
-    NULL
-),
-(809, 'Number of observation records with invalid person_id', NULL, NULL, NULL, NULL),
-(810, 'Number of observation records outside valid observation period', NULL, NULL, NULL, NULL),
-(812, 'Number of observation records with invalid provider_id', NULL, NULL, NULL, NULL),
-(813, 'Number of observation records with invalid visit_id', NULL, NULL, NULL, NULL),
-(814, 'Number of observation records with no value (numeric, string, or concept)', NULL, NULL, NULL, NULL),
-(815, 'Distribution of numeric values, by observation_concept_id and unit_concept_id', NULL, NULL, NULL, NULL),
-(820, 'Number of observation records  by observation start month', 'calendar month', NULL, NULL, NULL),
-(891, 'Number of persons that have at least x observations', 'observation_concept_id', 'observation_count', NULL, NULL),
---900- DRUG_ERA
-(900, 'Number of persons with at least one drug era, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(901, 'Number of drug era records, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(902, 'Number of persons by drug era start month, by drug_concept_id', 'drug_concept_id', 'calendar month', NULL, NULL),
-(903, 'Number of distinct drug era concepts per person', NULL, NULL, NULL, NULL),
-(904,
-    'Number of persons with at least one drug era, by drug_concept_id by calendar year by gender by age decile',
-    'drug_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(906, 'Distribution of age by drug_concept_id', 'drug_concept_id', 'gender_concept_id', NULL, NULL),
-(907, 'Distribution of drug era length, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(908, 'Number of drug eras without valid person', NULL, NULL, NULL, NULL),
-(909, 'Number of drug eras outside valid observation period', NULL, NULL, NULL, NULL),
-(910, 'Number of drug eras with end date < start date', NULL, NULL, NULL, NULL),
-(920, 'Number of drug era records  by drug era start month', 'calendar month', NULL, NULL, NULL),
---1000- CONDITION_ERA
-(1000,
-    'Number of persons with at least one condition era, by condition_concept_id',
-    'condition_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(1001, 'Number of condition era records, by condition_concept_id', 'condition_concept_id', NULL, NULL, NULL),
-(1002,
-    'Number of persons by condition era start month, by condition_concept_id',
-    'condition_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(1003, 'Number of distinct condition era concepts per person', NULL, NULL, NULL, NULL),
-(1004,
-    'Number of persons with at least one condition era, by condition_concept_id by calendar year by gender by age decile',
-    'condition_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(1006, 'Distribution of age by condition_concept_id', 'condition_concept_id', 'gender_concept_id', NULL, NULL),
-(1007, 'Distribution of condition era length, by condition_concept_id', 'condition_concept_id', NULL, NULL, NULL),
-(1008, 'Number of condition eras without valid person', NULL, NULL, NULL, NULL),
-(1009, 'Number of condition eras outside valid observation period', NULL, NULL, NULL, NULL),
-(1010, 'Number of condition eras with end date < start date', NULL, NULL, NULL, NULL),
-(1020, 'Number of condition era records by condition era start month', 'calendar month', NULL, NULL, NULL),
---1100- LOCATION
-(1100, 'Number of persons by location 3-digit zip', '3-digit zip', NULL, NULL, NULL),
-(1101, 'Number of persons by location state', 'state', NULL, NULL, NULL),
-(1102, 'Number of care sites by location 3-digit zip', '3-digit zip', NULL, NULL, NULL),
-(1103, 'Number of care sites by location state', 'state', NULL, NULL, NULL),
---1200- CARE_SITE
-(1200, 'Number of persons by place of service', 'place_of_service_concept_id', NULL, NULL, NULL),
-(1201, 'Number of visits by place of service', 'place_of_service_concept_id', NULL, NULL, NULL),
-(1202, 'Number of care sites by place of service', 'place_of_service_concept_id', NULL, NULL, NULL),
---1300- ORGANIZATION
---NOT APPLICABLE IN CDMV5
---insert into results.ACHILLES_analysis (analysis_id, analysis_name, stratum_1_name)
---	values (1300, 'Number of organizations by place of service', 'place_of_service_concept_id', NULL, NULL,NULL),
---1400- PAYOR_PLAN_PERIOD
-(1406, 'Length of payer plan (days) of first payer plan period by gender', 'gender_concept_id', NULL, NULL, NULL),
-(1407, 'Length of payer plan (days) of first payer plan period by age decile', 'age_decile', NULL, NULL, NULL),
-(1408,
-    'Number of persons by length of payer plan period, in 30d increments',
-    'payer plan period length 30d increments',
-    NULL,
-    NULL,
-    NULL
-),
-(1409, 'Number of persons with continuous payer plan in each year', 'calendar year', NULL, NULL, NULL),
-(1410, 'Number of persons with continuous payer plan in each month', 'calendar month', NULL, NULL, NULL),
-(1411, 'Number of persons by payer plan period start month', 'calendar month', NULL, NULL, NULL),
-(1412, 'Number of persons by payer plan period end month', 'calendar month', NULL, NULL, NULL),
-(1413, 'Number of persons by number of payer plan periods', 'number of payer plan periods', NULL, NULL, NULL),
-(1414, 'Number of persons with payer plan period before year-of-birth', NULL, NULL, NULL, NULL),
-(1415, 'Number of persons with payer plan period end < payer plan period start', NULL, NULL, NULL, NULL),
---1500- DRUG_COST
-(1500, 'Number of drug cost records with invalid drug exposure id', NULL, NULL, NULL, NULL),
-(1501, 'Number of drug cost records with invalid payer plan period id', NULL, NULL, NULL, NULL),
-(1502, 'Distribution of paid copay, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1503, 'Distribution of paid coinsurance, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1504, 'Distribution of paid toward deductible, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1505, 'Distribution of paid by payer, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1506, 'Distribution of paid by coordination of benefit, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1507, 'Distribution of total out-of-pocket, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1508, 'Distribution of total paid, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1509, 'Distribution of ingredient_cost, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1510, 'Distribution of dispensing fee, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
-(1511, 'Distribution of average wholesale price, by drug_concept_id', 'drug_concept_id', NULL, NULL, NULL),
---1600- PROCEDURE_COST
-(1600, 'Number of procedure cost records with invalid procedure occurrence id', NULL, NULL, NULL, NULL),
-(1601, 'Number of procedure cost records with invalid payer plan period id', NULL, NULL, NULL, NULL),
-(1602, 'Distribution of paid copay, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
-(1603, 'Distribution of paid coinsurance, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
-(1604, 'Distribution of paid toward deductible, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
-(1605, 'Distribution of paid by payer, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
-(1606,
-    'Distribution of paid by coordination of benefit, by procedure_concept_id',
-    'procedure_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(1607, 'Distribution of total out-of-pocket, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
-(1608, 'Distribution of total paid, by procedure_concept_id', 'procedure_concept_id', NULL, NULL, NULL),
---NOT APPLICABLE FOR OMOP CDM v5
---insert into results.ACHILLES_analysis (analysis_id, analysis_name, stratum_1_name)
---	values (1609, 'Number of records by disease_class_concept_id', 'disease_class_concept_id', NULL, NULL,NULL),
-(1610, 'Number of records by revenue_code_concept_id', 'revenue_code_concept_id', NULL, NULL, NULL),
---1700- COHORT
-(1700, 'Number of records by cohort_concept_id', 'cohort_concept_id', NULL, NULL, NULL),
-(1701, 'Number of records with cohort end date < cohort start date', NULL, NULL, NULL, NULL),
---1800- MEASUREMENT
-(1800,
-    'Number of persons with at least one measurement occurrence, by measurement_concept_id',
-    'measurement_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(1801,
-    'Number of measurement occurrence records, by measurement_concept_id',
-    'measurement_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(1802,
-    'Number of persons by measurement occurrence start month, by measurement_concept_id',
-    'measurement_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
-(1803, 'Number of distinct mesurement occurrence concepts per person', NULL, NULL, NULL, NULL),
-(1804,
-    'Number of persons with at least one mesurement  occurrence, by measurement_concept_id by calendar year by gender by age decile',
-    'measurement_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(1805,
-    'Number of measurement occurrence records, by measurement_concept_id by measurement_type_concept_id',
-    'measurement_concept_id',
-    'measurement_type_concept_id',
-    NULL,
-    NULL
-),
-(1806, 'Distribution of age by measurement_concept_id', 'measurement_concept_id', 'gender_concept_id', NULL, NULL),
-(1807,
-    'Number of measurement occurrence records, by measurement_concept_id and unit_concept_id',
-    'measurement_concept_id',
-    'unit_concept_id',
-    NULL,
-    NULL
-),
-(1809, 'Number of measurement records with invalid person_id', NULL, NULL, NULL, NULL),
-(1810, 'Number of measurement records outside valid observation period', NULL, NULL, NULL, NULL),
-(1812, 'Number of measurement records with invalid provider_id', NULL, NULL, NULL, NULL),
-(1813, 'Number of measurement records with invalid visit_id', NULL, NULL, NULL, NULL),
-(1814, 'Number of measurement records with no value (numeric, string, or concept)', NULL, NULL, NULL, NULL),
-(1815, 'Distribution of numeric values, by measurement_concept_id and unit_concept_id', NULL, NULL, NULL, NULL),
-(1816, 'Distribution of low range, by measurement_concept_id and unit_concept_id', NULL, NULL, NULL, NULL),
-(1817, 'Distribution of high range, by observation_concept_id and unit_concept_id', NULL, NULL, NULL, NULL),
-(1818,
-    'Number of measurement records below/within/above normal range, by measurement_concept_id and unit_concept_id',
-    NULL,
-    NULL,
-    NULL,
-    NULL
-),
-(1820, 'Number of measurement records  by measurement start month', 'calendar month', NULL, NULL, NULL),
-(1821, 'Number of measurement records with no numeric value', NULL, NULL, NULL, NULL),
-(1891, 'Number of persons that have at least x measurements', 'measurement_concept_id', 'measurement_count', NULL, NULL),
---1900 REPORTS
-(1900, 'Source values mapped to concept_id 0 by table, by source_value', 'table_name', 'source_value', NULL, NULL),
---2000 Iris (and possibly other new measures) integrated into Achilles
-(2000, 'Number of patients with at least 1 Dx and 1 Rx', NULL, NULL, NULL, NULL),
-(2001, 'Number of patients with at least 1 Dx and 1 Proc', NULL, NULL, NULL, NULL),
-(2002, 'Number of patients with at least 1 Meas, 1 Dx and 1 Rx', NULL, NULL, NULL, NULL),
-(2003, 'Number of patients with at least 1 Visit', NULL, NULL, NULL, NULL),
---2100- DEVICE_EXPOSURE
-(2100,
-    'Number of persons with at least one device exposure, by device_concept_id',
-    'device_concept_id',
-    NULL,
-    NULL,
-    NULL
-),
-(2101, 'Number of device exposure records, by device_concept_id', 'device_concept_id', NULL, NULL, NULL),
-(2102,
-    'Number of persons by device records  start month, by device_concept_id',
-    'device_concept_id',
-    'calendar month',
-    NULL,
-    NULL
-),
---2103 was not implemented at this point
-(2104,
-    'Number of persons with at least one device exposure, by device_concept_id by calendar year by gender by age decile',
-    'device_concept_id',
-    'calendar year',
-    'gender_concept_id',
-    'age decile'
-),
-(2105,
-    'Number of device exposure records, by device_concept_id by device_type_concept_id',
-    'device_concept_id',
-    'device_type_concept_id',
-    NULL,
-    NULL
-),
---2200- NOTE
-(2200, 'Number of persons with at least one note by  note_type_concept_id', 'note_type_concept_id', NULL, NULL, NULL),
-(2201, 'Number of note records, by note_type_concept_id', 'note_type_concept_id', NULL, NULL, NULL);
-
---end of importing values into analysis lookup table
-
---
-
-
-/* create achilles_results nonclustered indexes if dbms is PDW */
-
---
-
-
-/****
-7. generate results for analysis_results
-
-
-****/
-
 --
 -- 0	cdm name, version of Achilles and date when pre-computations were executed
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, stratum_3,count_value)
@@ -658,10 +146,10 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 103	Distribution of age at first observation period
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata  as ( select  p.person_id as person_id, min(EXTRACT(YEAR from observation_period_start_date)) - p.year_of_birth  as age_value   from  synpuf_100.person p
+WITH rawdata  as ( select  p.person_id as person_id, cast(min(EXTRACT(YEAR from observation_period_start_date)) - p.year_of_birth as float64) as age_value   from  synpuf_100.person p
   join synpuf_100.observation_period op on p.person_id = op.person_id
    group by  p.person_id, p.year_of_birth
- ), overallstats  as (select  cast(avg(1.0 * age_value)  as float64)  as avg_value, cast(STDDEV(age_value)  as float64)  as stdev_value, min(age_value)  as min_value, max(age_value)  as max_value, COUNT(*)  as total  from  rawdata
+ ), overallstats  as (select avg(1.0 * age_value) as avg_value, STDDEV(age_value) as stdev_value, min(age_value)  as min_value, max(age_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), agestats  as ( select  age_value as age_value, COUNT(*)  as total, row_number() over (order by age_value)  as rn   from  rawdata
    group by  1 ), agestatsprior  as ( select  s.age_value as age_value, s.total as total, sum(p.total)  as accumulated   from  agestats s
   join agestats p on p.rn <= s.rn
@@ -679,10 +167,10 @@ cross join overallstats o
 --
 -- 104	Distribution of age at first observation period by gender
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata  as ( select  p.gender_concept_id as gender_concept_id, min(EXTRACT(YEAR from observation_period_start_date)) - p.year_of_birth  as age_value   from  synpuf_100.person p
+WITH rawdata  as ( select  p.gender_concept_id as gender_concept_id, cast(min(EXTRACT(YEAR from observation_period_start_date)) - p.year_of_birth as float64) as age_value   from  synpuf_100.person p
 	join synpuf_100.observation_period op on p.person_id = op.person_id
 	 group by  p.person_id, p.gender_concept_id, p.year_of_birth
- ), overallstats  as ( select  gender_concept_id as gender_concept_id, cast(avg(1.0 * age_value)  as float64)  as avg_value, cast(STDDEV(age_value)  as float64)  as stdev_value, min(age_value)  as min_value, max(age_value)  as max_value, COUNT(*)  as total   from  rawdata
+ ), overallstats  as ( select  gender_concept_id as gender_concept_id, avg(1.0 * age_value) as avg_value, STDDEV(age_value) as stdev_value, min(age_value)  as min_value, max(age_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), agestats  as ( select  gender_concept_id as gender_concept_id, age_value as age_value, COUNT(*)  as total, row_number() over (order by age_value)  as rn   from  rawdata
    group by  1, 2 ), agestatsprior  as ( select  s.gender_concept_id as gender_concept_id, s.age_value as age_value, s.total as total, sum(p.total)  as accumulated   from  agestats s
   join agestats p on s.gender_concept_id = p.gender_concept_id and p.rn <= s.rn
@@ -700,11 +188,11 @@ join overallstats o on p.gender_concept_id = o.gender_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata  as (select  count_value
    as count_value  from  (
-    select  DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY) as count_value, row_number() over (partition by op.person_id order by op.observation_period_start_date asc) as rn
+    select  cast(DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY) as float64) as count_value, row_number() over (partition by op.person_id order by op.observation_period_start_date asc) as rn
      from  synpuf_100.observation_period op
 	) op
 	where op.rn = 1
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select avg(count_value) as avg_value, STDDEV(count_value) as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  (
     select  DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY) as count_value, row_number() over (partition by op.person_id order by op.observation_period_start_date asc) as rn
      from  synpuf_100.observation_period op
@@ -714,7 +202,7 @@ WITH rawdata  as (select  count_value
   join statsview p on p.rn <= s.rn
    group by  s.count_value, s.total, s.rn
  )
-select  105 as analysis_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value end) as p90_value
+select  105 as analysis_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, cast(min(case when p.accumulated >= .50 * o.total then count_value end) as float64) as median_value, cast(min(case when p.accumulated >= .10 * o.total then count_value end) as float64) as p10_value, cast(min(case when p.accumulated >= .25 * o.total then count_value end) as float64) as p25_value, cast(min(case when p.accumulated >= .75 * o.total then count_value end) as float64) as p75_value, cast(min(case when p.accumulated >= .90 * o.total then count_value end) as float64) as p90_value
   FROM  priorstats p
 cross join overallstats o
  group by  o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
@@ -727,18 +215,18 @@ cross join overallstats o
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata as (select  p.gender_concept_id as gender_concept_id, op.count_value
    as count_value  from  (
-    select  person_id, DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY) as count_value, row_number() over (partition by op.person_id order by op.observation_period_start_date asc) as rn
+    select  person_id, cast(DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY) as float64) as count_value, row_number() over (partition by op.person_id order by op.observation_period_start_date asc) as rn
      from  synpuf_100.observation_period op
 	) op
   join synpuf_100.person p on op.person_id = p.person_id
 	where op.rn = 1
-), overallstats  as ( select  gender_concept_id as gender_concept_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  gender_concept_id as gender_concept_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  gender_concept_id as gender_concept_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.gender_concept_id as gender_concept_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.gender_concept_id = p.gender_concept_id and p.rn <= s.rn
    group by  s.gender_concept_id, s.count_value, s.total, s.rn
  )
-select  106 as analysis_id, CAST(o.gender_concept_id  AS STRING) as gender_concept_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value end) as p90_value
+select  106 as analysis_id, CAST(o.gender_concept_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.gender_concept_id = o.gender_concept_id
  group by  o.gender_concept_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
@@ -749,19 +237,19 @@ join overallstats o on p.gender_concept_id = o.gender_concept_id
 -- 107	Length of observation (days) of first observation period by age decile
 
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata  as (select  floor((EXTRACT(YEAR from op.observation_period_start_date) - p.year_of_birth)/10)  as age_decile, DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY)  as count_value  from  (
+WITH rawdata  as (select  floor((EXTRACT(YEAR from op.observation_period_start_date) - p.year_of_birth)/10)  as age_decile, cast(DATE_DIFF(cast(op.observation_period_end_date as date), cast(op.observation_period_start_date as date), DAY) as float64) as count_value  from  (
     select  person_id, op.observation_period_start_date, op.observation_period_end_date, row_number() over (partition by op.person_id order by op.observation_period_start_date asc) as rn
      from  synpuf_100.observation_period op
   ) op
   join synpuf_100.person p on op.person_id = p.person_id
   where op.rn = 1
-), overallstats  as ( select  age_decile as age_decile, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  age_decile as age_decile, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  age_decile as age_decile, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.age_decile as age_decile, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.age_decile = p.age_decile and p.rn <= s.rn
    group by  s.age_decile, s.count_value, s.total, s.rn
  )
-select  107 as analysis_id, CAST(o.age_decile  AS STRING) as age_decile, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  107 as analysis_id, CAST(o.age_decile  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.age_decile = o.age_decile
  group by  o.age_decile, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
@@ -774,7 +262,7 @@ join overallstats o on p.age_decile = o.age_decile
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
 (select  108 as analysis_id, CAST(floor(DATE_DIFF(cast(op1.observation_period_end_date as date), cast(op1.observation_period_start_date as date), DAY)/30)  AS STRING) as stratum_1, COUNT(distinct p1.person_id) as count_value
   from  synpuf_100.person p1
-	inner join 
+	inner join
 	(select  person_id, observation_period_start_date, observation_period_end_date, row_number() over (partition by person_id order by observation_period_start_date asc) as rn1
 		  from  synpuf_100.observation_period
 	) op1
@@ -791,10 +279,10 @@ UNION ALL
   SELECT distinct  EXTRACT(YEAR from observation_period_start_date) as obs_year, parse_date('%Y%m%d', concat(concat(CAST(EXTRACT(YEAR from observation_period_start_date)  AS STRING), '01'), '01')) as obs_year_start, parse_date('%Y%m%d', concat(concat(CAST(EXTRACT(YEAR from observation_period_start_date)  AS STRING), '12'), '31')) as obs_year_end
   FROM  synpuf_100.observation_period
 ) select  109 as analysis_id, CAST(obs_year  AS STRING) as stratum_1, COUNT(distinct person_id) as count_value
-  from  synpuf_100.observation_period, obs_pd_dates 
-where  
+  from  synpuf_100.observation_period, obs_pd_dates
+where
 		observation_period_start_date <= obs_year_start
-	and 
+	and
 		observation_period_end_date >= obs_year_end
  group by  2)
 
@@ -809,8 +297,8 @@ UNION ALL
   as obs_month_start, DATE_ADD(cast(DATE_ADD(cast(parse_date('%Y%m%d', concat(concat(CAST(EXTRACT(YEAR from observation_period_start_date)  AS STRING), SUBSTR(concat('0', CAST(EXTRACT(MONTH from observation_period_start_date)  AS STRING)),-2)), '01')) as date), interval 1 MONTH) as date), interval -1 DAY) as obs_month_end
   FROM  synpuf_100.observation_period
 ) select  110 as analysis_id, CAST(obs_month  AS STRING) as stratum_1, COUNT(distinct person_id) as count_value
-  from  synpuf_100.observation_period, obs_pd_dates 
-where 
+  from  synpuf_100.observation_period, obs_pd_dates
+where
 		observation_period_start_date <= obs_month_start
 	and
 		observation_period_end_date >= obs_month_end
@@ -845,7 +333,7 @@ UNION ALL
 -- 114	Number of persons with observation period before year-of-birth
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  114 as analysis_id, COUNT(distinct p1.person_id) as count_value
- from 
+ from
 	synpuf_100.person p1
 	inner join ( select  person_id, min(EXTRACT(YEAR from observation_period_start_date)) as first_obs_year   from  synpuf_100.observation_period  group by  1 ) op1
 	on p1.person_id = op1.person_id
@@ -857,7 +345,7 @@ where p1.year_of_birth > op1.first_obs_year
 -- 115	Number of persons with observation period end < start
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  115 as analysis_id, COUNT(op1.person_id) as count_value
- from 
+ from
 	synpuf_100.observation_period op1
 where op1.observation_period_end_date < op1.observation_period_start_date
 ;
@@ -870,15 +358,15 @@ where op1.observation_period_end_date < op1.observation_period_start_date
 -- Note: using temp table instead of nested query because this gives vastly improved performance in Oracle
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, stratum_3, count_value)
 WITH obs_pd_dates AS (
-  SELECT distinct  EXTRACT(YEAR from observation_period_start_date) as obs_year 
-  FROM  
+  SELECT distinct  EXTRACT(YEAR from observation_period_start_date) as obs_year
+  FROM
   synpuf_100.observation_period
 ) select  116 as analysis_id, CAST(t1.obs_year  AS STRING) as stratum_1, CAST(p1.gender_concept_id  AS STRING) as stratum_2, CAST(floor((t1.obs_year - p1.year_of_birth)/10)  AS STRING) as stratum_3, COUNT(distinct p1.person_id) as count_value
   from  synpuf_100.person p1
-	inner join 
+	inner join
   synpuf_100.observation_period op1
 	on p1.person_id = op1.person_id
-	, obs_pd_dates  t1 
+	, obs_pd_dates  t1
 where EXTRACT(YEAR from op1.observation_period_start_date) <= t1.obs_year
 	and EXTRACT(YEAR from op1.observation_period_end_date) >= t1.obs_year
  group by  t1.obs_year, p1.gender_concept_id, 4 ;
@@ -891,10 +379,10 @@ where EXTRACT(YEAR from op1.observation_period_start_date) <= t1.obs_year
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
 WITH obs_pd_dates AS (
   SELECT distinct  EXTRACT(YEAR from observation_period_start_date)*100 + EXTRACT(MONTH from observation_period_start_date)  as obs_month
-  FROM  
+  FROM
   synpuf_100.observation_period
 ) select  117 as analysis_id, CAST(t1.obs_month  AS STRING) as stratum_1, COUNT(distinct op1.person_id) as count_value
-  from  synpuf_100.observation_period op1, obs_pd_dates  t1 
+  from  synpuf_100.observation_period op1, obs_pd_dates  t1
 where EXTRACT(YEAR from observation_period_start_date)*100 + EXTRACT(MONTH from observation_period_start_date) <= t1.obs_month
 	and EXTRACT(YEAR from observation_period_end_date)*100 + EXTRACT(MONTH from observation_period_end_date) >= t1.obs_month
  group by  t1.obs_month
@@ -906,7 +394,7 @@ where EXTRACT(YEAR from observation_period_start_date)*100 + EXTRACT(MONTH from 
 -- 118  Number of observation period records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  118 as analysis_id, COUNT(op1.person_id) as count_value
- from 
+ from
   synpuf_100.observation_period op1
   left join synpuf_100.person p1
   on p1.person_id = op1.person_id
@@ -966,9 +454,9 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 -- 203	Number of distinct visit occurrence concepts per person
 
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as ( select  vo1.person_id as person_id, COUNT(distinct vo1.visit_concept_id)  as count_value   from  synpuf_100.visit_occurrence vo1
+WITH rawdata as ( select  vo1.person_id as person_id, cast(COUNT(distinct vo1.visit_concept_id) as float64) as count_value   from  synpuf_100.visit_occurrence vo1
 		 group by  vo1.person_id
- ), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+ ), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1002,21 +490,21 @@ on p1.person_id = vo1.person_id
 -- 206	Distribution of age by visit_concept_id
 
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  vo1.visit_concept_id as stratum1_id, p1.gender_concept_id as stratum2_id, vo1.visit_start_year - p1.year_of_birth  as count_value  from  synpuf_100.person p1
-	inner join 
+WITH rawdata as (select  vo1.visit_concept_id as stratum1_id, p1.gender_concept_id as stratum2_id, cast(vo1.visit_start_year - p1.year_of_birth as float64) as count_value  from  synpuf_100.person p1
+	inner join
   (
 		 select  person_id, visit_concept_id, min(EXTRACT(YEAR from visit_start_date)) as visit_start_year
 		  from  synpuf_100.visit_occurrence
 		 group by  1, 2 ) vo1 on p1.person_id = vo1.person_id
-), overallstats  as ( select  stratum1_id as stratum1_id, stratum2_id as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum1_id as stratum1_id, stratum2_id as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
 	 group by  1, 2 ), statsview  as ( select  stratum1_id as stratum1_id, stratum2_id as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by stratum1_id, stratum2_id order by count_value)  as rn   from  rawdata
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  206 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  206 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 
@@ -1025,7 +513,7 @@ join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.strat
 --207	Number of visit records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 (select  207 as analysis_id, COUNT(vo1.person_id) as count_value
- from 
+ from
 	synpuf_100.visit_occurrence vo1
 	left join synpuf_100.person p1
 	on p1.person_id = vo1.person_id
@@ -1037,7 +525,7 @@ UNION ALL
 --
 --208	Number of visit records outside valid observation period
 (select  208 as analysis_id, COUNT(vo1.person_id) as count_value
- from 
+ from
 	synpuf_100.visit_occurrence vo1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = vo1.person_id
@@ -1050,7 +538,7 @@ UNION ALL
 --
 --209	Number of visit records with end date < start date
 (select  209 as analysis_id, COUNT(vo1.person_id) as count_value
- from 
+ from
 	synpuf_100.visit_occurrence vo1
 where visit_end_date < visit_start_date)
 
@@ -1059,7 +547,7 @@ UNION ALL
 --
 --210	Number of visit records with invalid care_site_id
 (select  210 as analysis_id, COUNT(vo1.person_id) as count_value
- from 
+ from
 	synpuf_100.visit_occurrence vo1
 	left join synpuf_100.care_site cs1
 	on vo1.care_site_id = cs1.care_site_id
@@ -1071,14 +559,14 @@ where vo1.care_site_id is not null
 --
 -- 211	Distribution of length of stay by visit_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  visit_concept_id as stratum_id, DATE_DIFF(cast(visit_end_date as date), cast(visit_start_date as date), DAY)  as count_value  from  synpuf_100.visit_occurrence
-), overallstats  as ( select  stratum_id as stratum_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+WITH rawdata as (select  visit_concept_id as stratum_id, cast(DATE_DIFF(cast(visit_end_date as date), cast(visit_start_date as date), DAY) as float64) as count_value  from  synpuf_100.visit_occurrence
+), overallstats  as ( select  stratum_id as stratum_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  stratum_id as stratum_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum_id as stratum_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum_id = p.stratum_id and p.rn <= s.rn
    group by  s.stratum_id, s.count_value, s.total, s.rn
  )
-select  211 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  211 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum_id = o.stratum_id
  group by  o.stratum_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
@@ -1089,7 +577,7 @@ join overallstats o on p.stratum_id = o.stratum_id
 --
 -- 212	Number of persons with at least one visit occurrence by calendar year by gender by age decile
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, stratum_3, count_value)
- select  212 as analysis_id, CAST(EXTRACT(YEAR from visit_start_date)  AS STRING), CAST(p1.gender_concept_id  AS STRING) as stratum_2, CAST(floor((EXTRACT(YEAR from visit_start_date) - p1.year_of_birth)/10)  AS STRING) as stratum_3, COUNT(distinct p1.person_id) as count_value
+ select  212 as analysis_id, CAST(EXTRACT(YEAR from visit_start_date)  AS STRING) as stratum_1, CAST(p1.gender_concept_id  AS STRING) as stratum_2, CAST(floor((EXTRACT(YEAR from visit_start_date) - p1.year_of_birth)/10)  AS STRING) as stratum_3, COUNT(distinct p1.person_id) as count_value
   from  synpuf_100.person p1
 inner join
 synpuf_100.visit_occurrence vo1
@@ -1108,7 +596,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
 
 
 --
--- 221	Number of persons by visit start year 
+-- 221	Number of persons by visit start year
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
  select  221 as analysis_id, CAST(EXTRACT(YEAR from visit_start_date)  AS STRING) as stratum_1, COUNT(distinct person_id) as count_value
   from  synpuf_100.visit_occurrence vo1
@@ -1190,8 +678,8 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 403	Number of distinct condition occurrence concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as ( select  person_id as person_id, COUNT(distinct condition_concept_id)  as count_value   from  synpuf_100.condition_occurrence
-	 group by  1 ), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+WITH rawdata as ( select  person_id as person_id, cast(COUNT(distinct condition_concept_id) as float64) as count_value   from  synpuf_100.condition_occurrence
+	 group by  1 ), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1229,22 +717,22 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_406 AS
-  (SELECT co1.condition_concept_id as subject_id, p1.gender_concept_id, (co1.condition_start_year - p1.year_of_birth) as count_value
+  (SELECT co1.condition_concept_id as subject_id, p1.gender_concept_id, cast((co1.condition_start_year - p1.year_of_birth) as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
 	 select  person_id, condition_concept_id, min(EXTRACT(YEAR from condition_start_date)) as condition_start_year
 	  from  synpuf_100.condition_occurrence
 	 group by  1, 2 ) co1 on p1.person_id = co1.person_id),
- overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_406
+ overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_406
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_406
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  406 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  406 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 
@@ -1253,7 +741,7 @@ join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.strat
 -- 409	Number of condition occurrence records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 (select  409 as analysis_id, COUNT(co1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_occurrence co1
 	left join synpuf_100.person p1
 	on p1.person_id = co1.person_id
@@ -1265,7 +753,7 @@ UNION ALL
 --
 -- 410	Number of condition occurrence records outside valid observation period
 (select  410 as analysis_id, COUNT(co1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_occurrence co1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = co1.person_id
@@ -1279,7 +767,7 @@ UNION ALL
 --
 -- 411	Number of condition occurrence records with end date < start date
 (select  411 as analysis_id, COUNT(co1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_occurrence co1
 where co1.condition_end_date < co1.condition_start_date)
 
@@ -1289,7 +777,7 @@ UNION ALL
 --
 -- 412	Number of condition occurrence records with invalid provider_id
 (select  412 as analysis_id, COUNT(co1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_occurrence co1
 	left join synpuf_100.provider p1
 	on p1.provider_id = co1.provider_id
@@ -1301,7 +789,7 @@ UNION ALL
 --
 -- 413	Number of condition occurrence records with invalid visit_id
 (select  413 as analysis_id, COUNT(co1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_occurrence co1
 	left join synpuf_100.visit_occurrence vo1
 	on co1.visit_occurrence_id = vo1.visit_occurrence_id
@@ -1376,19 +864,19 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
 -- 506	Distribution of age by condition_concept_id
 
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  p1.gender_concept_id as stratum_id, d1.death_year - p1.year_of_birth  as count_value  from  synpuf_100.person p1
+WITH rawdata as (select  p1.gender_concept_id as stratum_id, cast(d1.death_year - p1.year_of_birth as float64) as count_value  from  synpuf_100.person p1
   inner join
   ( select  person_id, min(EXTRACT(YEAR from death_date)) as death_year
     from  synpuf_100.death
    group by  1 ) d1
   on p1.person_id = d1.person_id
-), overallstats  as ( select  stratum_id as stratum_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum_id as stratum_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  stratum_id as stratum_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum_id as stratum_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum_id = p.stratum_id and p.rn <= s.rn
    group by  s.stratum_id, s.count_value, s.total, s.rn
  )
-select  506 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  506 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum_id = o.stratum_id
  group by  o.stratum_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
@@ -1401,7 +889,7 @@ join overallstats o on p.stratum_id = o.stratum_id
 -- 509	Number of death records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  509 as analysis_id, COUNT(d1.person_id) as count_value
- from 
+ from
 	synpuf_100.death d1
 		left join synpuf_100.person p1
 		on d1.person_id = p1.person_id
@@ -1412,7 +900,7 @@ UNION ALL
 --
 -- 510	Number of death records outside valid observation period
 select  510 as analysis_id, COUNT(d1.person_id) as count_value
- from 
+ from
 	synpuf_100.death d1
 		left join synpuf_100.observation_period op1
 		on d1.person_id = op1.person_id
@@ -1426,10 +914,10 @@ where op1.person_id is null
 --
 -- 511	Distribution of time from death to last condition
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-select  511 as analysis_id, COUNT(count_value) as count_value, min(count_value) as min_value, max(count_value) as max_value, cast(avg(1.0*count_value)  as float64) as avg_value, cast(STDDEV(count_value)  as float64) as stdev_value, max(case when p1<=0.50 then count_value else -9999 end) as median_value, max(case when p1<=0.10 then count_value else -9999 end) as p10_value, max(case when p1<=0.25 then count_value else -9999 end) as p25_value, max(case when p1<=0.75 then count_value else -9999 end) as p75_value, max(case when p1<=0.90 then count_value else -9999 end) as p90_value
- from 
+select  511 as analysis_id, COUNT(count_value) as count_value, min(count_value) as min_value, max(count_value) as max_value, cast(avg(1.0*count_value)  as float64) as avg_value, STDDEV(count_value) as stdev_value, max(case when p1<=0.50 then count_value else -9999 end) as median_value, max(case when p1<=0.10 then count_value else -9999 end) as p10_value, max(case when p1<=0.25 then count_value else -9999 end) as p25_value, max(case when p1<=0.75 then count_value else -9999 end) as p75_value, max(case when p1<=0.90 then count_value else -9999 end) as p90_value
+ from
 (
-select  DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY) as count_value, 1.0*(row_number() over (order by DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY)))/(COUNT(*) over () + 1) as p1
+select  cast(DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY) as float64) as count_value, 1.0*(row_number() over (order by DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY)))/(COUNT(*) over () + 1) as p1
  from  synpuf_100.death d1
 	inner join
 	(
@@ -1442,14 +930,14 @@ UNION ALL
 
 --
 -- 512	Distribution of time from death to last drug
-(WITH rawdata as (select  DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY)  as count_value  from  synpuf_100.death d1
+(WITH rawdata as (select  cast(DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY) as float64) as count_value  from  synpuf_100.death d1
   inner join
 	(
 		 select  person_id, max(drug_exposure_start_date) as max_date
 		  from  synpuf_100.drug_exposure
 		 group by  1 ) t0
 	on d1.person_id = t0.person_id
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1464,14 +952,14 @@ UNION ALL
 
 --
 -- 513	Distribution of time from death to last visit
-(WITH rawdata as (select  DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY)  as count_value  from  synpuf_100.death d1
+(WITH rawdata as (select  cast(DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY) as float64) as count_value  from  synpuf_100.death d1
 	inner join
 	(
 		 select  person_id, max(visit_start_date) as max_date
 		  from  synpuf_100.visit_occurrence
 		 group by  1 ) t0
 	on d1.person_id = t0.person_id
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1486,14 +974,14 @@ UNION ALL
 
 --
 -- 514	Distribution of time from death to last procedure
-(WITH rawdata as (select  DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY)  as count_value  from  synpuf_100.death d1
+(WITH rawdata as (select  cast(DATE_DIFF(cast(t0.max_date as date), cast(d1.death_date as date), DAY) as float64) as count_value  from  synpuf_100.death d1
 	inner join
 	(
 		 select  person_id, max(procedure_date) as max_date
 		  from  synpuf_100.procedure_occurrence
 		 group by  1 ) t0
 	on d1.person_id = t0.person_id
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1508,64 +996,17 @@ UNION ALL
 
 --
 -- 515	Distribution of time from death to last observation
-(WITH rawdata AS (SELECT DATE_DIFF(cast(t0.max_date AS DATE), cast(d1.death_date AS DATE), DAY) AS count_value
-                  FROM synpuf_100.death d1
-                      INNER JOIN
-                      (
-                          SELECT
-                              person_id,
-                              max(observation_date) AS max_date
-                          FROM synpuf_100.observation
-                          GROUP BY 1) t0
-                          ON d1.person_id = t0.person_id
-), overallstats AS (SELECT
-                        cast(avg(1.0 * count_value) AS FLOAT64) AS avg_value,
-                        cast(STDDEV(count_value) AS FLOAT64)    AS stdev_value,
-                        min(count_value)                        AS min_value,
-                        max(count_value)                        AS max_value,
-                        COUNT(*)                                AS total
-                    FROM rawdata
-), statsview AS ( SELECT
-                      count_value                AS count_value,
-                      COUNT(*)                   AS total,
-                      row_number()
-                      OVER (
-                          ORDER BY count_value ) AS rn
-                  FROM rawdata
-                  GROUP BY 1 ), priorstats AS ( SELECT
-                                                    s.count_value AS count_value,
-                                                    s.total       AS total,
-                                                    sum(p.total)  AS accumulated
-                                                FROM statsview s
-                                                    JOIN statsview p ON p.rn <= s.rn
-                                                GROUP BY s.count_value, s.total, s.rn
-)
-SELECT
-    515                       AS analysis_id,
-    o.total                   AS count_value,
-    o.min_value,
-    o.max_value,
-    o.avg_value,
-    o.stdev_value,
-    min(CASE WHEN p.accumulated >= .50 * o.total
-        THEN count_value
-        ELSE o.max_value END) AS median_value,
-    min(CASE WHEN p.accumulated >= .10 * o.total
-        THEN count_value
-        ELSE o.max_value END) AS p10_value,
-    min(CASE WHEN p.accumulated >= .25 * o.total
-        THEN count_value
-        ELSE o.max_value END) AS p25_value,
-    min(CASE WHEN p.accumulated >= .75 * o.total
-        THEN count_value
-        ELSE o.max_value END) AS p75_value,
-    min(CASE WHEN p.accumulated >= .90 * o.total
-        THEN count_value
-        ELSE o.max_value END) AS p90_value
-FROM priorstats p
-    CROSS JOIN overallstats o
-GROUP BY o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
-);
+(WITH rawdata AS (SELECT cast(DATE_DIFF(cast(t0.max_date AS DATE), cast(d1.death_date AS DATE), DAY) as float64) AS count_value FROM synpuf_100.death d1
+INNER JOIN (SELECT person_id, max(observation_date) AS max_date FROM synpuf_100.observation GROUP BY 1) t0 ON d1.person_id = t0.person_id
+), overallstats AS (SELECT cast(avg(count_value) AS FLOAT64) AS avg_value, cast(STDDEV(count_value) AS FLOAT64) AS stdev_value, min(count_value) AS min_value, max(count_value) AS max_value, COUNT(*) AS total FROM rawdata
+), statsview AS ( SELECT count_value AS count_value, COUNT(*) AS total, row_number() OVER (ORDER BY count_value) AS rn FROM rawdata GROUP BY 1
+), priorstats AS ( SELECT s.count_value AS count_value, s.total AS total, sum(p.total)  AS accumulated FROM statsview s JOIN statsview p ON p.rn <= s.rn GROUP BY s.count_value, s.total, s.rn)
+
+SELECT 515 AS analysis_id, o.total AS count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(CASE WHEN p.accumulated >= .50 * o.total THEN count_value ELSE o.max_value END) AS median_value,
+min(CASE WHEN p.accumulated >= .10 * o.total THEN count_value ELSE o.max_value END) AS p10_value, min(CASE WHEN p.accumulated >= .25 * o.total THEN count_value ELSE o.max_value END) AS p25_value,
+min(CASE WHEN p.accumulated >= .75 * o.total THEN count_value  ELSE o.max_value END) AS p75_value, min(CASE WHEN p.accumulated >= .90 * o.total THEN count_value ELSE o.max_value END) AS p90_value
+FROM priorstats p CROSS JOIN overallstats o GROUP BY o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value)
+;
 --
 
 
@@ -1612,9 +1053,9 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 603	Number of distinct procedure occurrence concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as ( select  COUNT(distinct po.procedure_concept_id)  as count_value   from  synpuf_100.procedure_occurrence po
+WITH rawdata as ( select  cast(COUNT(distinct po.procedure_concept_id) as float64) as count_value   from  synpuf_100.procedure_occurrence po
 	 group by  po.person_id
- ), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+ ), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1655,7 +1096,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 -- 606	Distribution of age by procedure_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_606 AS
-(SELECT po1.procedure_concept_id as subject_id, p1.gender_concept_id, po1.procedure_start_year - p1.year_of_birth as count_value
+(SELECT po1.procedure_concept_id as subject_id, p1.gender_concept_id, cast(po1.procedure_start_year - p1.year_of_birth as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
@@ -1663,15 +1104,15 @@ inner join
 	  from  synpuf_100.procedure_occurrence
 	 group by  1, 2 ) po1 on p1.person_id = po1.person_id
 ),
-overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_606
+overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_606
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_606
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  606 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  606 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -1680,7 +1121,7 @@ join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.strat
 -- 609	Number of procedure occurrence records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  609 as analysis_id, COUNT(po1.person_id) as count_value
- from 
+ from
 	synpuf_100.procedure_occurrence po1
 	left join synpuf_100.person p1
 	on p1.person_id = po1.person_id
@@ -1691,7 +1132,7 @@ UNION ALL
 --
 -- 610	Number of procedure occurrence records outside valid observation period
 select  610 as analysis_id, COUNT(po1.person_id) as count_value
- from 
+ from
 	synpuf_100.procedure_occurrence po1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = po1.person_id
@@ -1704,7 +1145,7 @@ UNION ALL
 --
 -- 612	Number of procedure occurrence records with invalid provider_id
 select  612 as analysis_id, COUNT(po1.person_id) as count_value
- from 
+ from
 	synpuf_100.procedure_occurrence po1
 	left join synpuf_100.provider p1
 	on p1.provider_id = po1.provider_id
@@ -1716,7 +1157,7 @@ UNION ALL
 --
 -- 613	Number of procedure occurrence records with invalid visit_id
 select  613 as analysis_id, COUNT(po1.person_id) as count_value
- from 
+ from
 	synpuf_100.procedure_occurrence po1
 	left join synpuf_100.visit_occurrence vo1
 	on po1.visit_occurrence_id = vo1.visit_occurrence_id
@@ -1788,12 +1229,12 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 703	Number of distinct drug exposure concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  num_drugs  as count_value  from  (
+WITH rawdata as (select  cast(num_drugs as float64) as count_value  from  (
 		 select  de1.person_id, COUNT(distinct de1.drug_concept_id) as num_drugs
 		  from  synpuf_100.drug_exposure de1
 		 group by  de1.person_id
 	 ) t0
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -1834,22 +1275,22 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 -- 706	Distribution of age by drug_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_706 AS
-(SELECT de1.drug_concept_id as subject_id, p1.gender_concept_id, de1.drug_start_year - p1.year_of_birth as count_value
+(SELECT de1.drug_concept_id as subject_id, p1.gender_concept_id, cast(de1.drug_start_year - p1.year_of_birth as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
 	 select  person_id, drug_concept_id, min(EXTRACT(YEAR from drug_exposure_start_date)) as drug_start_year
 	  from  synpuf_100.drug_exposure
 	 group by  1, 2 ) de1 on p1.person_id = de1.person_id),
-overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_706
+overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_706
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_706
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  706 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  706 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -1860,7 +1301,7 @@ join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.strat
 -- 709	Number of drug exposure records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  709 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_exposure de1
 	left join synpuf_100.person p1
 	on p1.person_id = de1.person_id
@@ -1872,7 +1313,7 @@ UNION ALL
 --
 -- 710	Number of drug exposure records outside valid observation period
 select  710 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_exposure de1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = de1.person_id
@@ -1885,7 +1326,7 @@ UNION ALL
 --
 -- 711	Number of drug exposure records with end date < start date
 select  711 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_exposure de1
 where de1.drug_exposure_end_date < de1.drug_exposure_start_date
 
@@ -1894,7 +1335,7 @@ UNION ALL
 --
 -- 712	Number of drug exposure records with invalid provider_id
 select  712 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_exposure de1
 	left join synpuf_100.provider p1
 	on p1.provider_id = de1.provider_id
@@ -1906,7 +1347,7 @@ UNION ALL
 --
 -- 713	Number of drug exposure records with invalid visit_id
 select  713 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_exposure de1
 	left join synpuf_100.visit_occurrence vo1
 	on de1.visit_occurrence_id = vo1.visit_occurrence_id
@@ -1920,15 +1361,15 @@ where de1.visit_occurrence_id is not null
 --
 -- 715	Distribution of days_supply by drug_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-(WITH rawdata as (select  drug_concept_id as stratum_id, days_supply  as count_value  from  synpuf_100.drug_exposure
+(WITH rawdata as (select  drug_concept_id as stratum_id, cast(days_supply as float64) as count_value  from  synpuf_100.drug_exposure
 	where days_supply is not null
-), overallstats  as ( select  stratum_id as stratum_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum_id as stratum_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
 	 group by  1 ), statsview  as ( select  stratum_id as stratum_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum_id as stratum_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum_id = p.stratum_id and p.rn <= s.rn
    group by  s.stratum_id, s.count_value, s.total, s.rn
  )
-select  715 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  715 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum_id = o.stratum_id
  group by  o.stratum_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value)
@@ -1937,15 +1378,15 @@ UNION ALL
 
 --
 -- 716	Distribution of refills by drug_concept_id
-(WITH rawdata as (select  drug_concept_id as stratum_id, refills  as count_value  from  synpuf_100.drug_exposure
+(WITH rawdata as (select  drug_concept_id as stratum_id, cast(refills as float64) as count_value  from  synpuf_100.drug_exposure
 	where refills is not null
-), overallstats  as ( select  stratum_id as stratum_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum_id as stratum_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
 	 group by  1 ), statsview  as ( select  stratum_id as stratum_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum_id as stratum_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum_id = p.stratum_id and p.rn <= s.rn
    group by  s.stratum_id, s.count_value, s.total, s.rn
  )
-select  716 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  716 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum_id = o.stratum_id
  group by  o.stratum_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value)
@@ -1956,13 +1397,13 @@ UNION ALL
 -- 717	Distribution of quantity by drug_concept_id
 (WITH rawdata as (select  drug_concept_id as stratum_id, cast(quantity  as float64)  as count_value  from  synpuf_100.drug_exposure
 	where quantity is not null
-), overallstats  as ( select  stratum_id as stratum_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum_id as stratum_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
 	 group by  1 ), statsview  as ( select  stratum_id as stratum_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum_id as stratum_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum_id = p.stratum_id and p.rn <= s.rn
    group by  s.stratum_id, s.count_value, s.total, s.rn
  )
-select  717 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  717 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum_id = o.stratum_id
  group by  o.stratum_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value)
@@ -2032,12 +1473,12 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 803	Number of distinct observation occurrence concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  num_observations  as count_value  from  (
+WITH rawdata as (select  cast(num_observations as float64) as count_value  from  (
   	 select  o1.person_id, COUNT(distinct o1.observation_concept_id) as num_observations
   	  from  synpuf_100.observation o1
   	 group by  o1.person_id
 	 ) t0
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -2078,7 +1519,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 -- 806	Distribution of age by observation_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_806 AS
-(SELECT o1.observation_concept_id as subject_id, p1.gender_concept_id, o1.observation_start_year - p1.year_of_birth as count_value
+(SELECT o1.observation_concept_id as subject_id, p1.gender_concept_id, cast(o1.observation_start_year - p1.year_of_birth as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
@@ -2087,15 +1528,15 @@ inner join
 	 group by  1, 2 ) o1
 on p1.person_id = o1.person_id
 ),
-overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_806
+overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_806
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_806
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  806 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  806 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -2117,7 +1558,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 -- 809	Number of observation records with invalid person_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  809 as analysis_id, COUNT(o1.person_id) as count_value
- from 
+ from
 	synpuf_100.observation o1
 	left join synpuf_100.person p1
 	on p1.person_id = o1.person_id
@@ -2130,7 +1571,7 @@ where p1.person_id is null
 -- 810	Number of observation records outside valid observation period
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  810 as analysis_id, COUNT(o1.person_id) as count_value
- from 
+ from
 	synpuf_100.observation o1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = o1.person_id
@@ -2146,7 +1587,7 @@ where op1.person_id is null
 -- 812	Number of observation records with invalid provider_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  812 as analysis_id, COUNT(o1.person_id) as count_value
- from 
+ from
 	synpuf_100.observation o1
 	left join synpuf_100.provider p1
 	on p1.provider_id = o1.provider_id
@@ -2158,7 +1599,7 @@ UNION ALL
 --
 -- 813	Number of observation records with invalid visit_id
 select  813 as analysis_id, COUNT(o1.person_id) as count_value
- from 
+ from
 	synpuf_100.observation o1
 	left join synpuf_100.visit_occurrence vo1
 	on o1.visit_occurrence_id = vo1.visit_occurrence_id
@@ -2170,7 +1611,7 @@ UNION ALL
 --
 -- 814	Number of observation records with no value (numeric, string, or concept)
 select  814 as analysis_id, COUNT(o1.person_id) as count_value
- from 
+ from
 	synpuf_100.observation o1
 where o1.value_as_number is null
 	and o1.value_as_string is null
@@ -2188,15 +1629,15 @@ WITH rawdata_815 AS
 where o1.unit_concept_id is not null
 	and o1.value_as_number is not null
 ),
-overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_815
+overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_815
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, unit_concept_id order by count_value)  as rn   from  rawdata_815
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  815 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  815 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 
@@ -2213,7 +1654,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
  select  891 as analysis_id, stratum_1, obs_cnt as stratum_2, sum(count(person_id))	over (partition by stratum_1 order by obs_cnt desc) as count_value
   from  (
 	 select  CAST(o.observation_concept_id AS STRING) as stratum_1, CAST(count(o.observation_id) AS STRING) as obs_cnt, o.person_id
-	  from  synpuf_100.observation o 
+	  from  synpuf_100.observation o
 	 group by  o.person_id, stratum_1
  ) cnt_q
  group by  2, 3 ;
@@ -2262,9 +1703,9 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 903	Number of distinct drug era concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as ( select  COUNT(distinct de1.drug_concept_id)  as count_value   from  synpuf_100.drug_era de1
+WITH rawdata as ( select  cast(COUNT(distinct de1.drug_concept_id) as float64) as count_value   from  synpuf_100.drug_era de1
 	 group by  de1.person_id
- ), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+ ), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -2298,7 +1739,7 @@ on p1.person_id = de1.person_id
 
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_906 AS
-(SELECT de.drug_concept_id as subject_id, p1.gender_concept_id, de.drug_start_year - p1.year_of_birth as count_value
+(SELECT de.drug_concept_id as subject_id, p1.gender_concept_id, cast(de.drug_start_year - p1.year_of_birth as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
@@ -2306,15 +1747,15 @@ inner join
 	  from  synpuf_100.drug_era
 	 group by  1, 2 ) de on p1.person_id =de.person_id
 ),
-overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_906
+overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_906
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_906
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  906 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  906 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -2323,8 +1764,8 @@ join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.strat
 --
 -- 907	Distribution of drug era length, by drug_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  drug_concept_id as stratum1_id, DATE_DIFF(cast(drug_era_end_date as date), cast(drug_era_start_date as date), DAY)  as count_value  from  synpuf_100.drug_era de1
-), overallstats  as ( select  stratum1_id as stratum1_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+WITH rawdata as (select  drug_concept_id as stratum1_id, cast(DATE_DIFF(cast(drug_era_end_date as date), cast(drug_era_start_date as date), DAY) as float64) as count_value  from  synpuf_100.drug_era de1
+), overallstats  as ( select  stratum1_id as stratum1_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  stratum1_id as stratum1_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by stratum1_id order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
@@ -2343,7 +1784,7 @@ join overallstats o on p.stratum1_id = o.stratum1_id
 -- 908	Number of drug eras with invalid person
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  908 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_era de1
 	left join synpuf_100.person p1
 	on p1.person_id = de1.person_id
@@ -2355,7 +1796,7 @@ UNION ALL
 --
 -- 909	Number of drug eras outside valid observation period
 select  909 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_era de1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = de1.person_id
@@ -2369,7 +1810,7 @@ UNION ALL
 --
 -- 910	Number of drug eras with end date < start date
 select  910 as analysis_id, COUNT(de1.person_id) as count_value
- from 
+ from
 	synpuf_100.drug_era de1
 where de1.drug_era_end_date < de1.drug_era_start_date
 ;
@@ -2430,9 +1871,9 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 1003	Number of distinct condition era concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as ( select  COUNT(distinct ce1.condition_concept_id)  as count_value   from  synpuf_100.condition_era ce1
+WITH rawdata as ( select cast(COUNT(distinct ce1.condition_concept_id) as float64) as count_value   from  synpuf_100.condition_era ce1
 	 group by  ce1.person_id
- ), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+ ), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -2467,7 +1908,7 @@ on p1.person_id = ce1.person_id
 
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_1006 AS
-(SELECT ce.condition_concept_id as subject_id, p1.gender_concept_id, ce.condition_start_year - p1.year_of_birth as count_value
+(SELECT ce.condition_concept_id as subject_id, p1.gender_concept_id, cast(ce.condition_start_year - p1.year_of_birth as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
@@ -2475,15 +1916,15 @@ inner join
     from  synpuf_100.condition_era
    group by  1, 2 ) ce on p1.person_id = ce.person_id
 ),
-overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1006
+overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1006
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_1006
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  1006 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  1006 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -2493,8 +1934,8 @@ join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.strat
 --
 -- 1007	Distribution of condition era length, by condition_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  condition_concept_id  as stratum1_id, DATE_DIFF(cast(condition_era_end_date as date), cast(condition_era_start_date as date), DAY)  as count_value  from  synpuf_100.condition_era ce1
-), overallstats  as ( select  stratum1_id as stratum1_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+WITH rawdata as (select  condition_concept_id  as stratum1_id, cast(DATE_DIFF(cast(condition_era_end_date as date), cast(condition_era_start_date as date), DAY) as float64) as count_value  from  synpuf_100.condition_era ce1
+), overallstats  as ( select  stratum1_id as stratum1_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  stratum1_id as stratum1_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by stratum1_id order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
@@ -2511,7 +1952,7 @@ join overallstats o on p.stratum1_id = o.stratum1_id
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 
 (select  1008 as analysis_id, COUNT(ce1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_era ce1
 	left join synpuf_100.person p1
 	on p1.person_id = ce1.person_id
@@ -2522,7 +1963,7 @@ UNION ALL
 --
 -- 1009	Number of condition eras outside valid observation period
 (select  1009 as analysis_id, COUNT(ce1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_era ce1
 	left join synpuf_100.observation_period op1
 	on op1.person_id = ce1.person_id
@@ -2535,7 +1976,7 @@ UNION ALL
 --
 -- 1010	Number of condition eras with end date < start date
 (select  1010 as analysis_id, COUNT(ce1.person_id) as count_value
- from 
+ from
 	synpuf_100.condition_era ce1
 where ce1.condition_era_end_date < ce1.condition_era_start_date);
 
@@ -2673,14 +2114,14 @@ ACHILLES Analyses on PAYOR_PLAN_PERIOD table
 --
 -- 1406	Length of payer plan (days) of first payer plan period by gender
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  p1.gender_concept_id  as stratum1_id, DATE_DIFF(cast(ppp1.payer_plan_period_end_date as date), cast(ppp1.payer_plan_period_start_date as date), DAY)  as count_value  from  synpuf_100.person p1
-	inner join 
+WITH rawdata as (select  p1.gender_concept_id  as stratum1_id, cast(DATE_DIFF(cast(ppp1.payer_plan_period_end_date as date), cast(ppp1.payer_plan_period_start_date as date), DAY) as float64) as count_value  from  synpuf_100.person p1
+	inner join
 	(select  person_id, payer_plan_period_start_date, payer_plan_period_end_date, row_number() over (partition by person_id order by payer_plan_period_start_date asc) as rn1
 		  from  synpuf_100.payer_plan_period
 	) ppp1
 	on p1.person_id = ppp1.person_id
 	where ppp1.rn1 = 1
-), overallstats  as ( select  stratum1_id as stratum1_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum1_id as stratum1_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  stratum1_id as stratum1_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by stratum1_id order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and p.rn <= s.rn
@@ -2698,20 +2139,20 @@ join overallstats o on p.stratum1_id = o.stratum1_id
 --
 -- 1407	Length of payer plan (days) of first payer plan period by age decile
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  floor((EXTRACT(YEAR from ppp1.payer_plan_period_start_date) - p1.year_of_birth)/10)  as stratum_id, DATE_DIFF(cast(ppp1.payer_plan_period_end_date as date), cast(ppp1.payer_plan_period_start_date as date), DAY)  as count_value  from  synpuf_100.person p1
-	inner join 
+WITH rawdata as (select  floor((EXTRACT(YEAR from ppp1.payer_plan_period_start_date) - p1.year_of_birth)/10)  as stratum_id, cast(DATE_DIFF(cast(ppp1.payer_plan_period_end_date as date), cast(ppp1.payer_plan_period_start_date as date), DAY) as float64) as count_value  from  synpuf_100.person p1
+	inner join
 	(select  person_id, payer_plan_period_start_date, payer_plan_period_end_date, row_number() over (partition by person_id order by payer_plan_period_start_date asc) as rn1
 		  from  synpuf_100.payer_plan_period
 	) ppp1
 	on p1.person_id = ppp1.person_id
 	where ppp1.rn1 = 1
-), overallstats  as ( select  stratum_id as stratum_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
+), overallstats  as ( select  stratum_id as stratum_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata
    group by  1 ), statsview  as ( select  stratum_id as stratum_id, count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1, 2 ), priorstats  as ( select  s.stratum_id as stratum_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum_id = p.stratum_id and p.rn <= s.rn
    group by  s.stratum_id, s.count_value, s.total, s.rn
  )
-select  1407 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  1407 as analysis_id, CAST(o.stratum_id  AS STRING) as stratum_1, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum_id = o.stratum_id
  group by  o.stratum_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
@@ -2723,7 +2164,7 @@ join overallstats o on p.stratum_id = o.stratum_id
 insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
 (select  1408 as analysis_id, CAST(floor(DATE_DIFF(cast(ppp1.payer_plan_period_end_date as date), cast(ppp1.payer_plan_period_start_date as date), DAY)/30)  AS STRING) as stratum_1, COUNT(distinct p1.person_id) as count_value
   from  synpuf_100.person p1
-	inner join 
+	inner join
 	(select  person_id, payer_plan_period_start_date, payer_plan_period_end_date, row_number() over (partition by person_id order by payer_plan_period_start_date asc) as rn1
 		  from  synpuf_100.payer_plan_period
 	) ppp1
@@ -2737,15 +2178,15 @@ UNION ALL
 -- 1409	Number of persons with continuous payer plan in each year
 -- Note: using temp table instead of nested query because this gives vastly improved
 (WITH obs_pd_dates AS (
-  SELECT distinct  EXTRACT(YEAR from payer_plan_period_start_date) as obs_year 
-  FROM  
+  SELECT distinct  EXTRACT(YEAR from payer_plan_period_start_date) as obs_year
+  FROM
   synpuf_100.payer_plan_period
 ) select  1409 as analysis_id, CAST(t1.obs_year  AS STRING) as stratum_1, COUNT(distinct p1.person_id) as count_value
   from  synpuf_100.person p1
-	inner join 
+	inner join
     synpuf_100.payer_plan_period ppp1
 	on p1.person_id = ppp1.person_id
-	, obs_pd_dates  t1 
+	, obs_pd_dates  t1
 where EXTRACT(YEAR from ppp1.payer_plan_period_start_date) <= t1.obs_year
 	and EXTRACT(YEAR from ppp1.payer_plan_period_end_date) >= t1.obs_year
  group by  t1.obs_year)
@@ -2757,14 +2198,14 @@ UNION ALL
 -- Note: using temp table instead of nested query because this gives vastly improved performance in Oracle
 (WITH obs_pd_dates AS (
   SELECT distinct  EXTRACT(YEAR from payer_plan_period_start_date)*100 + EXTRACT(MONTH from payer_plan_period_start_date) as obs_month, parse_date('%Y%m%d', concat(concat(CAST(EXTRACT(YEAR from payer_plan_period_start_date)  AS STRING), SUBSTR(concat('0', CAST(EXTRACT(MONTH from payer_plan_period_start_date)  AS STRING)),-2)), '01')) as obs_month_start, DATE_ADD(cast(DATE_ADD(cast(parse_date('%Y%m%d', concat(concat(CAST(EXTRACT(YEAR from payer_plan_period_start_date)  AS STRING), SUBSTR(concat('0', CAST(EXTRACT(MONTH from payer_plan_period_start_date)  AS STRING)),-2)), '01')) as date), interval 1 MONTH) as date), interval -1 DAY) as obs_month_end
-  FROM  
+  FROM
   synpuf_100.payer_plan_period
 ) select  1410 as analysis_id, CAST(obs_month  AS STRING) as stratum_1, COUNT(distinct p1.person_id) as count_value
   from  synpuf_100.person p1
-	inner join 
+	inner join
   synpuf_100.payer_plan_period ppp1
 	on p1.person_id = ppp1.person_id
-	, obs_pd_dates 
+	, obs_pd_dates
 where ppp1.payer_plan_period_start_date <= obs_month_start
 	and ppp1.payer_plan_period_end_date >= obs_month_end
  group by  2)
@@ -2804,7 +2245,7 @@ UNION ALL
 -- 1414	Number of persons with payer plan period before year-of-birth
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  1414 as analysis_id, COUNT(distinct p1.person_id) as count_value
- from 
+ from
 	synpuf_100.person p1
 	inner join ( select  person_id, min(EXTRACT(YEAR from payer_plan_period_start_date)) as first_obs_year   from  synpuf_100.payer_plan_period  group by  1 ) ppp1
 	on p1.person_id = ppp1.person_id
@@ -2816,7 +2257,7 @@ where p1.year_of_birth > ppp1.first_obs_year
 -- 1415	Number of persons with payer plan period end < start
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  1415 as analysis_id, COUNT(ppp1.person_id) as count_value
- from 
+ from
 	synpuf_100.payer_plan_period ppp1
 where ppp1.payer_plan_period_end_date < ppp1.payer_plan_period_start_date
 ;
@@ -2844,7 +2285,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, count_value)
 -- 1701	Number of records with cohort end date < cohort start date
 insert into synpuf_100.achilles_results (analysis_id, count_value)
 select  1701 as analysis_id, COUNT(subject_id) as count_value
- from 
+ from
 	synpuf_100.cohort c1
 where c1.cohort_end_date < c1.cohort_start_date
 ;
@@ -2892,12 +2333,12 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 --
 -- 1803	Number of distinct measurement occurrence concepts per person
 insert into synpuf_100.achilles_results_dist (analysis_id, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
-WITH rawdata as (select  num_measurements  as count_value  from  (
+WITH rawdata as (select  cast(num_measurements as float64) as count_value  from  (
   	 select  m.person_id, COUNT(distinct m.measurement_concept_id) as num_measurements
   	  from  synpuf_100.measurement m
   	 group by  m.person_id
 	 ) t0
-), overallstats  as (select  cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
+), overallstats  as (select  avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total  from  rawdata
 ), statsview  as ( select  count_value as count_value, COUNT(*)  as total, row_number() over (order by count_value)  as rn   from  rawdata
    group by  1 ), priorstats  as ( select  s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on p.rn <= s.rn
@@ -2936,7 +2377,7 @@ insert into synpuf_100.achilles_results (analysis_id, stratum_1, stratum_2, coun
 -- 1806	Distribution of age by measurement_concept_id
 insert into synpuf_100.achilles_results_dist (analysis_id, stratum_1, stratum_2, count_value, min_value, max_value, avg_value, stdev_value, median_value, p10_value, p25_value, p75_value, p90_value)
 WITH rawdata_1806 AS
-(SELECT o1.measurement_concept_id as subject_id, p1.gender_concept_id, o1.measurement_start_year - p1.year_of_birth as count_value
+(SELECT o1.measurement_concept_id as subject_id, p1.gender_concept_id, cast(o1.measurement_start_year - p1.year_of_birth as float64) as count_value
   FROM  synpuf_100.person p1
 inner join
 (
@@ -2944,15 +2385,15 @@ inner join
 	  from  synpuf_100.measurement
 	 group by  1, 2 ) o1
 on p1.person_id = o1.person_id),
-overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1806
+overallstats  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1806
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, gender_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, gender_concept_id order by count_value)  as rn   from  rawdata_1806
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  1806 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  1806 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -3013,7 +2454,7 @@ UNION ALL
 --
 -- 1814	Number of measurement records with no value (numeric or concept)
 select  1814 as analysis_id, COUNT(m.person_id) as count_value
- from 
+ from
 	synpuf_100.measurement m
 where m.value_as_number is null
 	and m.value_as_concept_id is null
@@ -3028,15 +2469,15 @@ WITH rawdata_1815 AS
   FROM  synpuf_100.measurement m
 where m.unit_concept_id is not null
 	and m.value_as_number is not null),
-overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1815
+overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1815
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, unit_concept_id order by count_value)  as rn   from  rawdata_1815
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  1815 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  1815 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -3052,15 +2493,15 @@ where m.unit_concept_id is not null
 	and m.value_as_number is not null
 	and m.range_low is not null
 	and m.range_high is not null),
-overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1816
+overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1816
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, unit_concept_id order by count_value)  as rn   from  rawdata_1816
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  1816 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  1816 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
-join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
+join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value
  ;
 --
@@ -3076,13 +2517,13 @@ where m.unit_concept_id is not null
 	and m.value_as_number is not null
 	and m.range_low is not null
 	and m.range_high is not null),
-overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, cast(avg(1.0 * count_value)  as float64)  as avg_value, cast(STDDEV(count_value)  as float64)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1817
+overallstats  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, avg(count_value) as avg_value, STDDEV(count_value)  as stdev_value, min(count_value)  as min_value, max(count_value)  as max_value, COUNT(*)  as total   from  rawdata_1817
 	 group by  1, 2 ), statsview  as ( select  subject_id  as stratum1_id, unit_concept_id  as stratum2_id, count_value as count_value, COUNT(*)  as total, row_number() over (partition by subject_id, unit_concept_id order by count_value)  as rn   from  rawdata_1817
    group by  1, 2, 3 ), priorstats  as ( select  s.stratum1_id as stratum1_id, s.stratum2_id as stratum2_id, s.count_value as count_value, s.total as total, sum(p.total)  as accumulated   from  statsview s
   join statsview p on s.stratum1_id = p.stratum1_id and s.stratum2_id = p.stratum2_id and p.rn <= s.rn
    group by  s.stratum1_id, s.stratum2_id, s.count_value, s.total, s.rn
  )
-select  1817 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum1_id, CAST(o.stratum2_id  AS STRING) as stratum2_id, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
+select  1817 as analysis_id, CAST(o.stratum1_id  AS STRING) as stratum_1, CAST(o.stratum2_id  AS STRING) as stratum_2, o.total as count_value, o.min_value, o.max_value, o.avg_value, o.stdev_value, min(case when p.accumulated >= .50 * o.total then count_value else o.max_value end) as median_value, min(case when p.accumulated >= .10 * o.total then count_value else o.max_value end) as p10_value, min(case when p.accumulated >= .25 * o.total then count_value else o.max_value end) as p25_value, min(case when p.accumulated >= .75 * o.total then count_value else o.max_value end) as p75_value, min(case when p.accumulated >= .90 * o.total then count_value else o.max_value end) as p90_value
   FROM  priorstats p
 join overallstats o on p.stratum1_id = o.stratum1_id and p.stratum2_id = o.stratum2_id 
  group by  o.stratum1_id, o.stratum2_id, o.total, o.min_value, o.max_value, o.avg_value, o.stdev_value

--- a/data_steward/resources/achilles_heel_dml.sql
+++ b/data_steward/resources/achilles_heel_dml.sql
@@ -10,7 +10,7 @@
 --optional TODO: possibly rewrite this with CASE statement to better make 705 into drug, 605 into proc ...etc
 --               in measure_id column (or make that separate sql calls for each category)
 insert into synpuf_100.achilles_results_derived (analysis_id, stratum_1, statistic_value,measure_id)
- select  null as analysis_id, stratum_2 as stratum_1, sum(count_value) as statistic_value, concat(concat('ach_', cast(analysis_id  as string) ), ':GlobalCnt' )as measure_id
+ select  null as analysis_id, stratum_2 as stratum_1, cast(sum(count_value) as float64) as statistic_value, concat(concat('ach_', cast(analysis_id  as string) ), ':GlobalCnt' )as measure_id
   from  synpuf_100.achilles_results
 where analysis_id in(1805,705,605,805,405)  group by  4, 2 ;
 
@@ -65,13 +65,13 @@ UNION ALL
 
 --age at first observation by decile
 insert into synpuf_100.achilles_results_derived (stratum_1,statistic_value,measure_id)
- select  cast(floor(cast(stratum_1  as int64)/10)  as string) as stratum_1, sum(count_value) as statistic_value, 'AgeAtFirstObsByDecile:PersonCnt' as measure_id
+ select  cast(floor(cast(stratum_1  as int64)/10)  as string) as stratum_1, cast(sum(count_value) as float64) as statistic_value, 'AgeAtFirstObsByDecile:PersonCnt' as measure_id
     from  synpuf_100.achilles_results where analysis_id = 101
  group by  1 ;
 
 --count whether all deciles from 0 to 8 are there  (has later a rule: if less the threshold, issue notification)
 insert into synpuf_100.achilles_results_derived (statistic_value,measure_id)
-select  count(*) as statistic_value, 'AgeAtFirstObsByDecile:DecileCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'AgeAtFirstObsByDecile:DecileCnt' as measure_id
  from  synpuf_100.achilles_results_derived
 where measure_id = 'AgeAtFirstObsByDecile:PersonCnt'
 and cast(stratum_1  as int64) <=8
@@ -80,69 +80,69 @@ and cast(stratum_1  as int64) <=8
 --data density measures
 
 UNION ALL
-select  count(*) as statistic_value, 'DrugExposure:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'DrugExposure:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 701
 
 UNION ALL
-select  count(*) as statistic_value, 'DrugEra:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'DrugEra:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 901
 
 UNION ALL
-select  count(*) as statistic_value, 'Condition:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Condition:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 401
 
 UNION ALL
-select  count(*) as statistic_value, 'Procedure:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Procedure:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 601
 
 UNION ALL
-select  count(*) as statistic_value, 'Observation:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Observation:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 801
 
 UNION ALL
-select  count(*) as statistic_value, 'Measurement:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Measurement:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 1801
 
 UNION ALL
-select  count(*) as statistic_value, 'Visit:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Visit:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 201
 
 UNION ALL
-select  count(*) as statistic_value, 'Death:DeathType:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Death:DeathType:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 505
 
 UNION ALL
-select  count(*) as statistic_value, 'Death:DeathCause:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Death:DeathCause:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 501
 
 UNION ALL
-select  count(*) as statistic_value, 'Person:Race:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Person:Race:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 4
 
 UNION ALL
-select  count(*) as statistic_value, 'Person:Ethnicity:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Person:Ethnicity:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 5
 
 
 UNION ALL
-select  count(*) as statistic_value, 'Device:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Device:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 2101
 
 UNION ALL
-select  count(*) as statistic_value, 'Note:ConceptCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Note:ConceptCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 2201;
 
 --unmapped data (concept_0) derived measures (focusing on source values)
 
 insert into synpuf_100.achilles_results_derived (stratum_1,statistic_value,measure_id)
- select  stratum_1, count(*) as statistic_value, 'UnmappedDataByDomain:SourceValueCnt' as measure_id
+ select  stratum_1, cast(count(*) as float64) as statistic_value, 'UnmappedDataByDomain:SourceValueCnt' as measure_id
   from  synpuf_100.achilles_results where analysis_id = 1900  group by  1 ;
 
 
 --count of specialties in the provider table
 --(subsequent rule can check if this count is > trehshold) (general population dataset only))
 insert into synpuf_100.achilles_results_derived (statistic_value,measure_id)
-select  count(*) as statistic_value, 'Provider:SpeciatlyCnt' as measure_id
+select  cast(count(*) as float64) as statistic_value, 'Provider:SpeciatlyCnt' as measure_id
  from  synpuf_100.achilles_results where analysis_id = 301;
 
 
@@ -152,7 +152,7 @@ select  count(*) as statistic_value, 'Provider:SpeciatlyCnt' as measure_id
 
 
 insert into synpuf_100.achilles_results_derived (stratum_1,statistic_value,measure_id)
-select  decade as stratum_1, temp_cnt as statistic_value, 'Death:byDecade:SafePatientCnt' as measure_id
+select  decade as stratum_1, cast(temp_cnt as float64) as statistic_value, 'Death:byDecade:SafePatientCnt' as measure_id
  from
    ( select  SUBSTR(stratum_1,0,3) as decade, sum(count_value) as temp_cnt   from  synpuf_100.achilles_results where analysis_id = 504   group by  1 )a
 where temp_cnt >= 11
@@ -160,7 +160,7 @@ where temp_cnt >= 11
 
 UNION ALL
 -- insert into synpuf_100.achilles_results_derived (stratum_1,statistic_value,measure_id)
-select  stratum_1, temp_cnt as statistic_value, 'Death:byYear:SafePatientCnt' as measure_id
+select  stratum_1, cast(temp_cnt as float64) as statistic_value, 'Death:byYear:SafePatientCnt' as measure_id
  from
    ( select  stratum_1, sum(count_value) as temp_cnt   from  synpuf_100.achilles_results where analysis_id = 504   group by  1 )a
 where temp_cnt >= 11;
@@ -182,7 +182,7 @@ where a.person_cnt >= 11;
 
 --size of Achilles Metadata
 insert into synpuf_100.achilles_results_derived (stratum_1,statistic_value,measure_id)
- select  cast(analysis_id as string) as stratum_1, COUNT(*) as statistic_value, 'Achilles:byAnalysis:RowCnt' as measure_id
+ select  cast(analysis_id as string) as stratum_1, cast(count(*) as float64) as statistic_value, 'Achilles:byAnalysis:RowCnt' as measure_id
   from  synpuf_100.achilles_results  group by  1 
 --;
 
@@ -225,7 +225,7 @@ insert into synpuf_100.achilles_heel_results (
 	rule_id,
 	record_count
 	)
-select distinct  or1.analysis_id, concat(concat(concat(concat(concat(concat('ERROR: ' , cast(or1.analysis_id  as string) ), '-' ), oa1.analysis_name ), '; count (n=' ), cast(or1.count_value  as string) ), ') should not be > 0' )as achilles_heel_warning, 1 as rule_id, or1.count_value
+select distinct  or1.analysis_id, concat(concat(concat(concat(concat(concat('ERROR: ' , cast(or1.analysis_id  as string) ), '-' ), oa1.analysis_name ), '; count (n=' ), cast(or1.count_value  as string) ), ') should not be > 0' )as achilles_heel_warning, 1 as rule_id, or1.count_value as record_count
  from  synpuf_100.achilles_results or1
 inner join synpuf_100.achilles_analysis oa1
 	on or1.analysis_id = oa1.analysis_id
@@ -1145,7 +1145,7 @@ insert into synpuf_100.achilles_heel_results (
 	rule_id,
 	record_count
 	)
-select distinct  or1.analysis_id, concat(concat(concat(concat(concat(concat('NOTIFICATION: ' , cast(or1.analysis_id  as string) ), '-' ), oa1.analysis_name ), '; count (n=' ), cast(or1.count_value  as string) ), ') should not be > 0' )as achilles_heel_warning, 1 as rule_id, or1.count_value
+select distinct  or1.analysis_id, concat(concat(concat(concat(concat(concat('NOTIFICATION: ' , cast(or1.analysis_id  as string) ), '-' ), oa1.analysis_name ), '; count (n=' ), cast(or1.count_value  as string) ), ') should not be > 0' )as achilles_heel_warning, 1 as rule_id, or1.count_value as record_count
  from  synpuf_100.achilles_results or1
 inner join synpuf_100.achilles_analysis oa1
 	on or1.analysis_id = oa1.analysis_id

--- a/data_steward/test/unit_test/achilles_heel_test.py
+++ b/data_steward/test/unit_test/achilles_heel_test.py
@@ -136,5 +136,5 @@ class AchillesHeelTest(unittest.TestCase):
         self.assertEqual(r, 'pitt_temple_achilles_results')
 
     def tearDown(self):
-        # test_util.delete_all_tables(bq_utils.get_dataset_id())
+        test_util.delete_all_tables(bq_utils.get_dataset_id())
         test_util.empty_bucket(self.hpo_bucket)

--- a/data_steward/test/unit_test/achilles_heel_test.py
+++ b/data_steward/test/unit_test/achilles_heel_test.py
@@ -144,5 +144,5 @@ class AchillesHeelTest(unittest.TestCase):
         self.assertEqual(r, 'pitt_temple_achilles_results')
 
     def tearDown(self):
-        test_util.delete_all_tables(bq_utils.get_dataset_id())
+        test_util.delete_all_tables(self.dataset)
         test_util.empty_bucket(self.hpo_bucket)

--- a/data_steward/test/unit_test/achilles_heel_test.py
+++ b/data_steward/test/unit_test/achilles_heel_test.py
@@ -1,7 +1,10 @@
 import os
 import unittest
+from random import randint
+from unittest import mock
 
 import bq_utils
+import common
 import gcs_utils
 import resources
 from test.unit_test import test_util
@@ -30,78 +33,90 @@ class AchillesHeelTest(unittest.TestCase):
         test_util.empty_bucket(self.hpo_bucket)
         test_util.delete_all_tables(bq_utils.get_dataset_id())
 
-    def _load_dataset(self):
+    def _load_dataset(self, hpo_id):
         for cdm_table in resources.CDM_TABLES:
             cdm_file_name = os.path.join(test_util.FIVE_PERSONS_PATH, cdm_table + '.csv')
             if os.path.exists(cdm_file_name):
                 test_util.write_cloud_file(self.hpo_bucket, cdm_file_name)
             else:
                 test_util.write_cloud_str(self.hpo_bucket, cdm_table + '.csv', 'dummy\n')
-            bq_utils.load_cdm_csv(FAKE_HPO_ID, cdm_table)
+            bq_utils.load_cdm_csv(hpo_id, cdm_table)
+        if not bq_utils.table_exists(common.CONCEPT):
+            bq_utils.create_standard_table(common.CONCEPT, common.CONCEPT)
 
-    def test_heel_analyses(self):
+    @staticmethod
+    def get_mock_hpo_bucket():
+        bucket_env = 'BUCKET_NAME_' + FAKE_HPO_ID.upper()
+        hpo_bucket_name = os.getenv(bucket_env)
+        if hpo_bucket_name is None:
+            raise EnvironmentError()
+        return hpo_bucket_name
+
+    @mock.patch('gcs_utils.get_hpo_bucket')
+    def test_heel_analyses(self, mock_hpo_bucket):
         # Long-running test
-        self._load_dataset()
-
-        # populate achilles first
+        mock_hpo_bucket.return_value = self.get_mock_hpo_bucket()
         test_util.get_synpuf_results_files()
-        test_util.populate_achilles(self.hpo_bucket, include_heel=False)
 
-        achilles_heel.create_tables(FAKE_HPO_ID, True)
-        achilles_heel.run_heel(hpo_id=FAKE_HPO_ID)
-        cmd = sql_wrangle.qualify_tables(
-            'SELECT COUNT(1) FROM %sachilles_heel_results' % sql_wrangle.PREFIX_PLACEHOLDER, FAKE_HPO_ID)
-        result = bq_utils.query(cmd)
-        self.assertEqual(ACHILLES_HEEL_RESULTS_COUNT, int(result['rows'][0]['f'][0]['v']))
-        cmd = sql_wrangle.qualify_tables(
-            'SELECT COUNT(1) FROM %sachilles_results_derived' % sql_wrangle.PREFIX_PLACEHOLDER, FAKE_HPO_ID)
-        result = bq_utils.query(cmd)
-        self.assertEqual(ACHILLES_RESULTS_DERIVED_COUNT, int(result['rows'][0]['f'][0]['v']))
+        random_string = str(randint(10000, 99999))
+        randomized_hpo_id = FAKE_HPO_ID + '_' + random_string
+
+        self._load_dataset(randomized_hpo_id)
+        test_util.populate_achilles(self.hpo_bucket, hpo_id=randomized_hpo_id, include_heel=False)
+
+        achilles_heel_results = randomized_hpo_id + '_' + achilles_heel.ACHILLES_HEEL_RESULTS
+        achilles_results_derived = randomized_hpo_id + '_' + achilles_heel.ACHILLES_RESULTS_DERIVED
+
+        achilles_heel.create_tables(randomized_hpo_id, True)
+        achilles_heel.run_heel(hpo_id=randomized_hpo_id)
+        query = sql_wrangle.qualify_tables(
+            'SELECT COUNT(1) as num_rows FROM %s' % achilles_heel_results)
+        response = bq_utils.query(query)
+        rows = bq_utils.response2rows(response)
+        self.assertEqual(ACHILLES_HEEL_RESULTS_COUNT, rows[0]['num_rows'])
+        query = sql_wrangle.qualify_tables(
+            'SELECT COUNT(1) as num_rows FROM %s' % achilles_results_derived)
+        response = bq_utils.query(query)
+        rows = bq_utils.response2rows(response)
+        self.assertEqual(ACHILLES_RESULTS_DERIVED_COUNT, rows[0]['num_rows'])
 
         # test new heel re-categorization
         errors = [2, 4, 5, 101, 200, 206, 207, 209, 400, 405, 406, 409, 411, 413, 500, 505, 506, 509,
                   600, 605, 606, 609, 613, 700, 705, 706, 709, 711, 713, 715, 716, 717, 800, 805, 806,
                   809, 813, 814, 906, 1006, 1609, 1805]
-        cmd = sql_wrangle.qualify_tables(
-            """SELECT analysis_id FROM {prefix}achilles_heel_results
-            WHERE achilles_heel_warning like 'ERROR:%'
-            GROUP BY analysis_id""".format(prefix=sql_wrangle.PREFIX_PLACEHOLDER),
-            FAKE_HPO_ID)
-        result = bq_utils.query(cmd)
-        # self.assertIsNone(result.get('analysis_id', None))
-        actual_result = [int(row['f'][0]['v']) for row in result['rows']]
+        query = sql_wrangle.qualify_tables(
+            """SELECT analysis_id FROM %s
+            WHERE achilles_heel_warning LIKE 'ERROR:%'
+            GROUP BY analysis_id""" % achilles_heel_results)
+        response = bq_utils.query(query)
+        rows = bq_utils.response2rows(response)
+        actual_result = [row["analysis_id"] for row in rows]
         for analysis_id in actual_result:
             self.assertIn(analysis_id, errors)
-        # self.assertEqual(ACHILLES_HEEL_RESULTS_ERROR_COUNT, int(result['rows'][0]['f'][0]['v']))
 
-        warnings = [4, 5, 7, 8, 9, 200, 210, 302, 400, 402, 412, 420,
-                    500, 511, 512, 513, 514, 515,
+        warnings = [4, 5, 7, 8, 9, 200, 210, 302, 400, 402, 412, 420, 500, 511, 512, 513, 514, 515,
                     602, 612, 620, 702, 712, 720, 802, 812, 820]
-        cmd = sql_wrangle.qualify_tables(
-            """SELECT analysis_id FROM {prefix}achilles_heel_results
-            WHERE achilles_heel_warning like 'WARNING:%'
-            GROUP BY analysis_id""".format(prefix=sql_wrangle.PREFIX_PLACEHOLDER),
-            FAKE_HPO_ID)
-        result = bq_utils.query(cmd)
-        # self.assertIsNone(result.get('analysis_id', None))
-        actual_result = [int(row['f'][0]['v']) for row in result['rows']]
+        query = sql_wrangle.qualify_tables(
+            """SELECT analysis_id FROM %s
+            WHERE achilles_heel_warning LIKE 'WARNING:%'
+            GROUP BY analysis_id""" % achilles_heel_results)
+        response = bq_utils.query(query)
+        rows = bq_utils.response2rows(response)
+        actual_result = [row["analysis_id"] for row in rows]
         for analysis_id in actual_result:
             self.assertIn(analysis_id, warnings)
-        # self.assertEqual(ACHILLES_HEEL_RESULTS_WARNING_COUNT, int(result['rows'][0]['f'][0]['v']))
 
         notifications = [101, 103, 105, 114, 115, 118, 208, 301, 410, 610,
                          710, 810, 900, 907, 1000, 1800, 1807]
-        cmd = sql_wrangle.qualify_tables(
-            """SELECT analysis_id FROM {prefix}achilles_heel_results
-            WHERE achilles_heel_warning like 'NOTIFICATION:%' and analysis_id is not null
-            GROUP BY analysis_id""".format(prefix=sql_wrangle.PREFIX_PLACEHOLDER),
-            FAKE_HPO_ID)
-        result = bq_utils.query(cmd)
-        self.assertIsNone(result.get('analysis_id', None))
-        actual_result = [int(row['f'][0]['v']) for row in result['rows']]
+        query = sql_wrangle.qualify_tables(
+            """SELECT analysis_id FROM %s
+            WHERE achilles_heel_warning LIKE 'NOTIFICATION:%' and analysis_id is not null
+            GROUP BY analysis_id""" % achilles_heel_results)
+        response = bq_utils.query(query)
+        rows = bq_utils.response2rows(response)
+        actual_result = [row["analysis_id"] for row in rows]
         for analysis_id in actual_result:
             self.assertIn(analysis_id, notifications)
-        # self.assertEqual(ACHILLES_HEEL_RESULTS_NOTIFICATION_COUNT, int(result['rows'][0]['f'][0]['v']))
 
     def test_qualify_tables(self):
         r = sql_wrangle.qualify_tables('temp.some_table', hpo_id='fake')
@@ -117,5 +132,5 @@ class AchillesHeelTest(unittest.TestCase):
         self.assertEqual(r, 'pitt_temple_achilles_results')
 
     def tearDown(self):
-        test_util.delete_all_tables(bq_utils.get_dataset_id())
+        # test_util.delete_all_tables(bq_utils.get_dataset_id())
         test_util.empty_bucket(self.hpo_bucket)

--- a/data_steward/test/unit_test/achilles_test.py
+++ b/data_steward/test/unit_test/achilles_test.py
@@ -1,9 +1,7 @@
-import datetime
 import os
-import re
 import unittest
-
-import mock
+from random import randint
+from unittest import mock
 
 import bq_utils
 import gcs_utils
@@ -65,12 +63,6 @@ class AchillesTest(unittest.TestCase):
         test_util.empty_bucket(self.hpo_bucket)
         test_util.delete_all_tables(bq_utils.get_dataset_id())
 
-    @staticmethod
-    def _get_timestamp_nums():
-        timestamp = str(datetime.datetime.now().time()).split('.')[0]
-        time_nums = re.sub('\D', '', timestamp)
-        return time_nums
-
     def _load_dataset(self, hpo_id):
         for cdm_table in resources.CDM_TABLES:
             cdm_file_name = os.path.join(test_util.FIVE_PERSONS_PATH, cdm_table + '.csv')
@@ -125,13 +117,13 @@ class AchillesTest(unittest.TestCase):
     def test_run_analyses(self, mock_hpo_bucket):
         # Long-running test
         mock_hpo_bucket.return_value = self.get_mock_hpo_bucket()
-        timestamp_nums = self._get_timestamp_nums()
-        timestamped_hpo_id = FAKE_HPO_ID + '_' + timestamp_nums
-        self._load_dataset(timestamped_hpo_id)
-        achilles.create_tables(timestamped_hpo_id, True)
-        achilles.load_analyses(timestamped_hpo_id)
-        achilles.run_analyses(hpo_id=timestamped_hpo_id)
-        achilles_results_table = timestamped_hpo_id + '_' + achilles.ACHILLES_RESULTS
+        random_string = str(randint(10000, 99999))
+        randomized_hpo_id = FAKE_HPO_ID + '_' + random_string
+        self._load_dataset(randomized_hpo_id)
+        achilles.create_tables(randomized_hpo_id, True)
+        achilles.load_analyses(randomized_hpo_id)
+        achilles.run_analyses(hpo_id=randomized_hpo_id)
+        achilles_results_table = randomized_hpo_id + '_' + achilles.ACHILLES_RESULTS
         cmd = sql_wrangle.qualify_tables(
             'SELECT COUNT(1) as num_rows FROM %s' % achilles_results_table)
         response = bq_utils.query(cmd)

--- a/data_steward/test/unit_test/achilles_test.py
+++ b/data_steward/test/unit_test/achilles_test.py
@@ -60,8 +60,9 @@ class AchillesTest(unittest.TestCase):
 
     def setUp(self):
         self.hpo_bucket = gcs_utils.get_hpo_bucket(test_util.FAKE_HPO_ID)
+        self.dataset = bq_utils.get_dataset_id()
         test_util.empty_bucket(self.hpo_bucket)
-        test_util.delete_all_tables(bq_utils.get_dataset_id())
+        test_util.delete_all_tables(self.dataset)
 
     def _load_dataset(self, hpo_id):
         for cdm_table in resources.CDM_TABLES:
@@ -92,8 +93,7 @@ class AchillesTest(unittest.TestCase):
 
     def test_get_run_analysis_commands(self):
         cmd_iter = achilles._get_run_analysis_commands(FAKE_HPO_ID)
-        commands = [achilles.convert_insert_to_append(command)[0] for command in cmd_iter]
-        self.assertEqual(len(commands), ACHILLES_ANALYSIS_COUNT)
+        self.assertEqual(len(cmd_iter), ACHILLES_ANALYSIS_COUNT)
 
     def test_temp_table(self):
         self.assertTrue(sql_wrangle.is_to_temp_table(TEMP_QUERY_1))
@@ -143,5 +143,5 @@ class AchillesTest(unittest.TestCase):
             self.assertFalse(is_temp)
 
     def tearDown(self):
-        test_util.delete_all_tables(bq_utils.get_dataset_id())
+        test_util.delete_all_tables(self.dataset)
         test_util.empty_bucket(self.hpo_bucket)

--- a/data_steward/test/unit_test/achilles_test.py
+++ b/data_steward/test/unit_test/achilles_test.py
@@ -117,12 +117,18 @@ class AchillesTest(unittest.TestCase):
     def test_run_analyses(self, mock_hpo_bucket):
         # Long-running test
         mock_hpo_bucket.return_value = self.get_mock_hpo_bucket()
+
+        # create randomized tables to bypass BQ rate limits
         random_string = str(randint(10000, 99999))
         randomized_hpo_id = FAKE_HPO_ID + '_' + random_string
+
+        # prepare and run achilles
         self._load_dataset(randomized_hpo_id)
         achilles.create_tables(randomized_hpo_id, True)
         achilles.load_analyses(randomized_hpo_id)
         achilles.run_analyses(hpo_id=randomized_hpo_id)
+
+        # validate results
         achilles_results_table = randomized_hpo_id + '_' + achilles.ACHILLES_RESULTS
         cmd = sql_wrangle.qualify_tables(
             'SELECT COUNT(1) as num_rows FROM %s' % achilles_results_table)

--- a/data_steward/validation/achilles.py
+++ b/data_steward/validation/achilles.py
@@ -88,7 +88,7 @@ def run_analysis_job(command):
     job_id = job_result['jobReference']['jobId']
     incomplete_jobs = bq_utils.wait_on_jobs([job_id])
     if len(incomplete_jobs) > 0:
-        logging.info('Job id %s taking more than 15 secs' % job_id)
+        logging.info('Job id %s taking too long' % job_id)
         raise RuntimeError('Job id %s taking too long' % job_id)
 
 

--- a/data_steward/validation/achilles.py
+++ b/data_steward/validation/achilles.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import os
 
+import app_identity
 import bq_utils
 import resources
 from validation import sql_wrangle
@@ -11,28 +13,13 @@ ACHILLES_RESULTS = 'achilles_results'
 ACHILLES_RESULTS_DIST = 'achilles_results_dist'
 ACHILLES_TABLES = [ACHILLES_ANALYSIS, ACHILLES_RESULTS, ACHILLES_RESULTS_DIST]
 ACHILLES_DML_SQL_PATH = os.path.join(resources.resource_path, 'achilles_dml.sql')
-END_OF_IMPORTING_LOOKUP_MARKER = 'end of importing values into analysis lookup'
 INSERT_INTO = 'insert into'
-
-
-def _get_load_analysis_commands(hpo_id):
-    raw_commands = sql_wrangle.get_commands(ACHILLES_DML_SQL_PATH)
-    commands = [sql_wrangle.qualify_tables(cmd, hpo_id) for cmd in raw_commands]
-    for command in commands:
-        if END_OF_IMPORTING_LOOKUP_MARKER in command.lower():
-            break
-        yield command
 
 
 def _get_run_analysis_commands(hpo_id):
     raw_commands = sql_wrangle.get_commands(ACHILLES_DML_SQL_PATH)
     commands = [sql_wrangle.qualify_tables(cmd, hpo_id) for cmd in raw_commands]
-    i = 0
-    for command in commands:
-        if END_OF_IMPORTING_LOOKUP_MARKER in command.lower():
-            break
-        i += 1
-    return commands[i:]
+    return commands
 
 
 def load_analyses(hpo_id):
@@ -41,22 +28,68 @@ def load_analyses(hpo_id):
     :param hpo_id:
     :return:
     """
-    commands = _get_load_analysis_commands(hpo_id)
-    for command in commands:
-        bq_utils.query(command)
+    project_id = app_identity.get_application_id()
+    dataset_id = bq_utils.get_dataset_id()
+    if hpo_id is None:
+        table_prefix = ""
+    else:
+        table_prefix = hpo_id + '_'
+    table_name = table_prefix + ACHILLES_ANALYSIS
+    csv_path = os.path.join(resources.resource_path, ACHILLES_ANALYSIS + '.csv')
+    json_path = os.path.join(resources.fields_path, ACHILLES_ANALYSIS + '.json')
+    with open(json_path, 'r') as f:
+        schema = json.load(f)
+    bq_utils.load_table_from_csv(project_id, dataset_id, table_name, csv_path, schema)
 
 
-def convert_insert_to_append(command):
-    select_command_lines = []
+def extract_table_id_from_query(command):
     table_id = None
     for line in command.split('\n'):
         if line.strip().lower().startswith(INSERT_INTO):
             words = line.strip().split()
             table_id = words[2]
-        else:
+    if not table_id:
+        raise RuntimeError('Table does not exist for insert query %s' % command)
+    return table_id
+
+
+def convert_insert_to_append(command):
+    select_command_lines = []
+    for line in command.split('\n'):
+        if not line.strip().lower().startswith(INSERT_INTO):
             select_command_lines.append(line)
     select_command = '\n'.join(select_command_lines)
-    return select_command, table_id
+    return select_command
+
+
+def drop_or_truncate_table(command):
+    if sql_wrangle.is_truncate(command):
+        table_id = sql_wrangle.get_truncate_table_name(command)
+    else:
+        table_id = sql_wrangle.get_drop_table_name(command)
+    if bq_utils.table_exists(table_id):
+        bq_utils.delete_table(table_id)
+
+
+def run_analysis_job(command):
+    if sql_wrangle.is_to_temp_table(command):
+        logging.info('Running achilles temp query %s' % command)
+        table_id = sql_wrangle.get_temp_table_name(command)
+        query = sql_wrangle.get_temp_table_query(command)
+        job_result = bq_utils.query(query,
+                                    destination_table_id=table_id)
+    else:
+        query = convert_insert_to_append(command)
+        table_id = extract_table_id_from_query(command)
+        logging.info('Running achilles load query %s' % command)
+        job_result = bq_utils.query(query,
+                                    destination_table_id=table_id,
+                                    write_disposition=bq_consts.WRITE_APPEND)
+    job_id = job_result['jobReference']['jobId']
+    incomplete_jobs = bq_utils.wait_on_jobs([job_id])
+    if len(incomplete_jobs) > 0:
+        logging.info('Job id %s taking more than 15 secs' % job_id)
+        raise RuntimeError('Job id %s taking too long' % job_id)
 
 
 def run_analyses(hpo_id):
@@ -65,42 +98,12 @@ def run_analyses(hpo_id):
     :param hpo_id:
     :return:
     """
-    job_ids = []
     commands = _get_run_analysis_commands(hpo_id)
     for command in commands:
-        logging.info(' ---- Running `%s`...\n' % command)
-        if sql_wrangle.is_to_temp_table(command):
-            table_id = sql_wrangle.get_temp_table_name(command)
-            query = sql_wrangle.get_temp_table_query(command)
-            insert_query_job_result = bq_utils.query(query, False, table_id)
-            query_job_id = insert_query_job_result['jobReference']['jobId']
-
-            incomplete_jobs = bq_utils.wait_on_jobs([query_job_id])
-            if len(incomplete_jobs) > 0:
-                logging.critical('tempresults doesnt get created in 15 secs')
-                raise RuntimeError('Tempresults taking too long to create')
-        elif sql_wrangle.is_truncate(command):
-            table_id = sql_wrangle.get_truncate_table_name(command)
-            if bq_utils.table_exists(table_id):
-                bq_utils.delete_table(table_id)
-        elif sql_wrangle.is_drop(command):
-            table_id = sql_wrangle.get_drop_table_name(command)
-            if bq_utils.table_exists(table_id):
-                bq_utils.delete_table(table_id)
+        if sql_wrangle.is_truncate(command) or sql_wrangle.is_drop(command):
+            drop_or_truncate_table(command)
         else:
-            append_command, table_id = convert_insert_to_append(command)
-            if table_id:
-                job_result = bq_utils.query(append_command,
-                                            destination_table_id=table_id,
-                                            write_disposition=bq_consts.WRITE_APPEND)
-            else:
-                logging.info('Query without table is %s' % append_command)
-                job_result = bq_utils.query(append_command)
-            job_ids.append(job_result['jobReference']['jobId'])
-
-    incomplete_jobs = bq_utils.wait_on_jobs(job_ids)
-    if len(incomplete_jobs) > 0:
-        raise RuntimeError('Jobs taking too long')
+            run_analysis_job(command)
 
 
 def create_tables(hpo_id, drop_existing=False):

--- a/data_steward/validation/achilles_heel.py
+++ b/data_steward/validation/achilles_heel.py
@@ -67,6 +67,11 @@ def load_heel(hpo_id):
 
 
 def drop_or_truncate_table(command):
+    """
+    Deletes or truncates table
+    :param command: query to run
+    :return: None
+    """
     if sql_wrangle.is_truncate(command):
         table_id = sql_wrangle.get_truncate_table_name(command)
         query = 'DELETE FROM %s WHERE TRUE' % table_id
@@ -77,6 +82,12 @@ def drop_or_truncate_table(command):
 
 
 def extract_table_id_from_heel_query(command):
+    """
+    Returns table_id from an insert query
+    :param command: insert query formatted without newlines and comments
+    :return table_id: Table the query inserts to
+    :raises RuntimeError: Raised if table_id does not exist in the query
+    """
     table_id = None
     if command.strip().lower().startswith(achilles.INSERT_INTO):
         words = command.strip().split()
@@ -87,6 +98,12 @@ def extract_table_id_from_heel_query(command):
 
 
 def convert_heel_insert_to_append(command):
+    """
+    Convert a command formatted as "insert into" to "select"
+    :param command: insert query without any newlines or comments
+    :return ignore_insert_command: command without "insert into", table_id and column headers enclosed in brackets
+    :raises RuntimeError: Raised if query does not start with "insert into"
+    """
     if not command.strip().lower().startswith(achilles.INSERT_INTO):
         raise RuntimeError('Query does not start with "insert into": %s' % command)
     ignore_insert_command = command.split(')', 1)[1]
@@ -94,6 +111,11 @@ def convert_heel_insert_to_append(command):
 
 
 def run_heel_analysis_job(command):
+    """
+    Runs command (query) and waits for job completion
+    :param command: query to run
+    :return: None
+    """
     if sql_wrangle.is_to_temp_table(command):
         logging.info('Running achilles heel temp query %s' % command)
         table_id = sql_wrangle.get_temp_table_name(command)
@@ -120,10 +142,7 @@ def run_heel(hpo_id):
 
     :param hpo_id:  string name for the hpo identifier
     :returns: None
-    :raises RuntimeError: Raised if BigQuery takes longer than 30 seconds
-        to complete a job on a temporary table
     """
-    # very long test
     commands = _get_heel_commands(hpo_id)
     for command in commands:
         if sql_wrangle.is_truncate(command) or sql_wrangle.is_drop(command):


### PR DESCRIPTION
Creates randomized tables so that achilles tests do not hit rate limits.
Also makes the following improvements:
- Initialize table achilles_analysis by loading from csv instead of bq VALUES
- Update queries in `achilles_dml.sql` and `achilles_heel_dml.sql` so that the output fields conform to table fields (name and type)
- Use `select *` instead of bq `insert into`, which still count towards the table load quota, but highlights issues which could hit table schema/metadata update quota. (This is probably the limit we keep hitting, which is 5 updates every 10 seconds)