### PR TITLE
[DC-529]  pylint fix on test module

### DIFF
--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py
@@ -43,10 +43,9 @@ class ObservationSourceConceptIDRowSuppressionTest(unittest.TestCase):
 
     def test_setup_rule(self):
         # test
-        alpha = self.query_class.setup_rule()
+        self.query_class.setup_rule()
 
-        # post conditions
-        self.assertEqual(alpha, None)
+        # no errors are raised, nothing happens
 
     def test_get_query_specs(self):
         # pre-conditions


### PR DESCRIPTION
* modifying unit test module `curation/unit_tests/data_steward/cdr_cleaner/cleaning_rules/rdr_observation_source_concept_id_suppression_test.py` for a pylint fix