### PR TITLE
[EDQ-414] Create 'erroneous date' data quality metric notebook

### DIFF
--- a/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
@@ -70,7 +70,8 @@ thresholds = {
     'unit_success_min': 85,
     'route_success_min': 85,
 
-    'date_datetime_disparity_max': 0
+    'date_datetime_disparity_max': 0,
+    'erroneous_dates_max': 0
 }
 
 
@@ -84,7 +85,8 @@ choice_dict = {
     'g': 'drug_success',
     'h': 'sites_measurement',
     'i': 'visit_date_disparity',
-    'j': 'date_datetime_disparity'}
+    'j': 'date_datetime_disparity',
+    'k': 'erroneous_dates'}
 
 percentage_dict = {
     'duplicates': False,
@@ -96,7 +98,8 @@ percentage_dict = {
     'drug_success': True,
     'sites_measurement': True,
     'visit_date_disparity': True,
-    'date_datetime_disparity': True
+    'date_datetime_disparity': True,
+    'erroneous_dates': True
 }
 
 target_low_dict = {
@@ -109,7 +112,8 @@ target_low_dict = {
     'drug_success': False,
     'sites_measurement': False,
     'visit_date_disparity': False,
-    'date_datetime_disparity': True
+    'date_datetime_disparity': True,
+    'erroneous_dates': True
 }
 
 columns_to_document_for_sheet = {
@@ -153,6 +157,12 @@ columns_to_document_for_sheet = {
         'measurement_success_rate', 'visit_success_rate'],
 
     'date_datetime_disparity': [
+        'visit_occurrence', 'condition_occurrence',
+        'drug_exposure', 'measurement',
+        'procedure_occurrence', 'observation'
+    ],
+
+    'erroneous_dates': [
         'visit_occurrence', 'condition_occurrence',
         'drug_exposure', 'measurement',
         'procedure_occurrence', 'observation'
@@ -213,7 +223,8 @@ data_quality_dimension_dict = {
     'drug_success': 'Completeness',
     'drug_routes': 'Completeness',
     'measurement_units': 'Completeness',
-    'date_datetime_disparity': 'Conformance'
+    'date_datetime_disparity': 'Conformance',
+    'erroneous_dates': 'Plausibility'
 }
 
 metric_type_to_english_dict = {
@@ -232,14 +243,16 @@ metric_type_to_english_dict = {
 
     # other metrics
     'concept': 'Concept ID Success Rate',
-    'duplicates': 'Duplicate Records'
+    'duplicates': 'Duplicate Records',
+    'erroneous_dates': 'Erroneous Dates'
 }
 
 metrics_to_weight = [
     'measurement_units', 'drug_routes',
     'end_before_begin', 'data_after_death',
     'concept', 'duplicates',
-    'date_datetime_disparity']
+    'date_datetime_disparity',
+    'erroneous_dates']
 
 full_names = {
     "saou_uab_selma": "UAB Selma",

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
@@ -60,7 +60,7 @@ def establish_hpo_objects(dqm_objects):
               end_before_begin=[], data_after_death=[],
               route_success=[], unit_success=[],
               measurement_integration=[], ingredient_integration=[],
-              date_datetime_disp=[])
+              date_datetime_disp=[], erroneous_dates=[])
 
             blank_hpo_objects.append(hpo)
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/messages.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/messages.py
@@ -40,7 +40,8 @@ analysis_type_prompt = \
         "G. Percentage of expected drug ingredients observed\n" \
         "H. Percentage of expected measurements observed\n" \
         "I. Date consistency across tables \n" \
-        "J. Date/datetime inconsistencies \n\n" \
+        "J. Date/datetime inconsistencies \n" \
+        "K. Erroneous dates \n\n" \
         "Please specify your choice by typing the corresponding letter."
 
 output_prompt = \

--- a/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
@@ -327,7 +327,7 @@ def main():
     create_excel_files(
         metric_choice=user_choice,
         sheet_output=sheet_output,
-        df_dict = dataframes_dict)
+        df_dict=dataframes_dict)
 
 
 if __name__ == "__main__":

--- a/data_steward/analytics/table_metrics/weekly_scripts/erroneous_dates.py
+++ b/data_steward/analytics/table_metrics/weekly_scripts/erroneous_dates.py
@@ -1,0 +1,583 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.3.0
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# ### This notebook is intended to show the percentage of rows where there are 'erroneous dates' in the 6 canonical tables. The 6 canonical tables are as follows:
+# - Condition Occurrence
+# - Procedure Occurrence
+# - Visit Occurrence
+# - Drug Exposure
+# - Measurement
+# - Observation
+#
+# ### Erroneous dates are those that precede 1900 for the observation table or precede 1980 for all other tables
+
+# +
+from google.cloud import bigquery
+
+# %reload_ext google.cloud.bigquery
+
+client = bigquery.Client()
+
+# %load_ext google.cloud.bigquery
+
+# +
+from notebooks import parameters
+DATASET = parameters.LATEST_DATASET
+
+print("Dataset to use: {DATASET}".format(DATASET = DATASET))
+
+# +
+#######################################
+print('Setting everything up...')
+#######################################
+
+import warnings
+
+warnings.filterwarnings('ignore')
+import pandas as pd
+import matplotlib.pyplot as plt
+# %matplotlib inline
+import os
+
+
+plt.style.use('ggplot')
+pd.options.display.max_rows = 999
+pd.options.display.max_columns = 999
+pd.options.display.max_colwidth = 999
+
+
+def cstr(s, color='black'):
+    return "<text style=color:{}>{}</text>".format(color, s)
+
+
+print('done.')
+# -
+
+cwd = os.getcwd()
+cwd = str(cwd)
+print("Current working directory is: {cwd}".format(cwd=cwd))
+
+# +
+dic = {
+    'src_hpo_id': [
+        "saou_uab_selma", "saou_uab_hunt", "saou_tul", "pitt_temple",
+        "saou_lsu", "trans_am_meyers", "trans_am_essentia", "saou_ummc",
+        "seec_miami", "seec_morehouse", "seec_emory", "uamc_banner", "pitt",
+        "nyc_cu", "ipmc_uic", "trans_am_spectrum", "tach_hfhs", "nec_bmc",
+        "cpmc_uci", "nec_phs", "nyc_cornell", "ipmc_nu", "nyc_hh",
+        "ipmc_uchicago", "aouw_mcri", "syhc", "cpmc_ceders", "seec_ufl",
+        "saou_uab", "trans_am_baylor", "cpmc_ucsd", "ecchc", "chci", "aouw_uwh",
+        "cpmc_usc", "hrhc", "ipmc_northshore", "chs", "cpmc_ucsf", "jhchc",
+        "aouw_mcw", "cpmc_ucd", "ipmc_rush", "va", "saou_umc"
+    ],
+    'HPO': [
+        "UAB Selma", "UAB Huntsville", "Tulane University", "Temple University",
+        "Louisiana State University",
+        "Reliant Medical Group (Meyers Primary Care)",
+        "Essentia Health Superior Clinic", "University of Mississippi",
+        "SouthEast Enrollment Center Miami",
+        "SouthEast Enrollment Center Morehouse",
+        "SouthEast Enrollment Center Emory", "Banner Health",
+        "University of Pittsburgh", "Columbia University Medical Center",
+        "University of Illinois Chicago", "Spectrum Health",
+        "Henry Ford Health System", "Boston Medical Center", "UC Irvine",
+        "Partners HealthCare", "Weill Cornell Medical Center",
+        "Northwestern Memorial Hospital", "Harlem Hospital",
+        "University of Chicago", "Marshfield Clinic",
+        "San Ysidro Health Center", "Cedars-Sinai", "University of Florida",
+        "University of Alabama at Birmingham", "Baylor", "UC San Diego",
+        "Eau Claire Cooperative Health Center", "Community Health Center, Inc.",
+        "UW Health (University of Wisconsin Madison)",
+        "University of Southern California", "HRHCare",
+        "NorthShore University Health System", "Cherokee Health Systems",
+        "UC San Francisco", "Jackson-Hinds CHC", "Medical College of Wisconsin",
+        "UC Davis", "Rush University", 
+        "United States Department of Veterans Affairs - Boston",
+        "University Medical Center (UA Tuscaloosa)"
+    ]
+}
+
+site_df = pd.DataFrame(data=dic)
+site_df
+
+# +
+######################################
+print('Getting the data from the database...')
+######################################
+
+site_map = pd.io.gbq.read_gbq('''
+    select distinct * from (
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_visit_occurrence`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_care_site`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_condition_occurrence`  
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_device_exposure`
+
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_drug_exposure`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_location`         
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_measurement`         
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_note`        
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_observation`         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_person`         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_procedure_occurrence`         
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_provider`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_specimen`
+    
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_visit_occurrence`   
+    )     
+    '''.format(DATASET=DATASET),
+                              dialect='standard')
+print(site_map.shape[0], 'records received.')
+# -
+
+site_df = pd.merge(site_map, site_df, how='outer', on='src_hpo_id')
+site_df
+
+# ## Observation Table
+
+observation_query = """
+SELECT
+total.src_hpo_id,
+-- IFNULL(bad_date.num_bad_rows, 0) AS num_bad_rows, 
+-- IFNULL(total.num_rows, 0) AS num_rows,
+ROUND(IFNULL(bad_date.num_bad_rows, 0) / IFNULL(total.num_rows, 0) * 100 , 2) as observation
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mo.src_hpo_id, COUNT(*) as num_rows
+  FROM
+  `{DATASET}.unioned_ehr_observation` o
+  JOIN
+  `{DATASET}._mapping_observation` mo
+  ON
+  o.observation_id = mo.observation_id
+  GROUP BY 1
+  ORDER BY num_rows DESC) total
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mo.src_hpo_id, COUNT(*) as num_bad_rows
+  FROM
+  `{DATASET}.unioned_ehr_observation` o
+  JOIN
+  `{DATASET}._mapping_observation` mo
+  ON
+  o.observation_id = mo.observation_id
+  WHERE
+  o.observation_datetime < CAST('1900-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  o.observation_date < CAST('1900-01-01' as DATE)
+  GROUP BY 1
+  ORDER BY num_bad_rows DESC) bad_date
+  
+ON
+bad_date.src_hpo_id = total.src_hpo_id
+
+GROUP BY 1, 2 --, 3, 4
+ORDER BY observation DESC
+""".format(DATASET=DATASET)
+
+observation_df = pd.io.gbq.read_gbq(observation_query, dialect ='standard')
+
+observation_df
+
+# ## Condition Occurrence Table
+
+condition_query = """
+SELECT
+total.src_hpo_id,
+-- IFNULL(bad_date.num_bad_rows, 0) AS num_bad_rows, 
+-- IFNULL(total.num_rows, 0) AS num_rows,
+ROUND(IFNULL(bad_date.num_bad_rows, 0) / IFNULL(total.num_rows, 0) * 100 , 2) as condition_occurrence
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mco.src_hpo_id, COUNT(*) as num_rows
+  FROM
+  `{DATASET}.unioned_ehr_condition_occurrence` co
+  JOIN
+  `{DATASET}._mapping_condition_occurrence` mco
+  ON
+  co.condition_occurrence_id = mco.condition_occurrence_id
+  GROUP BY 1
+  ORDER BY num_rows DESC) total
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mco.src_hpo_id, COUNT(*) as num_bad_rows
+  FROM
+  `{DATASET}.unioned_ehr_condition_occurrence` co
+  JOIN
+  `{DATASET}._mapping_condition_occurrence` mco
+  ON
+  co.condition_occurrence_id = mco.condition_occurrence_id
+  
+  WHERE
+  co.condition_start_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  co.condition_start_date < CAST('1980-01-01' as DATE)
+  
+  OR
+  
+  co.condition_end_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  co.condition_end_date < CAST('1980-01-01' as DATE)
+  
+  GROUP BY 1
+  ORDER BY num_bad_rows DESC) bad_date
+  
+ON
+bad_date.src_hpo_id = total.src_hpo_id
+
+GROUP BY 1, 2 --, 3, 4
+ORDER BY condition_occurrence DESC
+""".format(DATASET=DATASET)
+
+condition_occurrence_df = pd.io.gbq.read_gbq(condition_query, dialect ='standard')
+
+condition_occurrence_df
+
+# ## Procedure Occurrence Table
+
+procedure_query = """
+SELECT
+total.src_hpo_id,
+-- IFNULL(bad_date.num_bad_rows, 0) AS num_bad_rows, 
+-- IFNULL(total.num_rows, 0) AS num_rows,
+ROUND(IFNULL(bad_date.num_bad_rows, 0) / IFNULL(total.num_rows, 0) * 100 , 2) as procedure_occurrence
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mpo.src_hpo_id, COUNT(*) as num_rows
+  FROM
+  `{DATASET}.unioned_ehr_procedure_occurrence` po
+  JOIN
+  `{DATASET}._mapping_procedure_occurrence` mpo
+  ON
+  po.procedure_occurrence_id = mpo.procedure_occurrence_id
+  GROUP BY 1
+  ORDER BY num_rows DESC) total
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mpo.src_hpo_id, COUNT(*) as num_bad_rows
+  FROM
+  `{DATASET}.unioned_ehr_procedure_occurrence` po
+  JOIN
+  `{DATASET}._mapping_procedure_occurrence` mpo
+  ON
+  po.procedure_occurrence_id = mpo.procedure_occurrence_id
+  
+  WHERE
+  po.procedure_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  po.procedure_date < CAST('1980-01-01' as DATE)
+  
+  GROUP BY 1
+  ORDER BY num_bad_rows DESC) bad_date
+  
+ON
+bad_date.src_hpo_id = total.src_hpo_id
+
+GROUP BY 1, 2 --, 3, 4
+ORDER BY procedure_occurrence DESC
+""".format(DATASET=DATASET)
+
+procedure_occurrence_df = pd.io.gbq.read_gbq(procedure_query, dialect ='standard')
+
+procedure_occurrence_df
+
+# ## Visit Occurrence
+
+visit_query = """
+SELECT
+total.src_hpo_id,
+-- IFNULL(bad_date.num_bad_rows, 0) AS num_bad_rows, 
+-- IFNULL(total.num_rows, 0) AS num_rows,
+ROUND(IFNULL(bad_date.num_bad_rows, 0) / IFNULL(total.num_rows, 0) * 100 , 2) as visit_occurrence
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mvo.src_hpo_id, COUNT(*) as num_rows
+  FROM
+  `{DATASET}.unioned_ehr_visit_occurrence` vo
+  JOIN
+  `{DATASET}._mapping_visit_occurrence` mvo
+  ON
+  vo.visit_occurrence_id = mvo.visit_occurrence_id
+  GROUP BY 1
+  ORDER BY num_rows DESC) total
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mvo.src_hpo_id, COUNT(*) as num_bad_rows
+  FROM
+  `{DATASET}.unioned_ehr_visit_occurrence` vo
+  JOIN
+  `{DATASET}._mapping_visit_occurrence` mvo
+  ON
+  vo.visit_occurrence_id = mvo.visit_occurrence_id
+  
+  WHERE
+  vo.visit_start_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  vo.visit_start_date < CAST('1980-01-01' as DATE)
+  
+  OR
+  
+  vo.visit_end_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  vo.visit_end_date < CAST('1980-01-01' as DATE)
+  
+  GROUP BY 1
+  ORDER BY num_bad_rows DESC) bad_date
+  
+ON
+bad_date.src_hpo_id = total.src_hpo_id
+
+GROUP BY 1, 2 --, 3, 4
+ORDER BY visit_occurrence DESC
+""".format(DATASET=DATASET)
+
+visit_occurrence_df = pd.io.gbq.read_gbq(visit_query, dialect ='standard')
+
+visit_occurrence_df
+
+# # Drug Exposure
+
+drug_query = """
+SELECT
+total.src_hpo_id,
+-- IFNULL(bad_date.num_bad_rows, 0) AS num_bad_rows, 
+-- IFNULL(total.num_rows, 0) AS num_rows,
+ROUND(IFNULL(bad_date.num_bad_rows, 0) / IFNULL(total.num_rows, 0) * 100 , 2) as drug_exposure
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mde.src_hpo_id, COUNT(*) as num_rows
+  FROM
+  `{DATASET}.unioned_ehr_drug_exposure` de
+  JOIN
+  `{DATASET}._mapping_drug_exposure` mde
+  ON
+  de.drug_exposure_id = mde.drug_exposure_id
+  GROUP BY 1
+  ORDER BY num_rows DESC) total
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mde.src_hpo_id, COUNT(*) as num_bad_rows
+  FROM
+  `{DATASET}.unioned_ehr_drug_exposure` de
+  JOIN
+  `{DATASET}._mapping_drug_exposure` mde
+  ON
+  de.drug_exposure_id = mde.drug_exposure_id
+  
+  WHERE
+  de.drug_exposure_start_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  de.drug_exposure_start_date < CAST('1980-01-01' as DATE)
+  
+  OR
+  
+  de.drug_exposure_end_datetime < CAST('1980-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  de.drug_exposure_end_date < CAST('1980-01-01' as DATE)
+  
+  GROUP BY 1
+  ORDER BY num_bad_rows DESC) bad_date
+  
+ON
+bad_date.src_hpo_id = total.src_hpo_id
+
+GROUP BY 1, 2 --, 3, 4
+ORDER BY drug_exposure DESC
+""".format(DATASET=DATASET)
+
+drug_exposure_df = pd.io.gbq.read_gbq(drug_query, dialect ='standard')
+
+drug_exposure_df
+
+# ## Measurement
+
+measurement_query = """
+SELECT
+total.src_hpo_id,
+-- IFNULL(bad_date.num_bad_rows, 0) AS num_bad_rows, 
+-- IFNULL(total.num_rows, 0) AS num_rows,
+ROUND(IFNULL(bad_date.num_bad_rows, 0) / IFNULL(total.num_rows, 0) * 100 , 2) as measurement
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mm.src_hpo_id, COUNT(*) as num_rows
+  FROM
+  `{DATASET}.unioned_ehr_measurement` m
+  JOIN
+  `{DATASET}._mapping_measurement` mm
+  ON
+  m.measurement_id = mm.measurement_id
+  GROUP BY 1
+  ORDER BY num_rows DESC) total
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mm.src_hpo_id, COUNT(*) as num_bad_rows
+  FROM
+  `{DATASET}.unioned_ehr_measurement` m
+  JOIN
+  `{DATASET}._mapping_measurement` mm
+  ON
+  m.measurement_id = mm.measurement_id
+  WHERE
+  m.measurement_datetime < CAST('1900-01-01 00:00:00' AS TIMESTAMP)
+  OR
+  m.measurement_date < CAST('1900-01-01' as DATE)
+  GROUP BY 1
+  ORDER BY num_bad_rows DESC) bad_date
+  
+ON
+bad_date.src_hpo_id = total.src_hpo_id
+
+GROUP BY 1, 2 --, 3, 4
+ORDER BY measurement DESC
+""".format(DATASET=DATASET)
+
+measurement_df = pd.io.gbq.read_gbq(measurement_query, dialect ='standard')
+
+measurement_df
+
+# ## Bring it all together
+
+# +
+erroneous_date_df = pd.merge(
+    site_df, observation_df, how='outer', on='src_hpo_id')
+
+erroneous_date_df = pd.merge(
+    erroneous_date_df, measurement_df, how='outer', on='src_hpo_id')
+
+erroneous_date_df = pd.merge(
+    erroneous_date_df, visit_occurrence_df, how='outer', on='src_hpo_id')
+
+erroneous_date_df = pd.merge(
+    erroneous_date_df, procedure_occurrence_df, how='outer', on='src_hpo_id')
+
+erroneous_date_df = pd.merge(
+    erroneous_date_df, drug_exposure_df, how='outer', on='src_hpo_id')
+
+erroneous_date_df = pd.merge(
+    erroneous_date_df, condition_occurrence_df, how='outer', on='src_hpo_id')
+
+# +
+erroneous_date_df = erroneous_date_df.fillna(0)
+
+erroneous_date_df
+# -
+
+erroneous_date_df.to_csv("{cwd}/erroneous_dates.csv".format(cwd = cwd))
+
+


### PR DESCRIPTION
* Includes a notebook that calculates the percentage of 'erroneous dates' for the following tables: condition_occurrence, procedure_occurrence, visit_occurrence, drug_exposure, measurement, observation. Erroneous dates are those that are prior to 1900 for the observation table and prior to 1980 for all of the other tables.

* Changed the metrics_over_time library to accommodate for this new metric (part of EDQ-425)

* Validated the output for the resulting metrics_over_time script