### PR TITLE
[DC-369] Enforce Submission Directory Naming Convention

### DIFF
--- a/data_steward/constants/validation/main.py
+++ b/data_steward/constants/validation/main.py
@@ -199,3 +199,4 @@ ERRORS = 'errors'
 REASON = 'reason'
 
 FOLDER_NAME_REGEX = r'\d{4}-\d{2}-\d{2}-v\d+'
+FOLDER_NAMING_CONVENTION = 'YYYY-MM-DD-vN/'

--- a/data_steward/constants/validation/main.py
+++ b/data_steward/constants/validation/main.py
@@ -197,3 +197,5 @@ APPLICATION_JSON = 'application/json'
 ERROR = 'error'
 ERRORS = 'errors'
 REASON = 'reason'
+
+FOLDER_NAME_REGEX = r'\d{4}-\d{2}-\d{2}-v\d+'

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -399,22 +399,20 @@ def generate_empty_report(hpo_id, bucket, folder_prefix):
     report_data = dict()
     processed_datetime_str = datetime.datetime.now().strftime(
         '%Y-%m-%dT%H:%M:%S')
-    logging.info(
-        'Folder %s does not follow naming convention %s',
-        folder_prefix,
-    )
     report_data[report_consts.HPO_NAME_REPORT_KEY] = get_hpo_name(hpo_id)
     report_data[report_consts.FOLDER_REPORT_KEY] = folder_prefix
     report_data[report_consts.TIMESTAMP_REPORT_KEY] = processed_datetime_str
     report_data[
         report_consts.
         SUBMISSION_ERROR_REPORT_KEY] = f'Submission folder name {folder_prefix} does not follow the ' \
-                                       f'naming convention YYYY-MM-DD-vN/, where vN represents the version number ' \
-                                       f'for the day, starting at v1 each day. Please resubmit the files in a new ' \
-                                       f'folder with the correct naming convention'
-    logging.info('Processing skipped. Saving timestamp %s to `gs://%s/%s`.',
-                 processed_datetime_str, bucket,
-                 folder_prefix + common.PROCESSED_TXT)
+                                       f'naming convention {consts.FOLDER_NAMING_CONVENTION}, where vN represents ' \
+                                       f'the version number for the day, starting at v1 each day. ' \
+                                       f'Please resubmit the files in a new folder with the correct naming convention'
+    logging.info(
+        'Processing skipped. Reason: Folder %s does not follow naming convention %s. '
+        'Saving timestamp %s to `gs://%s/%s`.', folder_prefix,
+        consts.FOLDER_NAMING_CONVENTION, processed_datetime_str, bucket,
+        folder_prefix + common.PROCESSED_TXT)
     _write_string_to_file(bucket, folder_prefix + common.PROCESSED_TXT,
                           processed_datetime_str)
     results_html = hpo_report.render(report_data)

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -430,7 +430,13 @@ def is_valid_folder_prefix_name(folder_prefix):
     :return: Boolean indicating whether the input folder follows the aforementioned naming convention
     """
     folder_name_format = re.compile(consts.FOLDER_NAME_REGEX)
-    return folder_name_format.match(folder_prefix)
+    if not folder_name_format.match(folder_prefix):
+        return False
+    try:
+        datetime.datetime.strptime(folder_prefix[:10], '%Y-%m-%d')
+    except ValueError:
+        return False
+    return True
 
 
 def process_hpo(hpo_id, force_run=False):

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -4,7 +4,6 @@ Unit test components of data_steward.validation.main
 from __future__ import print_function
 import json
 import os
-import re
 import unittest
 from io import open
 
@@ -43,7 +42,7 @@ class ValidationMainTest(unittest.TestCase):
         self.addCleanup(mock_get_hpo_name.stop)
 
         self.bigquery_dataset_id = bq_utils.get_dataset_id()
-        self.folder_prefix = '2019-01-01/'
+        self.folder_prefix = '2019-01-01-v1/'
         self._empty_bucket()
         test_util.delete_all_tables(self.bigquery_dataset_id)
         self._create_drug_class_table(self.bigquery_dataset_id)


### PR DESCRIPTION
Generate empty report if submission folder is named incorrectly