### PR TITLE
[EDQ-451] Create New Metric to Monitor ACHILLES Errors Over Time

### DIFF
--- a/data_steward/analytics/cdr_ops/number_achilles_errors.py
+++ b/data_steward/analytics/cdr_ops/number_achilles_errors.py
@@ -1,0 +1,132 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.4.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# ### This notebook is designed to output the number of ACHILLES errors for each of the sites. The number of ACHILLES errors is triaged into two categories:
+# - Number of distinct ACHILLES errors
+# - Number of TOTAL ACHILLES errors (meaning the same 'issue' can be reported twice)
+
+from google.cloud import bigquery
+# %reload_ext google.cloud.bigquery
+client = bigquery.Client()
+# %load_ext google.cloud.bigquery
+
+# +
+from notebooks import parameters
+DATASET = parameters.LATEST_DATASET
+
+print("Dataset to use: {DATASET}".format(DATASET = DATASET))
+
+# +
+import warnings
+
+warnings.filterwarnings('ignore')
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+
+plt.style.use('ggplot')
+pd.options.display.max_rows = 999
+pd.options.display.max_columns = 999
+pd.options.display.max_colwidth = 999
+
+
+def cstr(s, color='black'):
+    return "<text style=color:{}>{}</text>".format(color, s)
+
+
+# -
+
+# ### Get the list of HPO IDs
+
+hpo_id_query = """
+SELECT REPLACE(table_id, '_person', '') AS hpo_id
+FROM
+`{DATASET}.__TABLES__`
+WHERE table_id LIKE '%person' 
+AND table_id 
+NOT LIKE '%unioned_ehr_%' 
+AND table_id NOT LIKE '\\\_%'
+""".format(DATASET=DATASET)
+
+hpo_ids = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard').hpo_id.tolist()
+
+# ### NOTE: This next section looks at distinct achilles_heel_warnings - NOT just ACHILLES Heel IDs. This means that NOTIFICATIONS (those that are not logged with an analysis_id) are also included in the count.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS hpo_id,
+COUNT(DISTINCT ahr.achilles_heel_warning) as num_distinct_warnings
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+    
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_distinct_ahes = """
+WITH num_distinct_ahes AS
+({final_query})
+
+SELECT
+DISTINCT
+*
+FROM
+num_distinct_ahes
+ORDER BY num_distinct_warnings DESC
+""".format(final_query=final_query)
+
+distinct_ahes_df = pd.io.gbq.read_gbq(dataframe_distinct_ahes, dialect='standard')
+
+distinct_ahes_df
+
+# ### NOTE: This next section looks at distinct achilles_heel_ids. NOTIFICATIONS are NOT included in this count.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS hpo_id,
+COUNT(DISTINCT ahr.analysis_id) as num_distinct_id
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+    
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_distinct_ahes = """
+WITH num_distinct_ids AS
+({final_query})
+
+SELECT
+DISTINCT
+*
+FROM
+num_distinct_ids
+ORDER BY num_distinct_ids DESC
+""".format(final_query=final_query)
+
+distinct_ahe_ids = pd.io.gbq.read_gbq(dataframe_distinct_ahes, dialect='standard')
+
+distinct_ahe_ids

--- a/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
@@ -54,6 +54,9 @@ unweighted_metric_already_integrated_for_hpo: shows which
 
 aggregate_metric_class_names: contains the 'names' of the aggregate
     metric objects that one can use
