### PR TITLE
[DC-619] Update person table repopulation to address missing race responses

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid.py
@@ -28,73 +28,134 @@ import constants.cdr_cleaner.clean_cdr as cdr_consts
 PERSON_TABLE = 'person'
 
 REPOPULATE_PERSON_QUERY = """
-select DISTINCT * from (SELECT
-  per.person_id,
-  case ob.value_source_concept_id
-    when 1585846 then 8507 --male
-    when 1585847 then 8532 --female
-    else 2000000009 --generalized
-    end  AS gender_concept_id,
-  EXTRACT(YEAR from birth_datetime) as year_of_birth,
-  EXTRACT(MONTH from birth_datetime) as month_of_birth,
-  EXTRACT(DAY from birth_datetime) as day_of_birth,
+WITH
+  repopulate_person_from_observation AS (
+  SELECT
+    DISTINCT *
+  FROM (
+    SELECT
+      per.person_id,
+      CASE ob.value_source_concept_id
+        WHEN 1585846 THEN 8507 --male
+        WHEN 1585847 THEN 8532 --female
+      ELSE
+      2000000009 --generalized
+    END
+      AS gender_concept_id,
+      EXTRACT(YEAR
+      FROM
+        birth_datetime) AS year_of_birth,
+      EXTRACT(MONTH
+      FROM
+        birth_datetime) AS month_of_birth,
+      EXTRACT(DAY
+      FROM
+        birth_datetime) AS day_of_birth,
+      birth_datetime,
+      --Case statement to get proper race domain matches
+      CASE ob2.value_source_concept_id
+        WHEN 1586142 THEN 8515 --asian
+        WHEN 1586143 THEN 8516 --black/aa
+        WHEN 1586146 THEN 8527 --white
+      --otherwise, just use the standard mapped answer (or 0)
+      ELSE
+      coalesce(ob2.value_as_concept_id,
+        0)
+    END
+      AS race_concept_id,
+      --Hardcode to the standard non-hispanic or hispanic code as applicable.
+    IF
+      (ob3.value_as_concept_id IS NULL,
+        --Case this out based on the ob2 (race) values, ie if it's a skip/pna respect that.
+        CASE ob2.value_source_concept_id
+          WHEN 0 THEN 0 --missing answer
+          WHEN NULL THEN 0 --missing answer
+          WHEN 903079 THEN 903079 --PNA
+          WHEN 903096 THEN 903096 --Skip
+          WHEN 1586148 THEN 1586148 --None of these
+        --otherwise, it's non-hispanic
+        ELSE
+        38003564
+      END
+        --Assign HLS if it's present
+        ,
+        38003563) AS ethnicity_concept_id,
+      location_id,
+      per.provider_id,
+      care_site_id,
+      CAST(per.person_id AS STRING) AS person_source_value,
+      coalesce(ob.value_source_value,
+        "No matching concept") AS gender_source_value,
+      coalesce(ob.value_source_concept_id,
+        0) AS gender_source_concept_id,
+      coalesce(ob2.value_source_value,
+        "No matching concept") AS race_source_value,
+      coalesce(ob2.value_source_concept_id,
+        0) AS race_source_concept_id,
+      coalesce(ob3.value_source_value,
+        --fill in the skip/pna/none of these if needed
+      IF
+        (ob2.value_source_concept_id IN (903079,
+            903096,
+            1586148),
+          ob2.value_source_value,
+          NULL)
+        --otherwise it is no matching
+        ,
+        "No matching concept") AS ethnicity_source_value,
+      coalesce(ob3.value_source_concept_id,
+        0) AS ethnicity_source_concept_id
+    FROM
+      `{project}.{dataset}.person` AS per
+    LEFT JOIN
+      `{project}.{dataset}.observation` ob
+    ON
+      per.person_id = ob.person_id
+      --Updated to sex at birth, not gender
+      AND ob.observation_source_concept_id =1585845
+    LEFT JOIN
+      `{project}.{dataset}.observation` ob2
+    ON
+      per.person_id = ob2.person_id
+      AND ob2.observation_concept_id = 1586140
+      AND ob2.value_source_concept_id != 1586147
+    LEFT JOIN
+      `{project}.{dataset}.observation` ob3
+    ON
+      per.person_id = ob3.person_id
+      AND ob3.observation_concept_id=1586140
+      AND ob3.value_source_concept_id = 1586147))
+SELECT
+  person_id,
+  gender_concept_id,
+  year_of_birth,
+  month_of_birth,
+  day_of_birth,
   birth_datetime,
-  --Case statement to get proper race domain matches
-  case ob2.value_source_concept_id
-    when 1586142 then 8515 --asian
-    when 1586143 then 8516 --black/aa
-    when 1586146 then 8527 --white
-    --otherwise, just use the standard mapped answer (or 0)
-    else coalesce(ob2.value_as_concept_id, 0) 
-    end AS race_concept_id,
-  --Hardcode to the standard non-hispanic or hispanic code as applicable.
-  if(ob3.value_as_concept_id is null, 
-  --Case this out based on the ob2 (race) values, ie if it's a skip/pna respect that.
-  case ob2.value_source_concept_id
-    when 0 then 0 --missing answer
-    when null then 0 --missing answer
-    when 903079 then 903079 --PNA
-    when 903096 then 903096 --Skip
-    when 1586148 then 1586148 --None of these
-    --otherwise, it's non-hispanic
-    else 38003564
-    end
-  --Assign HLS if it's present
-  , 38003563) AS ethnicity_concept_id,
+  CASE
+    WHEN (ethnicity_concept_id = 38003563 AND race_concept_id = 0) THEN 3000000001
+  ELSE
+  race_concept_id
+END
+  AS race_concept_id,
+  ethnicity_concept_id,
   location_id,
-  per.provider_id,
+  provider_id,
   care_site_id,
-  cast(per.person_id as STRING) as person_source_value,
-  coalesce(ob.value_source_value, "No matching concept") AS gender_source_value,
-  coalesce(ob.value_source_concept_id, 0) AS gender_source_concept_id,
-  coalesce(ob2.value_source_value, "No matching concept") AS race_source_value,
-  coalesce(ob2.value_source_concept_id, 0) AS race_source_concept_id,
-  coalesce(ob3.value_source_value, 
-  --fill in the skip/pna/none of these if needed
-  if(ob2.value_source_concept_id in (903079,903096,1586148),ob2.value_source_value,null)
-  --otherwise it is no matching
-  ,"No matching concept") AS ethnicity_source_value,
-  coalesce(ob3.value_source_concept_id, 0) AS ethnicity_source_concept_id
+  person_source_value,
+  gender_source_value,
+  gender_source_concept_id,
+  CASE
+    WHEN (ethnicity_concept_id = 38003563 AND race_concept_id = 0) THEN "None Indicated"
+  ELSE
+  race_source_value
+END
+  AS race_source_value,
+  race_source_concept_id,
+  ethnicity_source_value,
+  ethnicity_source_concept_id
 FROM
-  `{project}.{dataset}.person` AS per
-LEFT JOIN
-  `{project}.{dataset}.observation` ob
-ON
-  per.person_id = ob.person_id
-  --Updated to sex at birth, not gender
-  AND ob.observation_source_concept_id =1585845
-LEFT JOIN
-  `{project}.{dataset}.observation` ob2
-ON
-  per.person_id = ob2.person_id
-  AND ob2.observation_concept_id = 1586140
-  AND ob2.value_source_concept_id != 1586147
-LEFT JOIN
-  `{project}.{dataset}.observation` ob3
-ON
-  per.person_id = ob3.person_id
-  AND ob3.observation_concept_id=1586140
-  AND ob3.value_source_concept_id = 1586147)
+  repopulate_person_from_observation
 """
 
 

