### PR TITLE
[DC-636] Circle cleanup: cache pip installs, don't run unit tests nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,5 +156,4 @@ workflows:
             branches:
               only: develop
     jobs:
-      - unit_test
       - integration_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,13 @@ commands:
             sudo apt-get install dpkg
             sudo apt-get install google-cloud-sdk
       # Dependencies
+      - restore_cache:
+          keys:
+          - pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
+          - pip-cache-
       - run:
           name: Add virtual environment activation to bash startup
           command: python3 -m venv ~/curation_venv && echo "source ~/curation_venv/bin/activate" >> $BASH_ENV
-      # TODO(calbach): Setup a caching step here for pip deps.
       - run:
           name: Upgrade pip and install requirements
           command: |
@@ -53,6 +56,10 @@ commands:
           command: cat ${BASH_ENV}
   test_teardown:
     steps:
+      - save_cache:
+          paths:
+            ~/curation_venv
+          key: pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
       - run:
           name: Combine Coverage Results
           working_directory: ~/curation


### PR DESCRIPTION
Minor follow-ups to https://github.com/all-of-us/curation/pull/416 

1. Cache pip installs

This caches the virtualenv folder between runs, providing a starting point for `pip install`. You can see it in action here (~40s -> ~2s): 
![image](https://user-images.githubusercontent.com/822298/74783520-ba0a6880-525a-11ea-91e1-d3d756338b5e.png)

Note: there seems to be a fair amount of variance in the time required to download the cache. 3s seems typical, but on this PR the unit tests restore_cache step took ~50s (about the same time as just running pip install).

2. Skip unit tests. These already run post-merge into develop, so there's no additional information gained by running them nightly.