### PR TITLE
[DC-718] Create Clean Rules Base Class to hold basic cleaning rule info

### DIFF
--- a/data_steward/cdr_cleaner/args_parser.py
+++ b/data_steward/cdr_cleaner/args_parser.py
@@ -44,9 +44,21 @@ def get_argument_parser():
                         dest='dataset_id',
                         help='Dataset where cleaning rules are to be applied',
                         required=True)
+    parser.add_argument(
+        '-b',
+        '--sandbox_dataset_id',
+        action='store',
+        dest='sandbox_dataset_id',
+        help='Dataset to store intermediate results or changes in',
+        required=True)
     parser.add_argument('-s',
                         '--console_log',
                         dest='console_log',
                         action='store_true',
                         help='Send logs to console')
+    parser.add_argument('-l',
+                        '--list_queries',
+                        dest='list_queries',
+                        action='store_true',
+                        help='List the generated SQL without executing')
     return parser

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -47,10 +47,107 @@ import cdr_cleaner.manual_cleaning_rules.ppi_drop_duplicate_responses as ppi_dro
 import cdr_cleaner.manual_cleaning_rules.remove_operational_pii_fields as operational_pii_fields
 import cdr_cleaner.manual_cleaning_rules.update_questiona_answers_not_mapped_to_omop as map_questions_answers_to_omop
 import cdr_cleaner.cleaning_rules.remove_aian_participants as remove_aian_participants
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 from constants.cdr_cleaner.clean_cdr import DataStage as stage
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 
 LOGGER = logging.getLogger(__name__)