--- a/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid.py
@@ -30,101 +30,76 @@ PERSON_TABLE = 'person'
 REPOPULATE_PERSON_QUERY = """
 WITH
   repopulate_person_from_observation AS (
-  SELECT
-    DISTINCT *
-  FROM (
-    SELECT
-      per.person_id,
-      CASE ob.value_source_concept_id
-        WHEN 1585846 THEN 8507 --male
-        WHEN 1585847 THEN 8532 --female
-      ELSE
-      2000000009 --generalized
-    END
-      AS gender_concept_id,
-      EXTRACT(YEAR
-      FROM
-        birth_datetime) AS year_of_birth,
-      EXTRACT(MONTH
-      FROM
-        birth_datetime) AS month_of_birth,
-      EXTRACT(DAY
-      FROM
-        birth_datetime) AS day_of_birth,
-      birth_datetime,
-      --Case statement to get proper race domain matches
-      CASE ob2.value_source_concept_id
-        WHEN 1586142 THEN 8515 --asian
-        WHEN 1586143 THEN 8516 --black/aa
-        WHEN 1586146 THEN 8527 --white
+  select DISTINCT * 
+  from 
+    (SELECT
+    per.person_id,
+    case ob.value_source_concept_id
+      when 1585846 then 8507 --male
+      when 1585847 then 8532 --female
+      else 2000000009 --generalized
+      end  AS gender_concept_id,
+    EXTRACT(YEAR from birth_datetime) as year_of_birth,
+    EXTRACT(MONTH from birth_datetime) as month_of_birth,
+    EXTRACT(DAY from birth_datetime) as day_of_birth,
+    birth_datetime,
+    --Case statement to get proper race domain matches
+    case ob2.value_source_concept_id
+      when 1586142 then 8515 --asian
+      when 1586143 then 8516 --black/aa
+      when 1586146 then 8527 --white
       --otherwise, just use the standard mapped answer (or 0)
-      ELSE
-      coalesce(ob2.value_as_concept_id,
-        0)
-    END
-      AS race_concept_id,
-      --Hardcode to the standard non-hispanic or hispanic code as applicable.
-    IF
-      (ob3.value_as_concept_id IS NULL,
-        --Case this out based on the ob2 (race) values, ie if it's a skip/pna respect that.
-        CASE ob2.value_source_concept_id
-          WHEN 0 THEN 0 --missing answer
-          WHEN NULL THEN 0 --missing answer
-          WHEN 903079 THEN 903079 --PNA
-          WHEN 903096 THEN 903096 --Skip
-          WHEN 1586148 THEN 1586148 --None of these
-        --otherwise, it's non-hispanic
-        ELSE
-        38003564
-      END
-        --Assign HLS if it's present
-        ,
-        38003563) AS ethnicity_concept_id,
-      location_id,
-      per.provider_id,
-      care_site_id,
-      CAST(per.person_id AS STRING) AS person_source_value,
-      coalesce(ob.value_source_value,
-        "No matching concept") AS gender_source_value,
-      coalesce(ob.value_source_concept_id,
-        0) AS gender_source_concept_id,
-      coalesce(ob2.value_source_value,
-        "No matching concept") AS race_source_value,
-      coalesce(ob2.value_source_concept_id,
-        0) AS race_source_concept_id,
-      coalesce(ob3.value_source_value,
-        --fill in the skip/pna/none of these if needed
-      IF
-        (ob2.value_source_concept_id IN (903079,
-            903096,
-            1586148),
-          ob2.value_source_value,
-          NULL)
-        --otherwise it is no matching
-        ,
-        "No matching concept") AS ethnicity_source_value,
-      coalesce(ob3.value_source_concept_id,
-        0) AS ethnicity_source_concept_id
-    FROM
-      `{project}.{dataset}.person` AS per
-    LEFT JOIN
-      `{project}.{dataset}.observation` ob
-    ON
-      per.person_id = ob.person_id
-      --Updated to sex at birth, not gender
-      AND ob.observation_source_concept_id =1585845
-    LEFT JOIN
-      `{project}.{dataset}.observation` ob2
-    ON
-      per.person_id = ob2.person_id
-      AND ob2.observation_concept_id = 1586140
-      AND ob2.value_source_concept_id != 1586147
-    LEFT JOIN
-      `{project}.{dataset}.observation` ob3
-    ON
-      per.person_id = ob3.person_id
-      AND ob3.observation_concept_id=1586140
-      AND ob3.value_source_concept_id = 1586147))
+      else coalesce(ob2.value_as_concept_id, 0) 
+      end AS race_concept_id,
+    --Hardcode to the standard non-hispanic or hispanic code as applicable.
+    if(ob3.value_as_concept_id is null, 
+    --Case this out based on the ob2 (race) values, ie if it's a skip/pna respect that.
+    case ob2.value_source_concept_id
+      when 0 then 0 --missing answer
+      when null then 0 --missing answer
+      when 903079 then 903079 --PNA
+      when 903096 then 903096 --Skip
+      when 1586148 then 1586148 --None of these
+      --otherwise, it's non-hispanic
+      else 38003564
+      end
+    --Assign HLS if it's present
+    , 38003563) AS ethnicity_concept_id,
+    location_id,
+    per.provider_id,
+    care_site_id,
+    cast(per.person_id as STRING) as person_source_value,
+    coalesce(ob.value_source_value, "No matching concept") AS gender_source_value,
+    coalesce(ob.value_source_concept_id, 0) AS gender_source_concept_id,
+    coalesce(ob2.value_source_value, "No matching concept") AS race_source_value,
+    coalesce(ob2.value_source_concept_id, 0) AS race_source_concept_id,
+    coalesce(ob3.value_source_value, 
+    --fill in the skip/pna/none of these if needed
+    if(ob2.value_source_concept_id in (903079,903096,1586148),ob2.value_source_value,null)
+    --otherwise it is no matching
+    ,"No matching concept") AS ethnicity_source_value,
+    coalesce(ob3.value_source_concept_id, 0) AS ethnicity_source_concept_id
+  FROM
+    `{project}.{dataset}.person` AS per
+  LEFT JOIN
+    `{project}.{dataset}.observation` ob
+  ON
+    per.person_id = ob.person_id
+    --Updated to sex at birth, not gender
+    AND ob.observation_source_concept_id =1585845
+  LEFT JOIN
+    `{project}.{dataset}.observation` ob2
+  ON
+    per.person_id = ob2.person_id
+    AND ob2.observation_concept_id = 1586140
+    AND ob2.value_source_concept_id != 1586147
+  LEFT JOIN
+    `{project}.{dataset}.observation` ob3
+  ON
+    per.person_id = ob3.person_id
+    AND ob3.observation_concept_id=1586140
+    AND ob3.value_source_concept_id = 1586147)
+    )
 SELECT
   person_id,
   gender_concept_id,


### PR DESCRIPTION
Updates race_concept_id to 3000000001 and race_source_value to "None Indicated" when a person selects  “Hispanic, Latino, or Spanish” as - ethnicity but has not selected anything else.