### PR TITLE
[DC-529] Remove irrelevant observation_source_concept_ids from the RDR Export

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -498,19 +498,31 @@ if __name__ == '__main__':
     parser.add_argument('-s', action='store_true', help='Send logs to console')
     args = parser.parse_args()
     clean_engine.add_console_logging(args.s)
-    if args.data_stage == stage.EHR:
-        clean_ehr_dataset()
-    elif args.data_stage == stage.UNIONED:
-        clean_unioned_ehr_dataset()
-    elif args.data_stage == stage.RDR:
-        clean_rdr_dataset()
-    elif args.data_stage == stage.COMBINED:
-        clean_combined_dataset()
-    elif args.data_stage == stage.DEID_BASE:
-        clean_combined_de_identified_dataset()
-    elif args.data_stage == stage.DEID_CLEAN:
-        clean_combined_de_identified_clean_dataset()
-    else:
-        raise EnvironmentError(
-            f'Dataset selection should be from [{stage.EHR}, {stage.UNIONED}, {stage.RDR}, {stage.COMBINED},'
-            f' {stage.DEID_BASE}, {stage.DEID_CLEAN}]')
+    #    if args.data_stage == stage.EHR:
+    #        clean_ehr_dataset()
+    #    elif args.data_stage == stage.UNIONED:
+    #        clean_unioned_ehr_dataset()
+    #    elif args.data_stage == stage.RDR:
+    #        clean_rdr_dataset()
+    #    elif args.data_stage == stage.COMBINED:
+    #        clean_combined_dataset()
+    #    elif args.data_stage == stage.DEID_BASE:
+    #        clean_combined_de_identified_dataset()
+    #    elif args.data_stage == stage.DEID_CLEAN:
+    #        clean_combined_de_identified_clean_dataset()
+    #    else:
+    #        raise EnvironmentError(
+    #            f'Dataset selection should be from [{stage.EHR}, {stage.UNIONED}, {stage.RDR}, {stage.COMBINED},'
+    #            f' {stage.DEID_BASE}, {stage.DEID_CLEAN}]')
+
+    #    res = gather_test_query()
+    #    res = _gather_deid_clean_cleaning_queries('foo', 'bar', 'baz')
+    res = _gather_combined_queries('foo', 'bar', 'baz')
+    #    res = _gather_ehr_queries('foo', 'bar', 'baz')
+    #    res = _gather_deid_base_cleaning_queries('foo', 'bar', 'baz')
+    #    res = _gather_unioned_ehr_queries('foo', 'bar', 'baz')
+    #    res = _gather_rdr_queries('foo', 'bar', 'baz')
+    for item in res:
+        for k, v in item.items():
+            print('{}\t\t\t{}'.format(k, v))
+        print('--------------------------------------------------------\n\n')

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -498,31 +498,19 @@ if __name__ == '__main__':
     parser.add_argument('-s', action='store_true', help='Send logs to console')
     args = parser.parse_args()
     clean_engine.add_console_logging(args.s)
-    #    if args.data_stage == stage.EHR:
-    #        clean_ehr_dataset()
-    #    elif args.data_stage == stage.UNIONED:
-    #        clean_unioned_ehr_dataset()
-    #    elif args.data_stage == stage.RDR:
-    #        clean_rdr_dataset()
-    #    elif args.data_stage == stage.COMBINED:
-    #        clean_combined_dataset()
-    #    elif args.data_stage == stage.DEID_BASE:
-    #        clean_combined_de_identified_dataset()
-    #    elif args.data_stage == stage.DEID_CLEAN:
-    #        clean_combined_de_identified_clean_dataset()
-    #    else:
-    #        raise EnvironmentError(
-    #            f'Dataset selection should be from [{stage.EHR}, {stage.UNIONED}, {stage.RDR}, {stage.COMBINED},'
-    #            f' {stage.DEID_BASE}, {stage.DEID_CLEAN}]')
-
-    #    res = gather_test_query()
-    #    res = _gather_deid_clean_cleaning_queries('foo', 'bar', 'baz')
-    res = _gather_combined_queries('foo', 'bar', 'baz')
-    #    res = _gather_ehr_queries('foo', 'bar', 'baz')
-    #    res = _gather_deid_base_cleaning_queries('foo', 'bar', 'baz')
-    #    res = _gather_unioned_ehr_queries('foo', 'bar', 'baz')
-    #    res = _gather_rdr_queries('foo', 'bar', 'baz')
-    for item in res:
-        for k, v in item.items():
-            print('{}\t\t\t{}'.format(k, v))
-        print('--------------------------------------------------------\n\n')
+    if args.data_stage == stage.EHR:
+        clean_ehr_dataset()
+    elif args.data_stage == stage.UNIONED:
+        clean_unioned_ehr_dataset()
+    elif args.data_stage == stage.RDR:
+        clean_rdr_dataset()
+    elif args.data_stage == stage.COMBINED:
+        clean_combined_dataset()
+    elif args.data_stage == stage.DEID_BASE:
+        clean_combined_de_identified_dataset()
+    elif args.data_stage == stage.DEID_CLEAN:
+        clean_combined_de_identified_clean_dataset()
+    else:
+        raise EnvironmentError(
+            f'Dataset selection should be from [{stage.EHR}, {stage.UNIONED}, {stage.RDR}, {stage.COMBINED},'
+            f' {stage.DEID_BASE}, {stage.DEID_CLEAN}]')