+
+no_aggregate_metric_needed_for_table_sheets: indicates instances where
+    no 'aggregate' row needs to be calculated for the 'table' sheets
 """
 
 # ---------- Dictionaries ---------- #
@@ -72,7 +75,9 @@ thresholds = {
 
     'date_datetime_disparity_max': 0.01,
     'erroneous_dates_max': 0.01,
-    'person_failure_rate_max': 0.01
+    'person_failure_rate_max': 0.01,
+
+    'achilles_errors_max': 0.01
 }
 
 
@@ -88,7 +93,8 @@ choice_dict = {
     'i': 'visit_date_disparity',
     'j': 'date_datetime_disparity',
     'k': 'erroneous_dates',
-    'l': 'person_id_failure_rate'}
+    'l': 'person_id_failure_rate',
+    'm': 'achilles_errors'}
 
 percentage_dict = {
     'duplicates': False,
@@ -102,7 +108,8 @@ percentage_dict = {
     'visit_date_disparity': True,
     'date_datetime_disparity': True,
     'erroneous_dates': True,
-    'person_id_failure_rate': True
+    'person_id_failure_rate': True,
+    'achilles_errors': False
 }
 
 target_low_dict = {
@@ -124,7 +131,9 @@ target_low_dict = {
     # double negative.
     'date_datetime_disparity': False,
     'erroneous_dates': False,
-    'person_id_failure_rate': False
+    'person_id_failure_rate': False,
+
+    'achilles_errors': True
 }
 
 columns_to_document_for_sheet = {
@@ -182,7 +191,10 @@ columns_to_document_for_sheet = {
     'person_id_failure_rate': [
         'visit_occurrence', 'condition_occurrence',
         'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation']
+        'procedure_occurrence', 'observation'],
+
+    'achilles_errors': [
+        'num_distinct_ids']
 }
 
 
@@ -227,7 +239,9 @@ table_based_on_column_provided = {
     'CMP': 'Comprehensive Metabolic Panel',
     'CBCwDiff': 'CBC with Differential',
     'CBC': 'Complete Blood Count (CBC)',
-    'Lipid': 'Lipid'
+    'Lipid': 'Lipid',
+
+    'num_distinct_ids': 'All Tables'
 }
 
 data_quality_dimension_dict = {
@@ -241,7 +255,8 @@ data_quality_dimension_dict = {
     'measurement_units': 'Completeness',
     'date_datetime_disparity': 'Conformance',
     'erroneous_dates': 'Plausibility',
-    'person_id_failure_rate': 'Conformance'
+    'person_id_failure_rate': 'Conformance',
+    'achilles_errors': 'Conformance'
 }
 
 metric_type_to_english_dict = {
@@ -262,7 +277,8 @@ metric_type_to_english_dict = {
     'concept': 'Concept ID Success Rate',
     'duplicates': 'Duplicate Records',
     'erroneous_dates': 'Erroneous Dates',
-    'person_id_failure_rate': 'Person ID Failure Rate'
+    'person_id_failure_rate': 'Person ID Failure Rate',
+    'achilles_errors': 'Number of ACHILLES Errors'
 }
 
 metrics_to_weight = [
@@ -332,9 +348,9 @@ row_count_col_names = [
 # ---------- Lists ---------- #
 unweighted_metric_already_integrated_for_hpo = [
     'drug_routes',
-    'measurement_units']
+    'measurement_units', 'achilles_errors']
 
-no_aggregate_metric_needed_for_hpo_sheets = [
+no_aggregate_metric_needed_for_table_sheets = [
     'drug_success', 'sites_measurement']
 
 aggregate_metric_class_names = ['All Measurements', 'All Drugs']

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
@@ -61,7 +61,7 @@ def establish_hpo_objects(dqm_objects):
               route_success=[], unit_success=[],
               measurement_integration=[], ingredient_integration=[],
               date_datetime_disp=[], erroneous_dates=[],
-              person_id_failure=[])
+              person_id_failure=[], achilles_errors=[])
 
             blank_hpo_objects.append(hpo)
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/messages.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/messages.py
@@ -43,6 +43,7 @@ analysis_type_prompt = \
         "J. Date/datetime inconsistencies \n" \
         "K. Erroneous dates \n" \
         "L. Person ID failure rate\n" \
+        "M. Number of ACHILLES Errors\n\n" \
         "Please specify your choice by typing the corresponding letter."
 
 output_prompt = \

--- a/data_steward/analytics/table_metrics/metrics_over_time/organize_dataframes.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/organize_dataframes.py
@@ -15,12 +15,13 @@ from setup_dataframes import create_dataframe_skeletons
 from dictionaries_and_lists import \
     metric_type_to_english_dict, \
     unweighted_metric_already_integrated_for_hpo, \
-    no_aggregate_metric_needed_for_hpo_sheets
+    no_aggregate_metric_needed_for_table_sheets
 
 from populate_dfs_with_aggregate_info import \
     create_aggregate_info_df, add_aggregate_to_end_of_table_class_df, \
     add_aggregate_to_end_of_hpo_df
 
+import math
 
 def organize_dataframes_master_function(
         sheet_output, metric_dictionary, datetimes, hpo_names,
@@ -180,21 +181,21 @@ def populate_table_df_rows(
                     for dqm in relevant_dqms:
                         if dqm.date == date and \
                            dqm.table_or_class == table_class_name:
-                            row_to_place.append(dqm.value)
+                            value = dqm.value
+
+                            if math.isnan(value):
+                                row_to_place.append(0)
+                            else:
+                                row_to_place.append(dqm.value)
 
             df.loc[hpo] = row_to_place
 
-        # need to calculate and add the aggregate metric
-        if metric_choice not in \
-                unweighted_metric_already_integrated_for_hpo:
-            df = add_aggregate_to_end_of_table_class_df(
-                datetimes=datetimes,
-                aggregate_metrics=aggregate_metrics,
-                table_class_name=table_class_name,
-                metric_choice=metric_choice_eng, df=df)
-        else:
-            # no need - already logged
-            df = df.drop('aggregate_info')
+
+        df = add_aggregate_to_end_of_table_class_df(
+            datetimes=datetimes,
+            aggregate_metrics=aggregate_metrics,
+            table_class_name=table_class_name,
+            metric_choice=metric_choice_eng, df=df)
 
         # replace
         dataframes_dict[table_class_name] = df
@@ -288,7 +289,7 @@ def populate_hpo_df_rows(
         if metric_choice not in \
                 unweighted_metric_already_integrated_for_hpo\
                 and metric_choice not in \
-                no_aggregate_metric_needed_for_hpo_sheets:
+                no_aggregate_metric_needed_for_table_sheets:
             df = add_aggregate_to_end_of_hpo_df(
                 datetimes=datetimes,
                 aggregate_metrics=aggregate_metrics,

--- a/data_steward/analytics/table_metrics/metrics_over_time/populate_dfs_with_aggregate_info.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/populate_dfs_with_aggregate_info.py
@@ -23,7 +23,7 @@ from aggregate_metric_classes import \
 from dictionaries_and_lists import \
     metric_type_to_english_dict, \
     unweighted_metric_already_integrated_for_hpo, \
-    no_aggregate_metric_needed_for_hpo_sheets
+    no_aggregate_metric_needed_for_table_sheets
 
 from messages import err_message_agg_for_table, \
     err_message_agg_for_date, \
@@ -278,7 +278,7 @@ def create_aggregate_info_df(
     if metric_choice not in \
             unweighted_metric_already_integrated_for_hpo\
             and metric_choice not in \
-            no_aggregate_metric_needed_for_hpo_sheets:
+            no_aggregate_metric_needed_for_table_sheets:
         final_row = make_aggregate_row_for_aggregate_df(
             datetimes=datetimes, metric_choice=metric_choice_eng,
             aggregate_metrics=aggregate_metrics)

--- a/data_steward/analytics/table_metrics/metrics_over_time/unweighted_aggregate_metric_functions.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/unweighted_aggregate_metric_functions.py
@@ -20,6 +20,7 @@ from auxillary_aggregate_functions import \
     get_stats_for_unweighted_hpo_aggregate_metric, \
     find_unique_dates_and_metrics
 
+import numpy as np
 
 def create_unweighted_aggregate_metrics_for_tables(
         metric_dictionary, datetimes):
@@ -89,7 +90,7 @@ def create_unweighted_aggregate_metrics_for_tables(
                     total_rows, pertinent_rows = 0, 0
 
                     # 'unweighted' aspect comes in - simple mean
-                    overall_rate = sum(unweighted_metrics_for_hpos) / \
+                    overall_rate = np.nansum(unweighted_metrics_for_hpos) / \
                         len(unweighted_metrics_for_hpos)
 
                     new_uw_agg_metric = AggregateMetricForTableOrClass(

--- a/data_steward/analytics/table_metrics/other_scripts/number_achilles_errors.py
+++ b/data_steward/analytics/table_metrics/other_scripts/number_achilles_errors.py
@@ -1,0 +1,184 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.4.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# ### This notebook is designed to output the number of ACHILLES errors for each of the sites. The number of ACHILLES errors is triaged into two categories:
+# - Number of distinct ACHILLES errors
+# - Number of TOTAL ACHILLES errors (meaning the same 'issue' can be reported twice)
+
+from google.cloud import bigquery
+# %reload_ext google.cloud.bigquery
+client = bigquery.Client()
+# %load_ext google.cloud.bigquery
+
+# +
+from notebooks import parameters
+DATASET = parameters.EHR_OPS_Q2_2019
+
+print("Dataset to use: {DATASET}".format(DATASET = DATASET))
+
+# +
+import warnings
+
+warnings.filterwarnings('ignore')
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+
+plt.style.use('ggplot')
+pd.options.display.max_rows = 999
+pd.options.display.max_columns = 999
+pd.options.display.max_colwidth = 999
+
+
+def cstr(s, color='black'):
+    return "<text style=color:{}>{}</text>".format(color, s)
+
+
+# -
+
+cwd = os.getcwd()
+cwd = str(cwd)
+print("Current working directory is: {cwd}".format(cwd=cwd))
+
+# ### Get the list of HPO IDs
+#
+# ### NOTE: This assumes that all of the relevant HPOs have a person_id with at least one successful row.
+
+hpo_id_query = """
+SELECT REPLACE(table_id, '_person', '') AS hpo_id
+FROM
+`{DATASET}.__TABLES__`
+WHERE table_id LIKE '%person' 
+AND table_id 
+NOT LIKE '%unioned_ehr_%' 
+AND table_id NOT LIKE '\\\_%'
+AND row_count > 0
+""".format(DATASET=DATASET)
+
+hpo_ids = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard').hpo_id.tolist()
+
+# ### NOTE: This next section looks at distinct achilles_heel_warnings - NOT just ACHILLES Heel IDs. This means that NOTIFICATIONS (those that are not logged with an analysis_id) are also included in the count.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS src_hpo_id,
+COUNT(DISTINCT ahr.achilles_heel_warning) as num_distinct_warnings
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+    
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_distinct_ahes = """
+WITH num_distinct_ahes AS
+({final_query})
+
+SELECT
+DISTINCT
+*
+FROM
+num_distinct_ahes
+ORDER BY num_distinct_warnings DESC
+""".format(final_query=final_query)
+
+distinct_ahes_df = pd.io.gbq.read_gbq(dataframe_distinct_ahes, dialect='standard')
+
+distinct_ahes_df
+
+# ### NOTE: This next section looks at distinct achilles_heel_ids. NOTIFICATIONS are NOT included in this count.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS src_hpo_id,
+COUNT(DISTINCT ahr.analysis_id) as num_distinct_ids
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+    
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_distinct_ids = """
+WITH num_distinct_ids AS
+({final_query})
+
+SELECT
+DISTINCT
+*
+FROM
+num_distinct_ids
+ORDER BY num_distinct_ids DESC
+""".format(final_query=final_query)
+
+dataframe_distinct_ids = pd.io.gbq.read_gbq(dataframe_distinct_ids, dialect='standard')
+
+dataframe_distinct_ids
+
+# ### NOTE: This next section looks at distinct achilles_heel_ids. NOTIFICATIONS are NOT included in this count. This section, however, looks at the TOTAL NUMBER OF AFFECTED ROWS.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS src_hpo_id,
+SUM(ahr.record_count) as rows_with_ah_failure
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+    
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_ahe_failure_count = """
+WITH num_rows_with_ah_failure AS
+({final_query})
+
+SELECT
+DISTINCT
+*
+FROM
+num_rows_with_ah_failure
+ORDER BY rows_with_ah_failure DESC
+""".format(final_query=final_query)
+
+ahe_id_failure_counts = pd.io.gbq.read_gbq(dataframe_ahe_failure_count, dialect='standard')
+
+ahe_id_failure_counts
+
+final_df = pd.merge(dataframe_distinct_ids, distinct_ahes_df, how='outer', on='src_hpo_id')
+
+final_df = pd.merge(final_df, ahe_id_failure_counts, how='outer', on='src_hpo_id')
+
+final_df.fillna(0)
+
+final_df
+
+final_df.to_csv("{cwd}/achilles_errors.csv".format(cwd = cwd))

--- a/data_steward/analytics/table_metrics/weekly_scripts/number_achilles_errors.py
+++ b/data_steward/analytics/table_metrics/weekly_scripts/number_achilles_errors.py
@@ -1,0 +1,181 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.4.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# ### This notebook is designed to output the number of ACHILLES errors for each of the sites. The number of ACHILLES errors is triaged into two categories:
+# - Number of distinct ACHILLES errors
+# - Number of TOTAL ACHILLES errors (meaning the same 'issue' can be reported twice)
+
+from google.cloud import bigquery
+# %reload_ext google.cloud.bigquery
+client = bigquery.Client()
+# %load_ext google.cloud.bigquery
+
+# +
+from notebooks import parameters
+DATASET = parameters.LATEST_DATASET
+
+print("Dataset to use: {DATASET}".format(DATASET = DATASET))
+
+# +
+import warnings
+
+warnings.filterwarnings('ignore')
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+
+plt.style.use('ggplot')
+pd.options.display.max_rows = 999
+pd.options.display.max_columns = 999
+pd.options.display.max_colwidth = 999
+
+
+def cstr(s, color='black'):
+    return "<text style=color:{}>{}</text>".format(color, s)
+
+
+# -
+
+cwd = os.getcwd()
+cwd = str(cwd)
+print("Current working directory is: {cwd}".format(cwd=cwd))
+
+# ### Get the list of HPO IDs
+#
+# ### NOTE: This assumes that all of the relevant HPOs have a person_id with at least one successful row.
+
+hpo_id_query = """
+SELECT REPLACE(table_id, '_person', '') AS hpo_id
+FROM
+`{DATASET}.__TABLES__`
+WHERE table_id LIKE '%person' 
+AND table_id 
+NOT LIKE '%unioned_ehr_%' 
+AND table_id NOT LIKE '\\\_%'
+AND row_count > 0
+""".format(DATASET=DATASET)
+
+hpo_ids = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard').hpo_id.tolist()
+
+# ### NOTE: This next section looks at distinct achilles_heel_warnings - NOT just ACHILLES Heel IDs. This means that NOTIFICATIONS (those that are not logged with an analysis_id) are also included in the count.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS src_hpo_id,
+COUNT(DISTINCT ahr.achilles_heel_warning) as num_distinct_warnings
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+    
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_distinct_ahes = """
+WITH num_distinct_ahes AS
+({final_query})
+SELECT
+DISTINCT
+*
+FROM
+num_distinct_ahes
+ORDER BY num_distinct_warnings DESC
+""".format(final_query=final_query)
+
+distinct_ahes_df = pd.io.gbq.read_gbq(dataframe_distinct_ahes, dialect='standard')
+
+distinct_ahes_df
+
+# ### NOTE: This next section looks at distinct achilles_heel_ids. NOTIFICATIONS are NOT included in this count.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS src_hpo_id,
+COUNT(DISTINCT ahr.analysis_id) as num_distinct_ids
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_distinct_ids = """
+WITH num_distinct_ids AS
+({final_query})
+SELECT
+DISTINCT
+*
+FROM
+num_distinct_ids
+ORDER BY num_distinct_ids DESC
+""".format(final_query=final_query)
+
+dataframe_distinct_ids = pd.io.gbq.read_gbq(dataframe_distinct_ids, dialect='standard')
+
+dataframe_distinct_ids
+
+# ### NOTE: This next section looks at distinct achilles_heel_ids. NOTIFICATIONS are NOT included in this count. This section, however, looks at the TOTAL NUMBER OF AFFECTED ROWS.
+
+# +
+subqueries = []
+
+subquery = """
+SELECT
+'{hpo_id}' AS src_hpo_id,
+SUM(ahr.record_count) as rows_with_ah_failure
+FROM
+`{DATASET}.{hpo_id}_achilles_heel_results` ahr
+"""
+
+for hpo_id in hpo_ids:
+    subqueries.append(subquery.format(DATASET=DATASET, hpo_id=hpo_id))
+
+final_query = '\n\nUNION ALL\n'.join(subqueries)
+# -
+
+dataframe_ahe_failure_count = """
+WITH num_rows_with_ah_failure AS
+({final_query})
+SELECT
+DISTINCT
+*
+FROM
+num_rows_with_ah_failure
+ORDER BY rows_with_ah_failure DESC
+""".format(final_query=final_query)
+
+ahe_id_failure_counts = pd.io.gbq.read_gbq(dataframe_ahe_failure_count, dialect='standard')
+
+ahe_id_failure_counts
+
+final_df = pd.merge(dataframe_distinct_ids, distinct_ahes_df, how='outer', on='src_hpo_id')
+
+final_df = pd.merge(final_df, ahe_id_failure_counts, how='outer', on='src_hpo_id')
+
+final_df.fillna(0)
+
+final_df
+
+final_df.to_csv("{cwd}/achilles_errors.csv".format(cwd = cwd))

--- a/data_steward/analytics/tools/visualizations/conformance/achilles_errors.py
+++ b/data_steward/analytics/tools/visualizations/conformance/achilles_errors.py
@@ -1,0 +1,339 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.4.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# NOTES:
+# 1. matplotlib MUST be in 3.1.0; 3.1.1 ruins the heatmap
+
+# # Across-Site Statistics for ACHILLES Heel Errors
+
+import pandas as pd
+import xlrd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from math import pi
+# %matplotlib inline
+
+# +
+sheets = []
+
+fn1 = 'achilles_errors_table_sheets_analytics_report.xlsx'
+file_names = [fn1]
+
+s1 = 'All Tables'
+
+sheet_names = [s1]
+
+# +
+table_sheets = []
+
+for file in file_names:
+    for sheet in sheet_names:
+        s = pd.read_excel(file, sheet)
+        table_sheets.append(s)
+
+date_cols = table_sheets[0].columns
+date_cols = (list(date_cols))
+
+hpo_id_cols = table_sheets[0].index
+hpo_id_cols = (list(hpo_id_cols))
+# -
+
+# ### Converting the numbers as needed and putting into a dictionary
+
+# +
+new_table_sheets = {}
+
+for name, sheet in zip(sheet_names, table_sheets):
+    sheet_cols = sheet.columns
+    sheet_cols = sheet_cols[0:]
+    new_df = pd.DataFrame(columns=sheet_cols)
+
+    for col in sheet_cols:
+        old_col = sheet[col]
+        new_col = pd.to_numeric(old_col, errors='coerce')
+        new_df[col] = new_col
+
+    new_table_sheets[name] = new_df
+# -
+
+# ### Fixing typos
+
+# +
+fig, ax = plt.subplots(figsize=(18, 12))
+sns.heatmap(new_table_sheets['All Tables'], annot=True, annot_kws={"size": 10},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=hpo_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu")
+
+ax.set_title("Number of ACHILLES Heel Errors", size=14)
+# plt.savefig("achilles_heel_errors_all_sites.jpg")
+# -
+
+# ## Creating a box-and-whisker plot for the different table types across all sites
+#
+# #### NOTE: This doesn't work super well. Not saving as an image. Might be helpful down the line so keeping it for now.
+
+# sns.set(style = "ticks")
+# f, ax = plt.subplots(figsize=(18, 12))
+#
+# date = 'september_16_2019'
+#
+# date_info = {}
+#
+# for table_type in sheet_names:
+#     date_info[table_type] = new_table_sheets[table_type][date].tolist()
+#
+# july_15_df = pd.DataFrame.from_dict(date_info)
+#
+# sns.boxplot(data=july_15_df, 
+#             whis = "range", palette="vlag")
+#
+# sns.swarmplot(data=july_15_df,
+#               size = 5, color=".3", linewidth=0)
+#
+# plt.ylabel(ylabel="Success Rate", size=16)
+# plt.xlabel(xlabel="\nTable Type", size=16)
+# plt.title("ACHILLES Heel Errors for {}".format(date), size = 18)
+# sns.despine(trim=True, left=True)
+
+# # Now let's look at the metrics for particular sites with respect to ACHILLES Heel Errors; this will allow us to send them the same information
+
+# +
+site_name_list = ['aouw_mcri', 'aouw_mcw', 'aouw_uwh', 'chci', 'chs', 'cpmc_ceders', 
+                  'cpmc_ucd', 'cpmc_uci', 'cpmc_ucsd', 'cpmc_ucsf', 'cpmc_usc', 'ecchc',
+                  'hrhc', 'ipmc_northshore', 'ipmc_nu', 'ipmc_rush', 'ipmc_uchicago',
+                  'ipmc_uic', 'jhchc', 'nec_bmc', 'nec_phs', 'nyc_cornell', 'nyc_cu',
+                  'nyc_hh', 'pitt', 'pitt_temple', 'saou_lsu', 'saou_tul', 'saou_uab',
+                  'saou_uab_hunt', 'saou_uab_selma', 'saou_umc',
+                  'saou_ummc', 'seec_emory', 'seec_miami', 'seec_morehouse',
+                  'seec_ufl', 'syhc', 'tach_hfhs', 'trans_am_baylor',
+                  'trans_am_essentia', 'trans_am_meyers', 'trans_am_spectrum', 'uamc_banner',
+                  'va', 'aggregate_info']
+
+print(len(site_name_list))
+
+# +
+name_of_interest = 'aggregate_info'
+
+if name_of_interest not in site_name_list:
+    raise ValueError("Name not found in the list of HPO site names.")    
+
+for idx, site in enumerate(site_name_list):
+    if site == name_of_interest:
+        idx_of_interest = idx
+
+# +
+fn1_hpo_sheets = 'achilles_errors_hpo_sheets_analytics_report.xlsx'
+file_names_hpo_sheets = [fn1_hpo_sheets]
+
+s1, s2 = site_name_list[0], site_name_list[1]
+s3, s4 = site_name_list[2], site_name_list[3]
+s5, s6 = site_name_list[4], site_name_list[5]
+s7, s8 = site_name_list[6], site_name_list[7]
+s9, s10 = site_name_list[8], site_name_list[9]
+s11, s12 = site_name_list[10], site_name_list[11]
+s13, s14 = site_name_list[12], site_name_list[13]
+s15, s16 = site_name_list[14], site_name_list[15]
+s17, s18 = site_name_list[16], site_name_list[17]
+s19, s20 = site_name_list[18], site_name_list[19]
+s21, s22 = site_name_list[20], site_name_list[21]
+s23, s24 = site_name_list[22], site_name_list[23]
+s25, s26 = site_name_list[24], site_name_list[25]
+s27, s28 = site_name_list[26], site_name_list[27]
+s29, s30 = site_name_list[28], site_name_list[29]
+s31, s32 = site_name_list[30], site_name_list[31]
+s33, s34 = site_name_list[32], site_name_list[33]
+s35, s36 = site_name_list[34], site_name_list[35]
+s37, s38 = site_name_list[36], site_name_list[37]
+s39, s40 = site_name_list[38], site_name_list[39]
+s41, s42 = site_name_list[40], site_name_list[41]
+s43, s44 = site_name_list[42], site_name_list[43]
+s45, s46 = site_name_list[44], site_name_list[45] 
+
+hpo_sheet_names = [
+    s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, 
+    s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26,
+    s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38,
+    s39, s40, s41, s42, s43, s44, s45, s46]
+# +
+hpo_sheets = []
+
+for file in file_names_hpo_sheets:
+    for sheet in hpo_sheet_names:
+        s = pd.read_excel(file, sheet)
+        hpo_sheets.append(s)
+        
+
+table_id_cols = list(hpo_sheets[0].index)
+
+date_cols = table_sheets[0].columns
+date_cols = (list(date_cols))
+
+for idx, table_id in enumerate(table_id_cols):
+    under_encountered = False
+    start_idx, end_idx = 0, 0
+    
+    for c_idx, character in enumerate(table_id):
+        if character == '_' and not under_encountered:
+            start_idx = c_idx
+            under_encountered = True
+        elif character == '_' and under_encountered:
+            end_idx = c_idx
+    
+    in_between_str = table_id[start_idx:end_idx + 1]
+    
+    if in_between_str == '_succes_':
+        new_string = table_id[0:start_idx] + '_success' + table_id[end_idx:]
+        table_id_cols[idx] = new_string
+
+# +
+new_hpo_sheets = []
+start_idx = 0
+
+for sheet in hpo_sheets:
+    sheet_cols = sheet.columns
+    sheet_cols = sheet_cols[start_idx:]
+    new_df = pd.DataFrame(columns=sheet_cols)
+
+    for col in sheet_cols:
+        old_col = sheet[col]
+        new_col = pd.to_numeric(old_col, errors='coerce')
+        new_df[col] = new_col
+
+    new_hpo_sheets.append(new_df)
+# -
+
+# ### Showing for one particular site
+
+# +
+fig, ax = plt.subplots(figsize=(9, 6))
+sns.heatmap(new_hpo_sheets[idx_of_interest], annot=True, annot_kws={"size": 14},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=table_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu")
+
+ax.set_title("Number of Achilles Heel Errors for {}".format(name_of_interest), size=14)
+
+plt.tight_layout()
+img_name = name_of_interest + "_achilles_errors.png"
+
+plt.savefig(img_name)
+# -
+
+dates = new_hpo_sheets[0].columns.tolist()
+
+# ## NOTE: This is more experimental than anything else; Could be improved upon in the future. This particular graphic is also only quasi-informative.
+
+# +
+num_tables = len(new_hpo_sheets[0]) - 1  # do not include aggregate
+
+angles = [(angle / num_tables) * (2 * pi) for angle in range(num_tables)]
+angles += angles[:1] # back to the start
+
+
+# +
+max_val = 0
+
+site = new_hpo_sheets[idx_of_interest]
+site_name = site_name_list[idx_of_interest]
+
+for date in dates:
+    date_vals = site[date].values
+    date_vals = date_vals.flatten().tolist()[:-1]  # cut off aggregate
+    
+    for value in date_vals:
+        if value > max_val:
+            max_val = value
+
+y_ticks = [max_val / 5, max_val * 2 / 5, max_val * 3 / 5, max_val * 4 / 5, max_val]
+y_ticks_str = []
+
+for val in y_ticks:
+    string = str(val)
+    y_ticks_str.append(string)
+
+# +
+fig, ax = plt.subplots(figsize=(9, 6))
+ax = plt.subplot(111, polar = True)  # initialize
+
+ax.set_theta_offset(pi / 2)  # flip to top
+ax.set_theta_direction(-1)
+
+plt.xticks(angles[:-1],table_id_cols)
+
+# Draw ylabels
+ax.set_rlabel_position(0)
+plt.yticks(y_ticks, y_ticks_str, color="grey", size=8)
+plt.ylim(0, max_val)
+
+
+for date_idx in range(len(dates)):
+    date_vals = site[dates[date_idx]].values
+    date = date_vals.flatten().tolist()[:-1]  # cut off aggregate
+    date += date[:1]  # round out the graph
+    
+    ax.plot(angles, date, linewidth=1, linestyle='solid', label=dates[date_idx])
+    ax.fill(angles, date, alpha=0.1)
+
+plt.title("ACHILLES Errors: {}".format(name_of_interest), size=15, y = 1.1)
+plt.legend(loc='upper right', bbox_to_anchor=(0.1, 0.1))
+# -
+
+dates = new_hpo_sheets[idx_of_interest].columns
+
+# ## Want a line chart over time.
+
+times=new_hpo_sheets[idx_of_interest].columns.tolist()
+
+# +
+success_rates = {}
+
+for table_num, table_type in enumerate(table_id_cols):
+    table_metrics_over_time = new_hpo_sheets[idx_of_interest].iloc[table_num]
+    success_rates[table_type] = table_metrics_over_time.values.tolist()
+
+date_idxs = []
+for x in range(len(dates)):
+    date_idxs.append(x)
+
+# +
+for table, values_over_time in success_rates.items():
+    sample_list = [x for x in success_rates[table] if str(x) != 'nan']
+    if len(sample_list) > 1:
+        plt.plot(date_idxs, success_rates[table], '--', label=table)
+    
+for table, values_over_time in success_rates.items():
+    non_nan_idx = 0
+    new_lst = []
+    
+    for idx, x in enumerate(success_rates[table]):
+        if str(x) != 'nan':
+            new_lst.append(x)
+            non_nan_idx = idx
+    
+    if len(new_lst) == 1:
+        plt.plot(date_idxs[non_nan_idx], new_lst, 'o', label=table)
+
+plt.legend(loc="upper left", bbox_to_anchor=(1,1))
+plt.title("{} ACHILLES Heel Errors Over Time".format(name_of_interest))
+plt.ylabel("Number of ACHILLES Heel Errors")
+plt.xlabel("")
+plt.xticks(date_idxs, times, rotation = 'vertical')
+
+handles, labels = ax.get_legend_handles_labels()
+lgd = ax.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5,-0.1))
+
+img_name = name_of_interest + "_achilles_errors_line_graph.jpg"
+# plt.savefig(img_name, bbox_extraartist=(lgd,), bbox_inches='tight')
+# -
+


### PR DESCRIPTION
* Develops notebooks (both in the weekly metrics and other metrics sections) that can calculate the number of relevant ACHILLES errors

* Integrate the new metric (which would be very similar to the drug_integration and ingredient_integration metrics) into the metrics_over_time script

* Create a visualization notebook for this new metric

* Ensures that unweighted aggregate metrics are included in 'table' dataframes

* Improves means of calculating 'averages' for 'aggregate' objects in instances where the number is not available
 