### PR TITLE
[DC-695] Provide fallback username on anonymous circle runs

### DIFF
--- a/data_steward/init_env.sh
+++ b/data_steward/init_env.sh
@@ -19,8 +19,16 @@ export USERNAME=$(echo "${GH_USERNAME:-${CIRCLE_USERNAME:-}}" | tr '[:upper:]' '
 
 if [ -z "${USERNAME}" ]
 then
-    echo "Please set environment variable GH_USERNAME or CIRCLE_USERNAME";
+  if [ -n "${CIRCLECI}" ]
+  then
+    # If we're on circle without a CIRCLE_NAME, fallback to a default username.
+    # This can happen if a Circle job is triggered outside the context of a
+    # specific user interaction, e.g. during automated nightly cron runs.
+    export USERNAME="circleci"
+  else
+    echo "Please set environment variable GH_USERNAME, CIRCLE_USERNAME, or CIRCLECI";
     exit 1;
+  fi
 fi
 
 # Dataset IDs must be alphanumeric (plus underscores) and <= 1024 characters


### PR DESCRIPTION
Unfortunately I don't see a good way of verifying this fix. I triggered this rerun with SSH and hacked in GH_USERNAME=circleci to confirm this will at least is the only issue:
https://circleci.com/gh/all-of-us/curation/863

CC @mark-velez 