### PR TITLE
[EDQ-418] Create 'Foreign Key' Notebook (for invalid person_ids)

### DIFF
--- a/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
@@ -70,8 +70,9 @@ thresholds = {
     'unit_success_min': 85,
     'route_success_min': 85,
 
-    'date_datetime_disparity_max': 0,
-    'erroneous_dates_max': 0
+    'date_datetime_disparity_max': 0.01,
+    'erroneous_dates_max': 0.01,
+    'person_failure_rate_max': 0.01
 }
 
 
@@ -86,7 +87,8 @@ choice_dict = {
     'h': 'sites_measurement',
     'i': 'visit_date_disparity',
     'j': 'date_datetime_disparity',
-    'k': 'erroneous_dates'}
+    'k': 'erroneous_dates',
+    'l': 'person_id_failure_rate'}
 
 percentage_dict = {
     'duplicates': False,
@@ -99,7 +101,8 @@ percentage_dict = {
     'sites_measurement': True,
     'visit_date_disparity': True,
     'date_datetime_disparity': True,
-    'erroneous_dates': True
+    'erroneous_dates': True,
+    'person_id_failure_rate': True
 }
 
 target_low_dict = {
@@ -113,7 +116,8 @@ target_low_dict = {
     'sites_measurement': False,
     'visit_date_disparity': False,
     'date_datetime_disparity': True,
-    'erroneous_dates': True
+    'erroneous_dates': True,
+    'person_id_failure_rate': True
 }
 
 columns_to_document_for_sheet = {
@@ -166,7 +170,12 @@ columns_to_document_for_sheet = {
         'visit_occurrence', 'condition_occurrence',
         'drug_exposure', 'measurement',
         'procedure_occurrence', 'observation'
-    ]
+    ],
+
+    'person_id_failure_rate': [
+        'visit_occurrence', 'condition_occurrence',
+        'drug_exposure', 'measurement',
+        'procedure_occurrence', 'observation']
 }
 
 
@@ -224,7 +233,8 @@ data_quality_dimension_dict = {
     'drug_routes': 'Completeness',
     'measurement_units': 'Completeness',
     'date_datetime_disparity': 'Conformance',
-    'erroneous_dates': 'Plausibility'
+    'erroneous_dates': 'Plausibility',
+    'person_id_failure_rate': 'Conformance'
 }
 
 metric_type_to_english_dict = {
@@ -244,7 +254,8 @@ metric_type_to_english_dict = {
     # other metrics
     'concept': 'Concept ID Success Rate',
     'duplicates': 'Duplicate Records',
-    'erroneous_dates': 'Erroneous Dates'
+    'erroneous_dates': 'Erroneous Dates',
+    'person_id_failure_rate': 'Person ID Failure Rate'
 }
 
 metrics_to_weight = [
@@ -252,7 +263,7 @@ metrics_to_weight = [
     'end_before_begin', 'data_after_death',
     'concept', 'duplicates',
     'date_datetime_disparity',
-    'erroneous_dates']
+    'erroneous_dates', 'person_id_failure_rate']
 
 full_names = {
     "saou_uab_selma": "UAB Selma",

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
@@ -60,7 +60,8 @@ def establish_hpo_objects(dqm_objects):
               end_before_begin=[], data_after_death=[],
               route_success=[], unit_success=[],
               measurement_integration=[], ingredient_integration=[],
-              date_datetime_disp=[], erroneous_dates=[])
+              date_datetime_disp=[], erroneous_dates=[],
+              person_id_failure=[])
 
             blank_hpo_objects.append(hpo)
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/messages.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/messages.py
@@ -41,7 +41,8 @@ analysis_type_prompt = \
         "H. Percentage of expected measurements observed\n" \
         "I. Date consistency across tables \n" \
         "J. Date/datetime inconsistencies \n" \
-        "K. Erroneous dates \n\n" \
+        "K. Erroneous dates \n" \
+        "L. Person ID failure rate\n" \
         "Please specify your choice by typing the corresponding letter."
 
 output_prompt = \

--- a/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
@@ -274,7 +274,7 @@ def create_excel_files(
     writer.save()
 
 
-# UNIONED EHR COMPARISON
+# UNIONED EHR DATASET COMPARISON
 report1 = 'may_10_2019.xlsx'
 report2 = 'july_15_2019.xlsx'
 report3 = 'october_04_2019.xlsx'

--- a/data_steward/analytics/table_metrics/weekly_scripts/person_id_foreign_key_notebook.py
+++ b/data_steward/analytics/table_metrics/weekly_scripts/person_id_foreign_key_notebook.py
@@ -1,0 +1,705 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.3.0
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# ### This notebook is intended to show the percentage of rows with 'invalid' 'person_id' (a type of 'foreign key') in each of the 6 canonical tables. 
+#
+# ### An 'invalid' row would be one where the field value ('person_id') either:
+# ###     a. does not exist in the person table
+# ###     b. is seemingly associated with another site in the `unioned_ehr_person` table
+
+# ### The notebook will evaluate the following
+#
+# #### person_id and visit_occurrence_id in the following tables:
+#
+# - condition occurrence
+# - observation
+# - drug exposure
+# - procedure occurrence
+# - measurement
+# - visit occurrence
+
+# +
+from google.cloud import bigquery
+
+# %reload_ext google.cloud.bigquery
+
+client = bigquery.Client()
+
+# %load_ext google.cloud.bigquery
+
+# +
+from notebooks import parameters
+DATASET = parameters.LATEST_DATASET
+
+print("Dataset to use: {DATASET}".format(DATASET = DATASET))
+
+# +
+#######################################
+print('Setting everything up...')
+#######################################
+
+import warnings
+
+warnings.filterwarnings('ignore')
+import pandas as pd
+import matplotlib.pyplot as plt
+# %matplotlib inline
+import os
+
+
+plt.style.use('ggplot')
+pd.options.display.max_rows = 999
+pd.options.display.max_columns = 999
+pd.options.display.max_colwidth = 999
+
+
+def cstr(s, color='black'):
+    return "<text style=color:{}>{}</text>".format(color, s)
+
+
+print('done.')
+# -
+
+cwd = os.getcwd()
+cwd = str(cwd)
+print("Current working directory is: {cwd}".format(cwd=cwd))
+
+# +
+dic = {
+    'src_hpo_id': [
+        "saou_uab_selma", "saou_uab_hunt", "saou_tul", "pitt_temple",
+        "saou_lsu", "trans_am_meyers", "trans_am_essentia", "saou_ummc",
+        "seec_miami", "seec_morehouse", "seec_emory", "uamc_banner", "pitt",
+        "nyc_cu", "ipmc_uic", "trans_am_spectrum", "tach_hfhs", "nec_bmc",
+        "cpmc_uci", "nec_phs", "nyc_cornell", "ipmc_nu", "nyc_hh",
+        "ipmc_uchicago", "aouw_mcri", "syhc", "cpmc_ceders", "seec_ufl",
+        "saou_uab", "trans_am_baylor", "cpmc_ucsd", "ecchc", "chci", "aouw_uwh",
+        "cpmc_usc", "hrhc", "ipmc_northshore", "chs", "cpmc_ucsf", "jhchc",
+        "aouw_mcw", "cpmc_ucd", "ipmc_rush", "va", "saou_umc"
+    ],
+    'HPO': [
+        "UAB Selma", "UAB Huntsville", "Tulane University", "Temple University",
+        "Louisiana State University",
+        "Reliant Medical Group (Meyers Primary Care)",
+        "Essentia Health Superior Clinic", "University of Mississippi",
+        "SouthEast Enrollment Center Miami",
+        "SouthEast Enrollment Center Morehouse",
+        "SouthEast Enrollment Center Emory", "Banner Health",
+        "University of Pittsburgh", "Columbia University Medicalå Center",
+        "University of Illinois Chicago", "Spectrum Health",
+        "Henry Ford Health System", "Boston Medical Center", "UC Irvine",
+        "Partners HealthCare", "Weill Cornell Medical Center",
+        "Northwestern Memorial Hospital", "Harlem Hospital",
+        "University of Chicago", "Marshfield Clinic",
+        "San Ysidro Health Center", "Cedars-Sinai", "University of Florida",
+        "University of Alabama at Birmingham", "Baylor", "UC San Diego",
+        "Eau Claire Cooperative Health Center", "Community Health Center, Inc.",
+        "UW Health (University of Wisconsin Madison)",
+        "University of Southern California", "HRHCare",
+        "NorthShore University Health System", "Cherokee Health Systems",
+        "UC San Francisco", "Jackson-Hinds CHC", "Medical College of Wisconsin",
+        "UC Davis", "Rush University", 
+        "United States Department of Veterans Affairs - Boston",
+        "University Medical Center (UA Tuscaloosa)"
+    ]
+}
+
+site_df = pd.DataFrame(data=dic)
+site_df
+
+# +
+######################################
+print('Getting the data from the database...')
+######################################
+
+site_map = pd.io.gbq.read_gbq('''
+    select distinct * from (
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_visit_occurrence`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_care_site`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_condition_occurrence`  
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_device_exposure`
+
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_drug_exposure`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_location`         
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_measurement`         
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_note`        
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_observation`         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_person`         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_procedure_occurrence`         
+         
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_provider`
+         
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_specimen`
+    
+    UNION ALL
+    SELECT
+            DISTINCT(src_hpo_id) as src_hpo_id
+    FROM
+         `{DATASET}._mapping_visit_occurrence`   
+    )     
+    '''.format(DATASET=DATASET),
+                              dialect='standard')
+print(site_map.shape[0], 'records received.')
+# -
+
+site_df = pd.merge(site_map, site_df, how='outer', on='src_hpo_id')
+site_df
+
+# # person_id evaluations
+
+# ## Condition Occurrence Table
+
+condition_occurrence_query = f"""
+SELECT
+DISTINCT
+total_rows.src_hpo_id,
+-- IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) as rows_w_no_valid_person,
+-- total_rows.total_rows,
+round(IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) / total_rows.total_rows * 100, 2) AS condition_occurrence
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mco.src_hpo_id, COUNT(mco.src_hpo_id) as total_rows
+  FROM
+  `{DATASET}.unioned_ehr_condition_occurrence` co
+  LEFT JOIN
+  `{DATASET}._mapping_condition_occurrence` mco
+  ON
+  co.condition_occurrence_id = mco.condition_occurrence_id
+  GROUP BY 1
+  ORDER BY total_rows DESC) total_rows
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mco.src_hpo_id, COUNT(mco.src_hpo_id) as number_rows_w_no_valid_person
+
+  -- to enable site tracing
+  FROM
+  `{DATASET}.unioned_ehr_condition_occurrence` co
+  LEFT JOIN
+  `{DATASET}._mapping_condition_occurrence` mco
+  ON
+  co.condition_occurrence_id = mco.condition_occurrence_id
+
+  -- to enable person/src_hpo_id cross-checking
+  LEFT JOIN
+  `{DATASET}.unioned_ehr_person` p
+  ON
+  co.person_id = p.person_id
+  LEFT JOIN
+  `{DATASET}._mapping_person` mp
+  ON
+  p.person_id = mp.person_id
+
+
+  -- anything dropped by the 'left join'
+  WHERE
+  co.person_id NOT IN
+    (
+    SELECT
+    DISTINCT p.person_id
+    FROM
+    `{DATASET}.unioned_ehr_person` p
+    )
+
+  -- same person_id but traced to different sites
+  OR
+  mco.src_hpo_id <> mp.src_hpo_id
+
+  GROUP BY 1
+  ORDER BY number_rows_w_no_valid_person DESC) invalid_row_count
+
+ON
+total_rows.src_hpo_id = invalid_row_count.src_hpo_id
+ORDER BY condition_occurrence DESC
+"""
+
+condition_occurrence_df = pd.io.gbq.read_gbq(condition_occurrence_query, dialect ='standard')
+
+condition_occurrence_df
+
+# # Observation
+
+observation_query = f"""
+SELECT
+DISTINCT
+total_rows.src_hpo_id,
+-- IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) as rows_w_no_valid_person,
+-- total_rows.total_rows,
+round(IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) / total_rows.total_rows * 100, 2) AS observation
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mo.src_hpo_id, COUNT(mo.src_hpo_id) as total_rows
+  FROM
+  `{DATASET}.unioned_ehr_observation` o
+  LEFT JOIN
+  `{DATASET}._mapping_observation` mo
+  ON
+  mo.observation_id = o.observation_id
+  GROUP BY 1
+  ORDER BY total_rows DESC) total_rows
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mo.src_hpo_id, COUNT(mo.src_hpo_id) as number_rows_w_no_valid_person
+
+  -- to enable site tracing
+  FROM
+  `{DATASET}.unioned_ehr_observation` o
+  LEFT JOIN
+  `{DATASET}._mapping_observation` mo
+  ON
+  mo.observation_id = o.observation_id
+
+  -- to enable person/src_hpo_id cross-checking
+  LEFT JOIN
+  `{DATASET}.unioned_ehr_person` p
+  ON
+  o.person_id = p.person_id
+  LEFT JOIN
+  `{DATASET}._mapping_person` mp
+  ON
+  p.person_id = mp.person_id
+
+
+  -- anything dropped by the 'left join'
+  WHERE
+  o.person_id NOT IN
+    (
+    SELECT
+    DISTINCT p.person_id
+    FROM
+    `{DATASET}.unioned_ehr_person` p
+    )
+
+  -- same person_id but traced to different sites
+  OR
+  mo.src_hpo_id <> mp.src_hpo_id
+
+  GROUP BY 1
+  ORDER BY number_rows_w_no_valid_person DESC) invalid_row_count
+
+ON
+total_rows.src_hpo_id = invalid_row_count.src_hpo_id
+ORDER BY observation DESC
+"""
+
+observation_df = pd.io.gbq.read_gbq(observation_query, dialect ='standard')
+
+observation_df
+
+# # Drug Exposure Table
+
+drug_exposure_query = f"""
+SELECT
+DISTINCT
+total_rows.src_hpo_id,
+-- IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) as rows_w_no_valid_person,
+-- total_rows.total_rows,
+round(IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) / total_rows.total_rows * 100, 2) AS drug_exposure
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mde.src_hpo_id, COUNT(mde.src_hpo_id) as total_rows
+  FROM
+  `{DATASET}.unioned_ehr_drug_exposure` de
+  LEFT JOIN
+  `{DATASET}._mapping_drug_exposure` mde
+  ON
+  de.drug_exposure_id = mde.drug_exposure_id
+  GROUP BY 1
+  ORDER BY total_rows DESC) total_rows
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mde.src_hpo_id, COUNT(mde.src_hpo_id) as number_rows_w_no_valid_person
+
+  -- to enable site tracing
+  FROM
+  `{DATASET}.unioned_ehr_drug_exposure` de
+  LEFT JOIN
+  `{DATASET}._mapping_drug_exposure` mde
+  ON
+  de.drug_exposure_id = mde.drug_exposure_id
+
+  -- to enable person/src_hpo_id cross-checking
+  LEFT JOIN
+  `{DATASET}.unioned_ehr_person` p
+  ON
+  de.person_id = p.person_id
+  LEFT JOIN
+  `{DATASET}._mapping_person` mp
+  ON
+  p.person_id = mp.person_id
+
+
+  -- anything dropped by the 'left join'
+  WHERE
+  de.person_id NOT IN
+    (
+    SELECT
+    DISTINCT p.person_id
+    FROM
+    `{DATASET}.unioned_ehr_person` p
+    )
+
+  -- same person_id but traced to different sites
+  OR
+  mde.src_hpo_id <> mp.src_hpo_id
+
+  GROUP BY 1
+  ORDER BY number_rows_w_no_valid_person DESC) invalid_row_count
+
+ON
+total_rows.src_hpo_id = invalid_row_count.src_hpo_id
+ORDER BY drug_exposure DESC
+"""
+
+drug_exposure_df = pd.io.gbq.read_gbq(drug_exposure_query, dialect ='standard')
+
+drug_exposure_df
+
+# # Procedure Occurrence
+
+procedure_occurrence_query = f"""
+SELECT
+DISTINCT
+total_rows.src_hpo_id,
+-- IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) as rows_w_no_valid_person,
+-- total_rows.total_rows,
+round(IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) / total_rows.total_rows * 100, 2) AS procedure_occurrence
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mpo.src_hpo_id, COUNT(mpo.src_hpo_id) as total_rows
+  FROM
+  `{DATASET}.unioned_ehr_procedure_occurrence` po
+  LEFT JOIN
+  `{DATASET}._mapping_procedure_occurrence` mpo
+  ON
+  po.procedure_occurrence_id = mpo.procedure_occurrence_id
+  GROUP BY 1
+  ORDER BY total_rows DESC) total_rows
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mpo.src_hpo_id, COUNT(mpo.src_hpo_id) as number_rows_w_no_valid_person
+
+  -- to enable site tracing
+  FROM
+  `{DATASET}.unioned_ehr_procedure_occurrence` po
+  LEFT JOIN
+  `{DATASET}._mapping_procedure_occurrence` mpo
+  ON
+  po.procedure_occurrence_id = mpo.procedure_occurrence_id
+
+  -- to enable person/src_hpo_id cross-checking
+  LEFT JOIN
+  `{DATASET}.unioned_ehr_person` p
+  ON
+  po.person_id = p.person_id
+  LEFT JOIN
+  `{DATASET}._mapping_person` mp
+  ON
+  p.person_id = mp.person_id
+
+
+  -- anything dropped by the 'left join'
+  WHERE
+  po.person_id NOT IN
+    (
+    SELECT
+    DISTINCT p.person_id
+    FROM
+    `{DATASET}.unioned_ehr_person` p
+    )
+
+  -- same person_id but traced to different sites
+  OR
+  mpo.src_hpo_id <> mp.src_hpo_id
+
+  GROUP BY 1
+  ORDER BY number_rows_w_no_valid_person DESC) invalid_row_count
+
+ON
+total_rows.src_hpo_id = invalid_row_count.src_hpo_id
+ORDER BY procedure_occurrence DESC
+"""
+
+procedure_occurrence_df = pd.io.gbq.read_gbq(procedure_occurrence_query, dialect ='standard')
+
+procedure_occurrence_df
+
+# # Measurement
+
+measurement_query = f"""
+SELECT
+DISTINCT
+total_rows.src_hpo_id,
+-- IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) as rows_w_no_valid_person,
+-- total_rows.total_rows,
+round(IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) / total_rows.total_rows * 100, 2) AS measurement
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mm.src_hpo_id, COUNT(mm.src_hpo_id) as total_rows
+  FROM
+  `{DATASET}.unioned_ehr_measurement` m
+  LEFT JOIN
+  `{DATASET}._mapping_measurement` mm
+  ON
+  m.measurement_id = mm.measurement_id
+  GROUP BY 1
+  ORDER BY total_rows DESC) total_rows
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mm.src_hpo_id, COUNT(mm.src_hpo_id) as number_rows_w_no_valid_person
+
+  -- to enable site tracing
+  FROM
+  `{DATASET}.unioned_ehr_measurement` m
+  LEFT JOIN
+  `{DATASET}._mapping_measurement` mm
+  ON
+  m.measurement_id = mm.measurement_id
+
+  -- to enable person/src_hpo_id cross-checking
+  LEFT JOIN
+  `{DATASET}.unioned_ehr_person` p
+  ON
+  m.person_id = p.person_id
+  LEFT JOIN
+  `{DATASET}._mapping_person` mp
+  ON
+  p.person_id = mp.person_id
+
+
+  -- anything dropped by the 'left join'
+  WHERE
+  m.person_id NOT IN
+    (
+    SELECT
+    DISTINCT p.person_id
+    FROM
+    `{DATASET}.unioned_ehr_person` p
+    )
+
+  -- same person_id but traced to different sites
+  OR
+  mm.src_hpo_id <> mp.src_hpo_id
+
+  GROUP BY 1
+  ORDER BY number_rows_w_no_valid_person DESC) invalid_row_count
+
+ON
+total_rows.src_hpo_id = invalid_row_count.src_hpo_id
+ORDER BY measurement DESC
+"""
+
+measurement_df = pd.io.gbq.read_gbq(measurement_query, dialect ='standard')
+
+measurement_df
+
+# # Visit Occurrence
+
+visit_occurrence_query = f"""
+SELECT
+DISTINCT
+total_rows.src_hpo_id,
+-- IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) as rows_w_no_valid_person,
+-- total_rows.total_rows,
+round(IFNULL(invalid_row_count.number_rows_w_no_valid_person, 0) / total_rows.total_rows * 100, 2) AS visit_occurrence
+
+FROM
+
+  (SELECT
+  DISTINCT
+  mvo.src_hpo_id, COUNT(mvo.src_hpo_id) as total_rows
+  FROM
+  `{DATASET}.unioned_ehr_visit_occurrence` vo
+  LEFT JOIN
+  `{DATASET}._mapping_visit_occurrence` mvo
+  ON
+  vo.visit_occurrence_id = mvo.visit_occurrence_id
+  GROUP BY 1
+  ORDER BY total_rows DESC) total_rows
+
+LEFT JOIN
+
+  (SELECT
+  DISTINCT
+  mvo.src_hpo_id, COUNT(mvo.src_hpo_id) as number_rows_w_no_valid_person
+
+  -- to enable site tracing
+  FROM
+  `{DATASET}.unioned_ehr_visit_occurrence` vo
+  LEFT JOIN
+  `{DATASET}._mapping_visit_occurrence` mvo
+  ON
+  vo.visit_occurrence_id = mvo.visit_occurrence_id
+
+  -- to enable person/src_hpo_id cross-checking
+  LEFT JOIN
+  `{DATASET}.unioned_ehr_person` p
+  ON
+  vo.person_id = p.person_id
+  LEFT JOIN
+  `{DATASET}._mapping_person` mp
+  ON
+  p.person_id = mp.person_id
+
+
+  -- anything dropped by the 'left join'
+  WHERE
+  vo.person_id NOT IN
+    (
+    SELECT
+    DISTINCT p.person_id
+    FROM
+    `{DATASET}.unioned_ehr_person` p
+    )
+
+  -- same person_id but traced to different sites
+  OR
+  mvo.src_hpo_id <> mp.src_hpo_id
+
+  GROUP BY 1
+  ORDER BY number_rows_w_no_valid_person DESC) invalid_row_count
+
+ON
+total_rows.src_hpo_id = invalid_row_count.src_hpo_id
+ORDER BY visit_occurrence DESC
+"""
+
+visit_occurrence_df = pd.io.gbq.read_gbq(visit_occurrence_query, dialect ='standard')
+
+visit_occurrence_df
+
+# # Bringing it all together
+
+# +
+person_id_foreign_key_df = pd.merge(
+    site_df, observation_df, how='outer', on='src_hpo_id')
+
+person_id_foreign_key_df = pd.merge(
+    person_id_foreign_key_df, measurement_df, how='outer', on='src_hpo_id')
+
+person_id_foreign_key_df = pd.merge(
+    person_id_foreign_key_df, visit_occurrence_df, how='outer', on='src_hpo_id')
+
+person_id_foreign_key_df = pd.merge(
+    person_id_foreign_key_df, procedure_occurrence_df, how='outer', on='src_hpo_id')
+
+person_id_foreign_key_df = pd.merge(
+    person_id_foreign_key_df, drug_exposure_df, how='outer', on='src_hpo_id')
+
+person_id_foreign_key_df = pd.merge(
+    person_id_foreign_key_df, condition_occurrence_df, how='outer', on='src_hpo_id')
+
+# +
+person_id_foreign_key_df = person_id_foreign_key_df.fillna(0)
+
+person_id_foreign_key_df
+# -
+
+person_id_foreign_key_df.to_csv(f"{cwd}/person_id_failure_rate.csv")
+
+


### PR DESCRIPTION
* Includes a notebook that calculates the percentage of missing/invalid 'person_id' fields for the following tables: condition_occurrence, procedure_occurrence, visit_occurrence, drug_exposure, measurement, observation.
* Changed the metrics_over_time library to accommodate for this new metric (part of EDQ-425)
* Validated the output for the resulting metrics_over_time script