### PR TITLE
[DC-529] Remove irrelevant observation_source_concept_ids from RDR

### DIFF
--- a/data_steward/cdr_cleaner/args_parser.py
+++ b/data_steward/cdr_cleaner/args_parser.py
@@ -44,9 +44,21 @@ def get_argument_parser():
                         dest='dataset_id',
                         help='Dataset where cleaning rules are to be applied',
                         required=True)
+    parser.add_argument(
+        '-b',
+        '--sandbox_dataset_id',
+        action='store',
+        dest='sandbox_dataset_id',
+        help='Dataset to store intermediate results or changes in',
+        required=True)
     parser.add_argument('-s',
                         '--console_log',
                         dest='console_log',
                         action='store_true',
                         help='Send logs to console')
+    parser.add_argument('-l',
+                        '--list_queries',
+                        dest='list_queries',
+                        action='store_true',
+                        help='List the generated SQL without executing')
     return parser

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -518,12 +518,3 @@ if __name__ == '__main__':
         raise EnvironmentError(
             f'Dataset selection should be from [{stage.EHR}, {stage.UNIONED}, {stage.RDR}, {stage.COMBINED},'
             f' {stage.DEID_BASE}, {stage.DEID_CLEAN}]')
-
-    res = gather_test_query()
-    #res = _gather_combined_de_identified_queries('aou-res-curation-prod', 'R2019Q3R4_combined_deid_base_staging_1', 'R2019Q3R4_combined_deid_base_staging_1_sandbox')
-    res = _gather_unioned_ehr_queries('foo', 'bar', 'baz')
-    res = _gather_rdr_queries('foo', 'bar', 'baz')
-    for item in res:
-        for k, v in item.items():
-            print('{}\t\t\t{}'.format(k, v))
-        print('--------------------------------------------------------\n\n')

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -63,8 +63,10 @@ UNIONED_EHR_CLEANING_CLASSES = [
     (neg_ages.get_negative_ages_queries,),
     (bad_end_dates.get_bad_end_date_queries,),
     (drug_refills_supply.get_days_supply_refills_queries,),
-    # trying to load a table, won't work with mocked strings
-    #    (populate_routes.get_route_mapping_queries,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    # (populate_routes.get_route_mapping_queries,),
     (
         fix_datetimes.get_fix_incorrect_datetime_to_date_queries,),
     (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
@@ -81,14 +83,20 @@ RDR_CLEANING_CLASSES = [
     (remove_multiple_race_answers.
      get_remove_multiple_race_ethnicity_answers_queries,),
     (negative_ppi.get_update_ppi_queries,),
-    # trying to load a table, won't work with mocked strings
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
     #(smoking.get_queries_clean_smoking,),
     (
         ppi_drop_duplicates.
         get_remove_duplicate_set_of_responses_to_same_questions_queries,),
-    # trying to load a table, won't work with mocked strings
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
     #(operational_pii_fields.get_remove_operational_pii_fields_query,),
-    # trying to load a table, won't work with mocked strings
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
     #map_questions_answers_to_omop.
     #(get_update_questions_answers_not_mapped_to_omop,),
     (
@@ -99,9 +107,13 @@ RDR_CLEANING_CLASSES = [
 ]
 
 COMBINED_CLEANING_CLASSES = [
-    # trying to load a table, won't work with mocked strings
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
     #    (replace_standard_concept_ids.replace_standard_id_in_domain_tables,),
-    # trying to load a table, won't work with mocked strings
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
     #    (domain_alignment.domain_alignment,),
     (
         drop_participants_without_ppi_or_ehr.get_queries,),
@@ -112,7 +124,9 @@ COMBINED_CLEANING_CLASSES = [
     (no_data_30days_after_death.no_data_30_days_after_death,),
     (valid_death_dates.get_valid_death_date_queries,),
     (drug_refills_supply.get_days_supply_refills_queries,),
-    # trying to load a table, won't work with mocked strings
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
     #    (populate_routes.get_route_mapping_queries,),
     (
         fix_datetimes.get_fix_incorrect_datetime_to_date_queries,),

--- a/data_steward/cdr_cleaner/clean_cdr_engine.py
+++ b/data_steward/cdr_cleaner/clean_cdr_engine.py
@@ -34,7 +34,7 @@ def add_console_logging(add_handler):
         formatter = logging.Formatter(
             '%(asctime)s - %(levelname)s - %(name)s - %(message)s')
         handler.setFormatter(formatter)
-        LOGGER.addHandler(handler)
+        logging.getLogger('').addHandler(handler)
 
 
 def clean_dataset(project=None, statements=None, data_stage=stage.UNSPECIFIED):

--- a/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule.py
@@ -1,0 +1,134 @@
+"""
+A base class for cleaning rules to extend and implement.
+
+DC-???
+
+This is a base class that all cleaning rules should extend.  This base class
+should contain data relevant to each cleaning rule.  It's attributes and
+functions should be used to ensure that new cleaning rules are added with
+an adequate amount of information.  This is useful for things like, reporting
+features.
+"""
+# Python imports
+from typing import List
+
+# Third party imports
+
+# Project imports
+
+
+class BaseCleaningRule:
+    """
+    Contains attributes and functions relevant to all cleaning rules.
+    """
+    string_list = List[str]
+
+    def __init__(self,
+                 jira_issue_numbers: string_list = None,
+                 description: str = None,
+                 affected_datasets: string_list = None):
+        """
+        Instantiate a cleaning rule with basic attributes.
+
+        Inheriting classes must set issue numbers, description and affected
+        datasets.  As other tickets may affect the SQL of a cleaning rule,
+        add them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+
+        :param jira_issue_numbers:  a list of strings inidcating jira issues
+            impacting a cleaning rule.
+        :param description:  a written description of the cleaning rule.
+            describes why the rule exists and what it hopes to accomplish.
+        :param affected_datasets:  a list of strings describing the types of
+            datasets this rule is expected to impact, (e.g. rdr, unioned_ehr, combined)
+        """
+        self._jira_issue_numbers = jira_issue_numbers
+        self._description = description
+        self._affected_datasets = affected_datasets
+
+        self.__validate_arguments()
+
+    def __validate_list_of_strings(self, arg, arg_name):
+        """
+        Validate the given argument is a list of strings.
+
+        :param arg:  the argument to validate as a list of strings
+        :param arg_name:  the argument name that was passed.  useful for error messages
+
+        :raises NotImplementedError if arguments are not set.
+        :raises TypeError if arguments are not set to expected types
+        """
+        if arg is None:
+            raise NotImplementedError(
+                '{} cleaning rule must set {} variable'.format(
+                    self.__class__.__name__, arg_name))
+
+        if not isinstance(arg, list):
+            raise TypeError(
+                '{} is expected to be a list of strings.  offending type is:  {}'
+                .format(arg_name, type(arg)))
+        else:
+            for list_item in arg:
+                if not isinstance(list_item, str):
+                    raise TypeError(
+                        '{} is expected to be a list of strings.  offending list item {} is of type:  {}'
+                        .format(arg_name, list_item, type(list_item)))
+
+    def __validate_arguments(self):
+        """
+        Validate arguments passed to the base class were set.
+
+        :raises NotImplementedError if arguments are not set.
+        :raises TypeError if arguments are not set to expected types
+        """
+        # validate jira_issue_numbers is a list of strings
+        self.__validate_list_of_strings(self._jira_issue_numbers,
+                                        'jira_issue_numbers')
+
+        # validate description is a string
+        if self._description is None:
+            raise NotImplementedError(
+                '{} cleaning rule must set description variable'.format(
+                    self.__class__.__name__))
+
+        if not isinstance(self._description, str):
+            raise TypeError(
+                'description is expected to be a string.  offending description: <{}> is of type:  {}'
+                .format(self._description, type(self._description)))
+
+        # validate affected datasets is a list of strings.
+        self.__validate_list_of_strings(self._affected_datasets,
+                                        'affected_datasets')
+
+    def get_issue_numbers(self):
+        """
+        Return the jira_issue_numbers instance variable.
+        """
+        return self._jira_issue_numbers
+
+    def get_description(self):
+        """
+        Get the common language description of a cleaning rule.
+        """
+        return self._description
+
+    def get_affected_datasets(self):
+        """
+        Get the list of datasets a rule affects.
+        """
+        return self._affected_datasets
+
+    def get_query_dictionary_list(self, *args, **keyword_args):
+        """
+        Interface to return a list of query dictionaries.
+
+        Interface function each inheriting class should override.  Returns a
+        list of query dictionaries to describe each query that should
+        execute.
+
+        :returns:  a list of query dictionaries
+        :raises: NotImplementedError
+        """
+        raise NotImplementedError(
+            '{} has not implemented get_query_dictionary_list.  Must be implemented.'
+            .format(self.__class__.__name__))

--- a/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
@@ -1,0 +1,85 @@
+"""
+Removing three irrelevant observation_source_concept_ids from the RDR dataset.
+
+Original Issue:  DC-529
+
+The intent is to remove PPI records from the observation table in the RDR
+export where observation_source_concept_id in (43530490, 43528818, 43530333).
+The records for removal should be archived in the dataset sandbox.
+"""
+# Project imports
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from constants.bq_utils import WRITE_TRUNCATE
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+
+SAVE_TABLE_NAME = 'dc_529_obs_rows_dropped'
+
+DROP_SELECTION_QUERY = (
+    'CREATE OR REPLACE TABLE `{project}.{sandbox}.{drop_table}` '
+    'SELECT * '
+    'FROM `{project}.{dataset}.observation` '
+    'WHERE observation_source_concept_id IN (43530490, 43528818, 43530333)')
+
+DROP_QUERY = (
+    'SELECT * FROM `{project}.{dataset}.observation` AS o '
+    'WHERE NOT EXISTS ( '
+    '  SELECT 1 '
+    '  FROM `{project}.{dataset}.observation` AS n '
+    '  WHERE o.observation_id = n.observation_id AND '
+    '  n.observation_source_concept_id IN (43530490, 43528818, 43530333) '
+    ')')
+
+
+class ObservationSourceConceptIDRowSuppression(BaseCleaningRule):
+    """
+    Suppress rows by values in the observation_source_concept_id field.
+    """
+
+    def __init__(self):
+        """
+        Initialize the class with proper info.
+
+        Set the issue numbers, description and affected datasets.  As other
+        tickets may affect this SQL, add them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = (
+            'Remove records from the rdr dataset where '
+            'observation_source_concept_id in (43530490, 43528818, 43530333)')
+        BaseCleaningRule.__init__(self,
+                                  jira_issue_numbers=['DC-529'],
+                                  description=desc,
+                                  affected_datasets=[cdr_consts.RDR])
+
+    def get_query_dictionary_list(self, project_id, dataset_id, sandbox_id):
+        """
+        Get dictionary list of queries to execute.
+
+        :param project_id:  The project to query.
+        :param dataset_id:  The dataset to query.
+        :param sandbox_id:  The sandbox dataset id to store intermediate
+            results in.
+
+        :return:  A list of dictionaries.  Each contains a single query.
+            They may contain optional parameters describing the query.
+        """
+        save_dropped_rows = {
+            cdr_consts.QUERY:
+                DROP_SELECTION_QUERY.format(project=project_id,
+                                            dataset=dataset_id,
+                                            sandbox=sandbox_id,
+                                            drop_table=SAVE_TABLE_NAME),
+        }
+
+        drop_rows_query = {
+            cdr_consts.QUERY:
+                DROP_QUERY.format(project=project_id, dataset=dataset_id),
+            cdr_consts.DESTINATION_TABLE:
+                'observation',
+            cdr_consts.DESTINATION_DATASET:
+                dataset_id,
+            cdr_consts.DISPOSITION:
+                WRITE_TRUNCATE
+        }
+
+        return [save_dropped_rows, drop_rows_query]

--- a/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 SAVE_TABLE_NAME = 'dc_529_obs_rows_dropped'
 
 DROP_SELECTION_QUERY = (
-    'CREATE OR REPLACE TABLE `{project}.{sandbox}.{drop_table}` '
+    'CREATE OR REPLACE TABLE `{project}.{sandbox}.{drop_table}` AS '
     'SELECT * '
     'FROM `{project}.{dataset}.observation` '
     'WHERE observation_source_concept_id IN (43530490, 43528818, 43530333)')

--- a/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
@@ -51,13 +51,12 @@ class ObservationSourceConceptIDRowSuppression(BaseCleaningRule):
         desc = (
             'Remove records from the rdr dataset where '
             'observation_source_concept_id in (43530490, 43528818, 43530333)')
-        BaseCleaningRule.__init__(self,
-                                  jira_issue_numbers=['DC-529'],
-                                  description=desc,
-                                  affected_datasets=[cdr_consts.RDR],
-                                  project_id=project_id,
-                                  dataset_id=dataset_id,
-                                  sandbox_dataset_id=sandbox_dataset_id)
+        super().__init__(jira_issue_numbers=['DC-529'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
 
     def get_query_dictionary_list(self):
         """
@@ -93,6 +92,12 @@ class ObservationSourceConceptIDRowSuppression(BaseCleaningRule):
         }
 
         return [save_dropped_rows, drop_rows_query]
+
+    def setup_query_execution(self):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
@@ -1,0 +1,57 @@
+"""
+Unit Test for the rdr_observation_source_concept_id_suppression module.
+
+Remove three irrelevant observation_source_concept_ids from the RDR dataset.
+
+Original Issue:  DC-529
+
+The intent is to remove PPI records from the observation table in the RDR
+export where observation_source_concept_id in (43530490, 43528818, 43530333).
+The records for removal should be archived in the dataset sandbox.
+"""
+# Python imports
+import unittest
+
+# Third party imports
+
+# Project imports
+from constants.bq_utils import WRITE_TRUNCATE
+from constants.cdr_cleaner import clean_cdr as clean_consts
+from cdr_cleaner.cleaning_rules.rdr_observation_source_concept_id_suppression import ObservationSourceConceptIDRowSuppression, SAVE_TABLE_NAME, DROP_SELECTION_QUERY, DROP_QUERY
+
+
+class ObservationSourceConceptIDRowSuppressionTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.query_class = ObservationSourceConceptIDRowSuppression(
+            'foo', 'bar', 'baz')
+
+    def test_get_query_dictionary_list(self):
+        # pre-conditions
+        self.assertEqual(self.query_class.get_affected_datasets(),
+                         [clean_consts.RDR])
+
+        # test
+        result_list = self.query_class.get_query_dictionary_list()
+
+        # post conditions
+        expected_list = [{
+            clean_consts.QUERY:
+                DROP_SELECTION_QUERY.format(project='foo',
+                                            dataset='bar',
+                                            sandbox='baz',
+                                            drop_table=SAVE_TABLE_NAME)
+        }, {
+            clean_consts.QUERY: DROP_QUERY.format(project='foo', dataset='bar'),
+            clean_consts.DESTINATION_TABLE: 'observation',
+            clean_consts.DESTINATION_DATASET: 'bar',
+            clean_consts.DISPOSITION: WRITE_TRUNCATE
+        }]
+
+        self.assertEqual(result_list, expected_list)


### PR DESCRIPTION
[DC-529] Remove irrelevant observation_source_concept_ids from the RDR Export

* Setting up a base class for Cleaning Rules to Inherit from.
* Modifying the current rdr pipeline to accept class or function names.
* Setting the pipeline up to only accept instances of a BaseClass in the future.
* Unit and integration tests needed.

[DC-529]: https://precisionmedicineinitiative.atlassian.net/browse/DC-529