+
+EHR_CLEANING_CLASSES = [
+    (id_dedup.get_id_deduplicate_queries,),
+]
+
+UNIONED_EHR_CLEANING_CLASSES = [
+    (id_dedup.get_id_deduplicate_queries,),
+    (clean_years.get_year_of_birth_queries,),
+    (neg_ages.get_negative_ages_queries,),
+    (bad_end_dates.get_bad_end_date_queries,),
+    (drug_refills_supply.get_days_supply_refills_queries,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    # (populate_routes.get_route_mapping_queries,),
+    (
+        fix_datetimes.get_fix_incorrect_datetime_to_date_queries,),
+    (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
+    ),
+    # DC-698 opened to fix it.
+    #    (invalid_procedure_source.get_remove_invalid_procedure_source_queries,),
+]
+
+RDR_CLEANING_CLASSES = [
+    (maps_to_value_vocab_update.get_maps_to_value_ppi_vocab_update_queries,),
+    (back_fill_pmi_skip.get_run_pmi_fix_queries,),
+    (ppi_numeric_fields.get_clean_ppi_num_fields_using_parameters_queries,),
+    (remove_multiple_race_answers.
+     get_remove_multiple_race_ethnicity_answers_queries,),
+    (negative_ppi.get_update_ppi_queries,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    #(smoking.get_queries_clean_smoking,),
+    (
+        ppi_drop_duplicates.
+        get_remove_duplicate_set_of_responses_to_same_questions_queries,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    #(operational_pii_fields.get_remove_operational_pii_fields_query,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    #map_questions_answers_to_omop.
+    #(get_update_questions_answers_not_mapped_to_omop,),
+    (
+        round_ppi_values.get_round_ppi_values_queries,),
+    (update_family_history.get_update_family_history_qa_queries,),
+    (extreme_measurements.get_drop_extreme_measurement_queries,),
+    (drop_mult_meas.get_drop_multiple_measurement_queries,),
+]
+
+COMBINED_CLEANING_CLASSES = [
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    #    (replace_standard_concept_ids.replace_standard_id_in_domain_tables,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    #    (domain_alignment.domain_alignment,),
+    (
+        drop_participants_without_ppi_or_ehr.get_queries,),
+    (id_dedup.get_id_deduplicate_queries,),
+    (clean_years.get_year_of_birth_queries,),
+    (neg_ages.get_negative_ages_queries,),
+    (bad_end_dates.get_bad_end_date_queries,),
+    (no_data_30days_after_death.no_data_30_days_after_death,),
+    (valid_death_dates.get_valid_death_date_queries,),
+    (drug_refills_supply.get_days_supply_refills_queries,),
+    # trying to load a table while creating query strings,
+    # won't work with mocked strings.  should use base class
+    # setup_query_execution function to load dependencies before query execution
+    #    (populate_routes.get_route_mapping_queries,),
+    (
+        fix_datetimes.get_fix_incorrect_datetime_to_date_queries,),
+    (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
+    ),
+    (drop_duplicate_states.get_drop_duplicate_states_queries,),
+    # TODO : Make null_invalid_foreign_keys able to run on de_identified dataset
+    (
+        null_foreign_key.null_invalid_foreign_keys,),
+    (remove_aian_participants.get_queries,)
+]
+
+DEID_BASE_CLEANING_CLASSES = [
+    (id_dedup.get_id_deduplicate_queries,),
+    (neg_ages.get_negative_ages_queries,),
+    (bad_end_dates.get_bad_end_date_queries,),
+    (valid_death_dates.get_valid_death_date_queries,),
+    (fill_source_value.get_fill_freetext_source_value_fields_queries,),
+    (repopulate_person.get_repopulate_person_post_deid_queries,),
+]
+
+DEID_CLEAN_CLEANING_CLASSES = []
 
 
 def add_module_info_decorator(query_function, *positional_args, **keyword_args):
@@ -86,11 +183,8 @@ def _gather_ehr_queries(project_id, dataset_id, sandbox_dataset_id):
     :param dataset_id: ehr dataset name
     :return: returns list of queries
     """
-    query_list = []
-    query_list.extend(
-        add_module_info_decorator(id_dedup.get_id_deduplicate_queries,
-                                  project_id, dataset_id, sandbox_dataset_id))
-    return query_list
+    return _get_query_list(EHR_CLEANING_CLASSES, project_id, dataset_id,
+                           sandbox_dataset_id)
 
 
 def _gather_rdr_queries(project_id, dataset_id, sandbox_dataset_id):
@@ -102,60 +196,8 @@ def _gather_rdr_queries(project_id, dataset_id, sandbox_dataset_id):
     :param sandbox_dataset_id: sandbox_dataset_id
     :return: returns list of queries
     """
-    query_list = []
-    query_list.extend(
-        add_module_info_decorator(
-            maps_to_value_vocab_update.
-            get_maps_to_value_ppi_vocab_update_queries, project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(back_fill_pmi_skip.get_run_pmi_fix_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            ppi_numeric_fields.
-            get_clean_ppi_num_fields_using_parameters_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            remove_multiple_race_answers.
-            get_remove_multiple_race_ethnicity_answers_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(negative_ppi.get_update_ppi_queries,
-                                  project_id, dataset_id, sandbox_dataset_id))
-    query_list.extend(
-        add_module_info_decorator(smoking.get_queries_clean_smoking, project_id,
-                                  dataset_id, sandbox_dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            ppi_drop_duplicates.
-            get_remove_duplicate_set_of_responses_to_same_questions_queries,
-            project_id, dataset_id, sandbox_dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            operational_pii_fields.get_remove_operational_pii_fields_query,
-            project_id, dataset_id, sandbox_dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            map_questions_answers_to_omop.
-            get_update_questions_answers_not_mapped_to_omop, project_id,
-            dataset_id, sandbox_dataset_id))
-    query_list.extend(
-        add_module_info_decorator(round_ppi_values.get_round_ppi_values_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            update_family_history.get_update_family_history_qa_queries,
-            project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            extreme_measurements.get_drop_extreme_measurement_queries,
-            project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            drop_mult_meas.get_drop_multiple_measurement_queries, project_id,
-            dataset_id, sandbox_dataset_id))
-    return query_list
+    return _get_query_list(RDR_CLEANING_CLASSES, project_id, dataset_id,
+                           sandbox_dataset_id)
 
 
 def _gather_combined_queries(project_id, dataset_id, sandbox_dataset_id):
@@ -166,111 +208,8 @@ def _gather_combined_queries(project_id, dataset_id, sandbox_dataset_id):
     :param dataset_id: combined dataset name
     :return: returns list of queries
     """
-    query_list = []
-    query_list.extend(
-        add_module_info_decorator(
-            replace_standard_concept_ids.replace_standard_id_in_domain_tables,
-            project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(domain_alignment.domain_alignment, project_id,
-                                  dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            drop_participants_without_ppi_or_ehr.get_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(id_dedup.get_id_deduplicate_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(clean_years.get_year_of_birth_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(neg_ages.get_negative_ages_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(bad_end_dates.get_bad_end_date_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            no_data_30days_after_death.no_data_30_days_after_death, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            valid_death_dates.get_valid_death_date_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            drug_refills_supply.get_days_supply_refills_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(populate_routes.get_route_mapping_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            fix_datetimes.get_fix_incorrect_datetime_to_date_queries,
-            project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            remove_records_with_wrong_date.
-            get_remove_records_with_wrong_date_queries, project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            drop_duplicate_states.get_drop_duplicate_states_queries, project_id,
-            dataset_id, sandbox_dataset_id))
-    # TODO : Make null_invalid_foreign_keys able to run on de_identified dataset
-    query_list.extend(
-        add_module_info_decorator(null_foreign_key.null_invalid_foreign_keys,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            remove_aian_participants.get_queries(project_id, dataset_id)))
-    return query_list
-
-
-def _gather_combined_de_identified_queries(project_id, dataset_id,
-                                           sandbox_dataset_id):
-    """
-    gathers all the queries required to clean de_identified dataset
-
-    :param project_id: project name
-    :param dataset_id: de_identified dataset name
-    :return: returns list of queries
-    """
-    query_list = []
-    query_list.extend(
-        add_module_info_decorator(id_dedup.get_id_deduplicate_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(neg_ages.get_negative_ages_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(bad_end_dates.get_bad_end_date_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            valid_death_dates.get_valid_death_date_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            fill_source_value.get_fill_freetext_source_value_fields_queries,
-            project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            repopulate_person.get_repopulate_person_post_deid_queries,
-            project_id, dataset_id))
-    return query_list
-
-
-def _gather_combined_de_identified_clean_queries(project_id, dataset_id,
-                                                 sandbox_dataset_id):
-    """
-    gathers all the queries required to clean base version of de_identified dataset
-    :param project_id: project name
-    :param dataset_id: de_identified dataset name
-    :return: returns list of queries
-    """
-    query_list = []
-    return query_list
+    return _get_query_list(COMBINED_CLEANING_CLASSES, project_id, dataset_id,
+                           sandbox_dataset_id)
 
 
 def _gather_unioned_ehr_queries(project_id, dataset_id, sandbox_dataset_id):
@@ -281,43 +220,92 @@ def _gather_unioned_ehr_queries(project_id, dataset_id, sandbox_dataset_id):
     :param dataset_id: unioned_ehr dataset name
     :return: returns list of queries
     """
+    return _get_query_list(UNIONED_EHR_CLEANING_CLASSES, project_id, dataset_id,
+                           sandbox_dataset_id)
+
+
+def _gather_deid_base_cleaning_queries(project_id, dataset_id,
+                                       sandbox_dataset_id):
+    """
+    gathers all the queries required to clean de_identified dataset
+
+    These queries are applied to a copy of `<dataset_release_tag>_combined_deid`
+    to create `<dataset_release_tag>_combined_deid_base`.  This dataset is
+    copied for use by the Workbench team.
+
+    :param project_id: project name
+    :param dataset_id: de_identified dataset name
+    :return: returns list of queries
+    """
+    return _get_query_list(DEID_BASE_CLEANING_CLASSES, project_id, dataset_id,
+                           sandbox_dataset_id)
+
+
+def _gather_deid_clean_cleaning_queries(project_id, dataset_id,
+                                        sandbox_dataset_id):
+    """
+    gathers all the queries required to clean base version of de_identified dataset
+
+    These queries are applied to a copy of `<dataset_release_tag>_combined_deid_base`
+    to create `<dataset_release_tag>_combined_deid_clean`.  This dataset is
+    copied for use by the Cohort Builder team.
+
+    :param project_id: project name
+    :param dataset_id: de_identified dataset name
+    :return: returns list of queries
+    """
+    return _get_query_list(DEID_CLEAN_CLEANING_CLASSES, project_id, dataset_id,
+                           sandbox_dataset_id)
+
+
+def _get_query_list(cleaning_classes, project_id, dataset_id,
+                    sandbox_dataset_id):
+    """
+    gathers all the queries required to clean a dataset
+
+    :param cleaning_classes:  the list of classes generating SQL cleaning statements
+    :param project_id: project name
+    :param dataset_id: de_identified dataset name
+    :return: returns list of queries
+    """
     query_list = []
-    query_list.extend(
-        add_module_info_decorator(id_dedup.get_id_deduplicate_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(clean_years.get_year_of_birth_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(neg_ages.get_negative_ages_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(bad_end_dates.get_bad_end_date_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            valid_death_dates.get_valid_death_date_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            drug_refills_supply.get_days_supply_refills_queries, project_id,
-            dataset_id))
-    query_list.extend(
-        add_module_info_decorator(populate_routes.get_route_mapping_queries,
-                                  project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            fix_datetimes.get_fix_incorrect_datetime_to_date_queries,
-            project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            remove_records_with_wrong_date.
-            get_remove_records_with_wrong_date_queries, project_id, dataset_id))
-    query_list.extend(
-        add_module_info_decorator(
-            invalid_procedure_source.
-            get_remove_invalid_procedure_source_queries, project_id,
-            dataset_id))
+
+    for class_info in cleaning_classes:
+        clazz = class_info[0]
+        try:
+            instance = clazz(project_id, dataset_id, sandbox_dataset_id)
+        except TypeError:
+            # raised when called with the 3 parameters and only 2 are needed
+            query_list.extend(
+                add_module_info_decorator(clazz, project_id, dataset_id))
+        else:
+            # should eventually be the main component of this function.
+            # Everything should transition to using a common base class.
+            if isinstance(instance, BaseCleaningRule):
+
+                keywords = class_info[-1]
+                if isinstance(keywords, dict):
+                    positionals = class_info[1:-1]
+                else:
+                    keywords = {}
+                    positionals = class_info[1:]
+
+                query_list.extend(
+                    add_module_info_decorator(
+                        instance.get_query_dictionary_list, *positionals,
+                        **keywords))
+            else:
+                # if the class is not of the common base class, raise an error
+                # will prevent running manual cleaning rules that have not been
+                # transitioned into proper cleaning rules
+                #                raise TypeError(
+                #                    '{} is not an instance of BaseCleaningRule'.format(
+                #                        instance.__class__.__name__))
+                # is raised when a function is called without all the required variables
+                query_list.extend(
+                    add_module_info_decorator(clazz, project_id, dataset_id,
+                                              sandbox_dataset_id))
+
     return query_list
 
 
@@ -447,8 +435,8 @@ def clean_combined_de_identified_dataset(project_id=None, dataset_id=None):
     sandbox_dataset_id = sandbox.create_sandbox_dataset(project_id=project_id,
                                                         dataset_id=dataset_id)
 
-    query_list = _gather_combined_de_identified_queries(project_id, dataset_id,
-                                                        sandbox_dataset_id)
+    query_list = _gather_deid_base_cleaning_queries(project_id, dataset_id,
+                                                    sandbox_dataset_id)
 
     LOGGER.info("Cleaning de-identified dataset")
     clean_engine.clean_dataset(project_id, query_list, stage.DEID_BASE)
@@ -474,8 +462,8 @@ def clean_combined_de_identified_clean_dataset(project_id=None,
     sandbox_dataset_id = sandbox.create_sandbox_dataset(project_id=project_id,
                                                         dataset_id=dataset_id)
 
-    query_list = _gather_combined_de_identified_clean_queries(
-        project_id, dataset_id, sandbox_dataset_id)
+    query_list = _gather_deid_clean_cleaning_queries(project_id, dataset_id,
+                                                     sandbox_dataset_id)
 
     LOGGER.info("Cleaning de-identified dataset")
     clean_engine.clean_dataset(project_id, query_list, stage.DEID_CLEAN)

--- a/data_steward/cdr_cleaner/clean_cdr_engine.py
+++ b/data_steward/cdr_cleaner/clean_cdr_engine.py
@@ -34,7 +34,7 @@ def add_console_logging(add_handler):
         formatter = logging.Formatter(
             '%(asctime)s - %(levelname)s - %(name)s - %(message)s')
         handler.setFormatter(formatter)
-        LOGGER.addHandler(handler)
+        logging.getLogger('').addHandler(handler)
 
 
 def clean_dataset(project=None, statements=None, data_stage=stage.UNSPECIFIED):

--- a/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule.py
@@ -1,0 +1,248 @@
+"""
+A base class for cleaning rules to extend and implement.
+
+DC-718
+
+This is a base class that all cleaning rules should extend.  This base class
+should contain data relevant to each cleaning rule.  It's attributes and
+functions should be used to ensure that new cleaning rules are added with
+an adequate amount of information.  This is useful for things like, reporting
+features.
+"""
+# Python imports
+import logging
+from abc import ABC, abstractmethod
+from typing import List
+
+# Third party imports
+import googleapiclient
+import oauth2client
+
+# Project imports
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AbstractBaseCleaningRule(ABC):
+    """
+    Contains attributes and functions relevant to all cleaning rules.
+    """
+    string_list = List[str]
+
+    def __init__(self):
+        """
+        Instantiate a cleaning rule with basic attributes.
+        """
+        super().__init__()
+
+    @abstractmethod
+    def get_query_dictionary_list(self, *args, **keyword_args):
+        """
+        Interface to return a list of query dictionaries.
+
+        :returns:  a list of query dictionaries
+        """
+        pass
+
+    @abstractmethod
+    def print_queries(self, *args, **keyword_args):
+        """
+        Helper function to print the SQL a class geenerates.
+        """
+        pass
+
+
+class BaseCleaningRule(AbstractBaseCleaningRule):
+    """
+    Contains attributes and functions relevant to all cleaning rules.
+    """
+    string_list = List[str]
+    cleaning_class_list = List[AbstractBaseCleaningRule]
+
+    def __init__(self,
+                 jira_issue_numbers: string_list = None,
+                 description: str = None,
+                 affected_datasets: string_list = None,
+                 project_id: str = None,
+                 dataset_id: str = None,
+                 sandbox_dataset_id: str = None,
+                 depends_on: cleaning_class_list = None):
+        """
+        Instantiate a cleaning rule with basic attributes.
+
+        Inheriting classes must set issue numbers, description and affected
+        datasets.  As other tickets may affect the SQL of a cleaning rule,
+        append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+
+        :param jira_issue_numbers:  a list of strings inidcating jira issues
+            impacting a cleaning rule.
+        :param description:  a written description of the cleaning rule.
+            describes why the rule exists and what it hopes to accomplish.
+        :param affected_datasets:  a list of strings describing the types of
+            datasets this rule is expected to impact, (e.g. rdr, unioned_ehr, combined)
+        """
+        self._jira_issue_numbers = jira_issue_numbers
+        self._description = description
+        self._affected_datasets = affected_datasets
+        self._project_id = project_id
+        self._dataset_id = dataset_id
+        self._sandbox_dataset_id = sandbox_dataset_id
+        self._depends_on_classes = depends_on if depends_on else []
+
+        super().__init__()
+
+        self.__validate_arguments()
+
+    def __validate_list_of_strings(self, arg, arg_name):
+        """
+        Validate the given argument is a list of strings.
+
+        :param arg:  the argument to validate as a list of strings
+        :param arg_name:  the argument name that was passed.  useful for error messages
+
+        :raises NotImplementedError if arguments are not set.
+        :raises TypeError if arguments are not set to expected types
+        """
+        if arg is None:
+            raise NotImplementedError(
+                '{} cleaning rule must set {} variable'.format(
+                    self.__class__.__name__, arg_name))
+
+        if not isinstance(arg, list):
+            raise TypeError(
+                '{} is expected to be a list of strings.  offending type is:  {}'
+                .format(arg_name, type(arg)))
+        else:
+            for list_item in arg:
+                if not isinstance(list_item, str):
+                    raise TypeError(
+                        ('{} is expected to be a list of strings.  '
+                         'offending list item {} is of type:  {}').format(
+                             arg_name, list_item, type(list_item)))
+
+    def __validate_string(self, arg, arg_name):
+        """
+        Validate string parameters.
+
+        :param arg:  The actual argument value to validate is a string.
+        :param arg_name:  The name of the variable being validated.  Used
+            in error messages, if needed.
+
+        :raises NotImplementedError if arguments are not set.
+        :raises TypeError if arguments are not set to expected types
+        """
+        if arg is None:
+            raise NotImplementedError(
+                '{} cleaning rule must set {} variable'.format(
+                    self.__class__.__name__, arg_name))
+
+        if not isinstance(arg, str):
+            raise TypeError(
+                '{0} is expected to be a string.  offending {0}: <{1}> is of type:  {2}'
+                .format(arg_name, arg, type(arg)))
+
+    def __validate_arguments(self):
+        """
+        Validate arguments passed to the base class were set.
+
+        :raises NotImplementedError if arguments are not set.
+        :raises TypeError if arguments are not set to expected types
+        """
+        # validate jira_issue_numbers is a list of strings
+        self.__validate_list_of_strings(self._jira_issue_numbers,
+                                        'jira_issue_numbers')
+
+        # validate affected datasets is a list of strings.
+        self.__validate_list_of_strings(self._affected_datasets,
+                                        'affected_datasets')
+
+        # validate description is a string
+        self.__validate_string(self._description, 'description')
+
+        # validate project_id is a string
+        self.__validate_string(self._project_id, 'project_id')
+
+        # validate dataset_id is a string
+        self.__validate_string(self._dataset_id, 'dataset_id')
+
+        # validate sandbox_dataset_id is a string
+        self.__validate_string(self._sandbox_dataset_id, 'sandbox_dataset_id')
+
+        # depends_on_classes is allowed to be null,
+        # so is not validated against None
+        for clazz in self._depends_on_classes:
+            if not isinstance(clazz, BaseCleaningRule):
+                raise TypeError(
+                    '{} is expected to inherit from BaseCleaningRule'.format(
+                        self.__class__.__name__))
+
+    def get_depends_on_classes(self):
+        """
+        Return the names of classes the rule depends on.
+        """
+        return self._depends_on_classes
+
+    def get_jira_issue_numbers(self):
+        """
+        Return the jira_issue_numbers instance variable.
+        """
+        return self._jira_issue_numbers
+
+    def get_description(self):
+        """
+        Get the common language description of a cleaning rule.
+        """
+        return self._description
+
+    def get_affected_datasets(self):
+        """
+        Get the list of datasets a rule affects.
+        """
+        return self._affected_datasets
+
+    def get_project_id(self):
+        """
+        Get the project id for this class instance.
+        """
+        return self._project_id
+
+    def get_dataset_id(self):
+        """
+        Get the dataset id for this class instance.
+        """
+        return self._dataset_id
+
+    def get_sandbox_dataset_id(self):
+        """
+        Get the sandbox dataset id for this class instance.
+        """
+        return self._sandbox_dataset_id
+
+    def print_queries(self):
+        """
+        Helper function to print the SQL a class geenerates.
+
+        If the inheriting class builds tables inside the
+        get_query_dictionary_list function, the inheriting class will need
+        to override this function.
+        """
+        try:
+            query_list = self.get_query_dictionary_list()
+        except (oauth2client.client.HttpAccessTokenRefreshError,
+                googleapiclient.errors.HttpError, KeyError):
+            LOGGER.exception("Cannot list queries for %s",
+                             self.__class__.__name__)
+            raise
+
+        for query in query_list:
+            LOGGER.info('Generated SQL Query:\n%s',
+                        query.get(cdr_consts.QUERY, 'NO QUERY FOUND'))
+
+    @abstractmethod
+    def setup_query_execution(self, *args, **keyword_args):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule_test.py
@@ -1,0 +1,405 @@
+"""
+Testing the base cleaning rule class with some dummy classes.
+
+The point is to make it explicitly clear what is and is not required.
+"""
+# Python imports
+import unittest
+
+# Third party imports
+from mock import patch
+import googleapiclient
+import oauth2client
+
+# Project imports
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+
+
+class Inheritance(BaseCleaningRule):
+    """
+    Class that correctly sets all required parameters and methods.
+
+    Extends the BaseCleaningRule class correctly.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = ('Basic test case without depends_on parameter')
+        super().__init__(issue_numbers=['AA-000'],
+                         description=desc,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class BadIssueNumbers(BaseCleaningRule):
+    """
+    Class that incorrectly sets issue_numbers as a string parameter.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = (
+            'Defines issue_numbers as something other than a list of strings')
+        super().__init__(issue_numbers='AA-000',
+                         issue_urls=['www.fake_url.com'],
+                         description=desc,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class BadIssueUrls(BaseCleaningRule):
+    """
+    Class that incorrectly sets issue_urls as a string parameter.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = ('Defines issue_urls as something other than a list of strings')
+        super().__init__(issue_numbers=['AA-000'],
+                         issue_urls='www.fake_url.com',
+                         description=desc,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class BadDescription(BaseCleaningRule):
+    """
+    Class that incorrectly sets description as something other than a string.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        super().__init__(issue_numbers=['AA-000'],
+                         issue_urls=['www.fake_url.com'],
+                         description=88,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class BadAffectedDatasets(BaseCleaningRule):
+    """
+    Class that incorrectly sets affected datasets with a non-string list item.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = (
+            'Defines affected_datasets as something other than a list of strings'
+        )
+        super().__init__(issue_numbers=['AA-000'],
+                         issue_urls=['www.fake_url.com'],
+                         description=desc,
+                         affected_datasets=['yo_mama', 88],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class InheritanceWithDependency(BaseCleaningRule):
+    """
+    Class that shows how to set the optional dependency list.
+
+    It is setting the correctly extending Inheritance class as a dependency class.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = ('Test class with depends_on parameter set')
+        super().__init__(issue_numbers=['AA-000'],
+                         issue_urls=['www.fake_url.com'],
+                         description=desc,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         depends_on=[Inheritance])
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class NoInheritance(object):
+    """
+    Class that is not inheriting from the BaseCleaningRule.
+    """
+
+    def __init__(self):
+        pass
+
+
+class NoAbstractMethodDefinitions(BaseCleaningRule):
+    """
+    Class that does not correctly override abstractmethods from BaseCleaningRule.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = ('Does not fully implement BaseCleaningRule and is not abstract')
+        super().__init__(issue_numbers=['AA-000'],
+                         issue_urls=['www.fake_url.com'],
+                         description=desc,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         depends_on=[Inheritance])
+
+
+class InheritanceWithBadDependencyClass(BaseCleaningRule):
+    """
+    Example of using a non-cleaning rule class as a dependency.  Incorrect usage.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = ('Setting a dependency on a non-cleaning rule class')
+        super().__init__(issue_numbers=['AA-000'],
+                         description=desc,
+                         issue_urls=['www.fake_url.com'],
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         depends_on=[Inheritance, NoInheritance])
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class InheritanceWithBadDependencyType(BaseCleaningRule):
+    """
+    Class that sets a non class parameter for depends_on.  Incorrect usage.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        desc = ('Sets depends_on to a non-class object')
+        super().__init__(issue_numbers=['AA-00'],
+                         issue_urls=['www.fake_url.com'],
+                         description=desc,
+                         affected_datasets=['yo_mama'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         depends_on=[Inheritance, 99])
+
+    def get_query_specs(self):
+        pass
+
+    def setup_rule(self):
+        pass
+
+
+class NoSuperInitialization(BaseCleaningRule):
+    """
+    Class that does not call super during initialization.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        self.project_id = project_id
+        self.dataset_id = dataset_id
+        self.sandbox_dataset_id = sandbox_dataset_id
+
+    def get_query_specs(self):
+        _ = self.get_project_id()
+        _ = self.get_issue_numbers()
+
+    def setup_rule(self):
+        _ = self.get_project_id()
+        _ = self.get_dataset_id()
+        _ = self.get_sandbox_dataset_id()
+        _ = self.get_issue_numbers()
+        _ = self.get_affected_datasets()
+        _ = self.get_issue_urls()
+
+
+class BaseCleaningRuleTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'foo'
+        self.dataset_id = 'bar'
+        self.sandbox_dataset_id = 'baz'
+        self.issue_numbers = ['AA-000']
+        self.description = 'phony cleaning rule'
+        self.affected_datasets = ['yo_mama']
+        self.depends_on = [Inheritance]
+
+    def test_instantiating_base_class(self):
+        """
+        Prove that the base class can't be instantiated.
+        """
+
+        self.assertRaises(TypeError, BaseCleaningRule, self.issue_numbers,
+                          self.description, self.affected_datasets,
+                          self.project_id, self.dataset_id,
+                          self.sandbox_dataset_id)
+
+    def test_instantiating_inheriting_class_correctly(self):
+        """
+        Prove how to correctly inherit from the base class.
+        """
+        # tests
+        alpha = Inheritance(self.project_id, self.dataset_id,
+                            self.sandbox_dataset_id)
+        beta = InheritanceWithDependency(self.project_id, self.dataset_id,
+                                         self.sandbox_dataset_id)
+
+        # post conditions
+        for clazz in [alpha, beta]:
+            self.assertEqual(self.project_id, clazz.get_project_id())
+            self.assertEqual(self.issue_numbers, clazz.get_issue_numbers())
+            self.assertEqual(self.affected_datasets,
+                             clazz.get_affected_datasets())
+            self.assertEqual(self.dataset_id, clazz.get_dataset_id())
+            self.assertEqual(self.sandbox_dataset_id,
+                             clazz.get_sandbox_dataset_id())
+
+        self.assertEqual([], alpha.get_depends_on_classes())
+        self.assertEqual(self.depends_on, beta.get_depends_on_classes())
+
+    def test_instantiating_inheriting_class_incorrectly(self):
+        """
+        Test forgetting to define some abstract class methods.
+        """
+        # No defined abstract methods
+        self.assertRaises(TypeError, NoAbstractMethodDefinitions,
+                          self.project_id, self.dataset_id,
+                          self.sandbox_dataset_id)
+
+        # Not using super in initialization
+        bad_init = NoSuperInitialization(self.project_id, self.dataset_id,
+                                         self.sandbox_dataset_id)
+        self.assertRaises(AttributeError, bad_init.get_description)
+        self.assertRaises(AttributeError, bad_init.get_issue_numbers)
+        self.assertRaises(AttributeError, bad_init.get_depends_on_classes)
+        self.assertRaises(AttributeError, bad_init.get_affected_datasets)
+
+    def test_passing_bad_constructor_arguments(self):
+        """
+        Test that bad constructor arguments raise errors.
+        """
+        # These bad constructor arguments are explicitly passed to
+        # the class under test
+        self.assertRaises(TypeError, Inheritance, 99, self.dataset_id,
+                          self.sandbox_dataset_id)
+
+        self.assertRaises(TypeError, Inheritance, self.project_id, 99,
+                          self.sandbox_dataset_id)
+
+        self.assertRaises(TypeError, Inheritance, self.project_id,
+                          self.dataset_id, 99)
+
+        self.assertRaises(TypeError, InheritanceWithBadDependencyClass,
+                          self.project_id, self.dataset_id,
+                          self.sandbox_dataset_id)
+
+        self.assertRaises(TypeError, InheritanceWithBadDependencyType,
+                          self.project_id, self.dataset_id,
+                          self.sandbox_dataset_id)
+
+        # These constructor arguments being tested, are defined when
+        # the class is written
+        self.assertRaises(TypeError, BadAffectedDatasets, self.project_id,
+                          self.dataset_id, self.sandbox_dataset_id)
+
+        self.assertRaises(TypeError, BadDescription, self.project_id,
+                          self.dataset_id, self.sandbox_dataset_id)
+
+        self.assertRaises(TypeError, BadIssueNumbers, self.project_id,
+                          self.dataset_id, self.sandbox_dataset_id)
+
+        self.assertRaises(TypeError, BadIssueUrls, self.project_id,
+                          self.dataset_id, self.sandbox_dataset_id)
+
+    @patch.object(Inheritance, 'get_query_specs')
+    def test_log_queries(self, mock_query_list):
+        """
+        Test logging queries and its error handling.
+        """
+        mock_query_list.return_value = [{
+            'query': 'select count(*) from `foo.bar.baz`'
+        }, {}]
+
+        alpha = Inheritance(self.project_id, self.dataset_id,
+                            self.sandbox_dataset_id)
+
+        with self.assertLogs(level='INFO') as cm:
+            # test
+            alpha.log_queries()
+
+            # post conditions
+            self.assertEqual(cm.output, [
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                'select count(*) from `foo.bar.baz`',
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                'NO QUERY FOUND'
+            ])
+
+    @patch.object(Inheritance, 'get_query_specs')
+    def test_log_queries_all_errors(self, mock_query_list):
+        """
+        Test logging queries and its error handling.
+        """
+        error_list = [
+            KeyError('bad fake key'),
+            oauth2client.client.HttpAccessTokenRefreshError(
+                'bad refresh token'),
+            googleapiclient.errors.HttpError(b'404', b'bad http error')
+        ]
+        mock_query_list.side_effect = error_list
+
+        alpha = Inheritance(self.project_id, self.dataset_id,
+                            self.sandbox_dataset_id)
+
+        for err in error_list:
+            with self.assertLogs(level='INFO') as cm:
+                # test
+                self.assertRaises(err.__class__, alpha.log_queries)
+
+                # post conditions
+                expected_msg = (
+                    'ERROR:cdr_cleaner.cleaning_rules.base_cleaning_rule:'
+                    'Cannot list queries for Inheritance')
+                self.assertEqual([cm.output[0][:len(expected_msg)]],
+                                 [expected_msg])


### PR DESCRIPTION
* Setting up a base class for Cleaning Rules to Inherit from.
* Modifying the current rdr pipeline to accept class or function names.
* Setting the pipeline up to only accept instances of a BaseClass in the future.
* Allows the base class to store project_id, dataset_id, sandbox_dataset_id,
  affected datasets, jira issue numbers, and a common language description of each rule.
* Updates the gather_<dataset>_queries functions to use a single helper module.
* Currently allows backwards compatability to work with existing function calls.
* Allows new rules to be added to a list of classes to call.  Removes a lot of boiler plate code.
* Updates the logging to add the logging handler to the root handler instead
  the engine logger.
* Adds two new common command line parameters:  one for a sandbox dataset and one for
  listing the queries only.
* Makes use of an AbstractBaseCleaningRule to help with type hints
* Makes the BaseCleaningRule an abstract class
* Makes setup processes explicit and expects you to define something as a pass if no action is needed.