--- a/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression.py
@@ -1,0 +1,116 @@
+"""
+Removing three irrelevant observation_source_concept_ids from the RDR dataset.
+
+Original Issue:  DC-529
+
+The intent is to remove PPI records from the observation table in the RDR
+export where observation_source_concept_id in (43530490, 43528818, 43530333).
+The records for removal should be archived in the dataset sandbox.
+"""
+# Python Imports
+import logging
+
+# Project imports
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from constants.bq_utils import WRITE_TRUNCATE
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+
+LOGGER = logging.getLogger(__name__)
+
+SAVE_TABLE_NAME = 'dc_529_obs_rows_dropped'
+
+DROP_SELECTION_QUERY = (
+    'CREATE OR REPLACE TABLE `{project}.{sandbox}.{drop_table}` AS '
+    'SELECT * '
+    'FROM `{project}.{dataset}.observation` '
+    'WHERE observation_source_concept_id IN (43530490, 43528818, 43530333)')
+
+DROP_QUERY = (
+    'SELECT * FROM `{project}.{dataset}.observation` AS o '
+    'WHERE NOT EXISTS ( '
+    '  SELECT 1 '
+    '  FROM `{project}.{dataset}.observation` AS n '
+    '  WHERE o.observation_id = n.observation_id AND '
+    '  n.observation_source_concept_id IN (43530490, 43528818, 43530333) '
+    ')')
+
+
+class ObservationSourceConceptIDRowSuppression(BaseCleaningRule):
+    """
+    Suppress rows by values in the observation_source_concept_id field.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper info.
+
+        Set the issue numbers, description and affected datasets.  As other
+        tickets may affect this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = (
+            'Remove records from the rdr dataset where '
+            'observation_source_concept_id in (43530490, 43528818, 43530333)')
+        super().__init__(jira_issue_numbers=['DC-529'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_dictionary_list(self):
+        """
+        Get dictionary list of queries to execute.
+
+        :param project_id:  The project to query.
+        :param dataset_id:  The dataset to query.
+        :param sandbox_id:  The sandbox dataset id to store intermediate
+            results in.
+
+        :return:  A list of dictionaries.  Each contains a single query.
+            They may contain optional parameters describing the query.
+        """
+        save_dropped_rows = {
+            cdr_consts.QUERY:
+                DROP_SELECTION_QUERY.format(
+                    project=self.get_project_id(),
+                    dataset=self.get_dataset_id(),
+                    sandbox=self.get_sandbox_dataset_id(),
+                    drop_table=SAVE_TABLE_NAME),
+        }
+
+        drop_rows_query = {
+            cdr_consts.QUERY:
+                DROP_QUERY.format(project=self.get_project_id(),
+                                  dataset=self.get_dataset_id()),
+            cdr_consts.DESTINATION_TABLE:
+                'observation',
+            cdr_consts.DESTINATION_DATASET:
+                self.get_dataset_id(),
+            cdr_consts.DISPOSITION:
+                WRITE_TRUNCATE
+        }
+
+        return [save_dropped_rows, drop_rows_query]
+
+    def setup_query_execution(self):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.parse_args()
+    clean_engine.add_console_logging(ARGS.console_log)
+    rdr_cleaner = ObservationSourceConceptIDRowSuppression(
+        ARGS.project_id, ARGS.dataset_id, ARGS.sandbox_dataset_id)
+    query_list = rdr_cleaner.get_query_dictionary_list()
+
+    if ARGS.list_queries:
+        rdr_cleaner.print_queries()
+    else:
+        clean_engine.clean_dataset(ARGS.project_id, query_list)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
@@ -1,0 +1,57 @@
+"""
+Unit Test for the rdr_observation_source_concept_id_suppression module.
+
+Remove three irrelevant observation_source_concept_ids from the RDR dataset.
+
+Original Issue:  DC-529
+
+The intent is to remove PPI records from the observation table in the RDR
+export where observation_source_concept_id in (43530490, 43528818, 43530333).
+The records for removal should be archived in the dataset sandbox.
+"""
+# Python imports
+import unittest
+
+# Third party imports
+
+# Project imports
+from constants.bq_utils import WRITE_TRUNCATE
+from constants.cdr_cleaner import clean_cdr as clean_consts
+from cdr_cleaner.cleaning_rules.rdr_observation_source_concept_id_suppression import ObservationSourceConceptIDRowSuppression, SAVE_TABLE_NAME, DROP_SELECTION_QUERY, DROP_QUERY
+
+
+class ObservationSourceConceptIDRowSuppressionTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.query_class = ObservationSourceConceptIDRowSuppression(
+            'foo', 'bar', 'baz')
+
+    def test_get_query_dictionary_list(self):
+        # pre-conditions
+        self.assertEqual(self.query_class.get_affected_datasets(),
+                         [clean_consts.RDR])
+
+        # test
+        result_list = self.query_class.get_query_dictionary_list()
+
+        # post conditions
+        expected_list = [{
+            clean_consts.QUERY:
+                DROP_SELECTION_QUERY.format(project='foo',
+                                            dataset='bar',
+                                            sandbox='baz',
+                                            drop_table=SAVE_TABLE_NAME)
+        }, {
+            clean_consts.QUERY: DROP_QUERY.format(project='foo', dataset='bar'),
+            clean_consts.DESTINATION_TABLE: 'observation',
+            clean_consts.DESTINATION_DATASET: 'bar',
+            clean_consts.DISPOSITION: WRITE_TRUNCATE
+        }]
+
+        self.assertEqual(result_list, expected_list)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
@@ -29,29 +29,75 @@ class ObservationSourceConceptIDRowSuppressionTest(unittest.TestCase):
         print('**************************************************************')
 
     def setUp(self):
-        self.query_class = ObservationSourceConceptIDRowSuppression(
-            'foo', 'bar', 'baz')
+        self.project_id = 'foo'
+        self.dataset_id = 'bar'
+        self.sandbox_id = 'baz'
 
-    def test_get_query_dictionary_list(self):
+        self.query_class = ObservationSourceConceptIDRowSuppression(
+            self.project_id, self.dataset_id, self.sandbox_id)
+
+        self.assertEqual(self.query_class.get_project_id(), self.project_id)
+        self.assertEqual(self.query_class.get_dataset_id(), self.dataset_id)
+        self.assertEqual(self.query_class.get_sandbox_dataset_id(),
+                         self.sandbox_id)
+
+    def test_setup_rule(self):
+        # test
+        alpha = self.query_class.setup_rule()
+
+        # post conditions
+        self.assertEqual(alpha, None)
+
+    def test_get_query_specs(self):
         # pre-conditions
         self.assertEqual(self.query_class.get_affected_datasets(),
                          [clean_consts.RDR])
 
         # test
-        result_list = self.query_class.get_query_dictionary_list()
+        result_list = self.query_class.get_query_specs()
 
         # post conditions
         expected_list = [{
             clean_consts.QUERY:
-                DROP_SELECTION_QUERY.format(project='foo',
-                                            dataset='bar',
-                                            sandbox='baz',
+                DROP_SELECTION_QUERY.format(project=self.project_id,
+                                            dataset=self.dataset_id,
+                                            sandbox=self.sandbox_id,
                                             drop_table=SAVE_TABLE_NAME)
         }, {
-            clean_consts.QUERY: DROP_QUERY.format(project='foo', dataset='bar'),
-            clean_consts.DESTINATION_TABLE: 'observation',
-            clean_consts.DESTINATION_DATASET: 'bar',
-            clean_consts.DISPOSITION: WRITE_TRUNCATE
+            clean_consts.QUERY:
+                DROP_QUERY.format(project=self.project_id,
+                                  dataset=self.dataset_id),
+            clean_consts.DESTINATION_TABLE:
+                'observation',
+            clean_consts.DESTINATION_DATASET:
+                self.dataset_id,
+            clean_consts.DISPOSITION:
+                WRITE_TRUNCATE
         }]
 
         self.assertEqual(result_list, expected_list)
+
+    def test_log_queries(self):
+        # pre-conditions
+        self.assertEqual(self.query_class.get_affected_datasets(),
+                         [clean_consts.RDR])
+
+        store_drops = DROP_SELECTION_QUERY.format(project=self.project_id,
+                                                  dataset=self.dataset_id,
+                                                  sandbox=self.sandbox_id,
+                                                  drop_table=SAVE_TABLE_NAME)
+        select_saves = DROP_QUERY.format(project=self.project_id,
+                                         dataset=self.dataset_id)
+        # test
+        with self.assertLogs(level='INFO') as cm:
+            self.query_class.log_queries()
+
+            expected = [
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                + store_drops,
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                + select_saves
+            ]
+
+            # post condition
+            self.assertEqual(cm.output, expected)


### PR DESCRIPTION
* Contains an application of using the base class to instantiate a rule.
* Adds a unit test of the new cleaning rule.
* adds a cleaning rule to sandbox rows removed and then remove rows where
observation_source_concept_id IN ((43530490, 43528818, 43530333)

