### PR TITLE
[EDQ-462] Small Fixes in Data Quality Metrics Processes

### DIFF
--- a/data_steward/analytics/table_metrics/combined_deid_scripts/concept_success_rate.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/concept_success_rate.py
@@ -51,20 +51,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -82,7 +68,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # Below is how we calculate **true** concept_success_rate. This involves concept_id fields that are of Standard Concept = 'S' and of the correct domain.

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/date_datetime_disparity.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/date_datetime_disparity.py
@@ -60,20 +60,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -91,7 +77,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # Condition Occurrence Table

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/diabetes_completeness.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/diabetes_completeness.py
@@ -51,20 +51,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -82,7 +68,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # Participant should have supporting data in either lab results or drugs if he/she has a condition code for diabetes.

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/drug_integration_success_rate.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/drug_integration_success_rate.py
@@ -51,20 +51,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -82,7 +68,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # Improve the Definitions of Drug Ingredient

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/drug_route_success_rate.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/drug_route_success_rate.py
@@ -51,20 +51,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -82,7 +68,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # #  Integration of Routes for Select Drugs:

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/end_before_begin.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/end_before_begin.py
@@ -59,20 +59,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -90,7 +76,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # All temporal data points should be consistent such that end dates should NOT be before a start date.
@@ -151,14 +137,14 @@ temporal_df = pd.io.gbq.read_gbq('''
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_date_rows'] / temporal_df['total_rows'], 1)
 temporal_df
 
 visit_occurrence = temporal_df.rename(
-    columns={"success_rate": "visit_occurrence"})
+    columns={"failure_rate": "visit_occurrence"})
 visit_occurrence = visit_occurrence[["src_hpo_id", "visit_occurrence"]]
-visit_occurrence = visit_occurrence.fillna(100)
+visit_occurrence = visit_occurrence.fillna(0)
 visit_occurrence
 
 total_wrong = temporal_df['wrong_date_rows'].sum()
@@ -228,16 +214,16 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_date_rows'] / temporal_df['total_rows'], 1)
 temporal_df
 
 condition_occurrence = temporal_df.rename(
-    columns={"success_rate": "condition_occurrence"})
+    columns={"failure_rate": "condition_occurrence"})
 condition_occurrence = condition_occurrence[[
     "src_hpo_id", "condition_occurrence"
 ]]
-condition_occurrence = condition_occurrence.fillna(100)
+condition_occurrence = condition_occurrence.fillna(0)
 condition_occurrence
 
 total_wrong = temporal_df['wrong_date_rows'].sum()
@@ -305,13 +291,13 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_date_rows'] / temporal_df['total_rows'], 1)
 temporal_df
 
-drug_exposure = temporal_df.rename(columns={"success_rate": "drug_exposure"})
+drug_exposure = temporal_df.rename(columns={"failure_rate": "drug_exposure"})
 drug_exposure = drug_exposure[["src_hpo_id", "drug_exposure"]]
-drug_exposure = drug_exposure.fillna(100)
+drug_exposure = drug_exposure.fillna(0)
 drug_exposure
 
 total_wrong = temporal_df['wrong_date_rows'].sum()
@@ -334,7 +320,7 @@ success_rate = pd.merge(success_rate, drug_exposure, how='outer', on='src_hpo_id
 
 
 success_rate = pd.merge(success_rate, site_df, how='outer', on='src_hpo_id')
-success_rate = success_rate.fillna(100)
+success_rate = success_rate.fillna(0)
 success_rate
 # -
 

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/erroneous_dates.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/erroneous_dates.py
@@ -60,20 +60,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -91,7 +77,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # ## Observation Table

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/measurement_integration_success_rate.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/measurement_integration_success_rate.py
@@ -51,20 +51,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -82,7 +68,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 Lipid = (40782589, 40795800, 40772572)

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/measurement_units_success_rate.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/measurement_units_success_rate.py
@@ -51,20 +51,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -82,7 +68,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 Lipid = (40782589, 40795800, 40772572)

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/number_achilles_errors.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/number_achilles_errors.py
@@ -54,20 +54,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -85,7 +71,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # ### NOTE: This next section looks at distinct achilles_heel_warnings - NOT just ACHILLES Heel IDs. This means that NOTIFICATIONS (those that are not logged with an analysis_id) are also included in the count.

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/person_id_foreign_key_notebook.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/person_id_foreign_key_notebook.py
@@ -70,20 +70,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -101,7 +87,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # person_id evaluations

--- a/data_steward/analytics/table_metrics/combined_deid_scripts/source_concept_success_rate.py
+++ b/data_steward/analytics/table_metrics/combined_deid_scripts/source_concept_success_rate.py
@@ -50,20 +50,6 @@ cwd = str(cwd)
 print("Current working directory is: {cwd}".format(cwd=cwd))
 
 # ### Get the list of HPO IDs
-#
-# ### NOTE: This assumes that all of the relevant HPOs have a person table.
-
-hpo_id_query = f"""
-SELECT REPLACE(table_id, '_person', '') AS src_hpo_id
-FROM
-`{DATASET}.__TABLES__`
-WHERE table_id LIKE '%person' 
-AND table_id 
-NOT LIKE '%unioned_ehr_%' 
-AND table_id NOT LIKE '\\\_%'
-"""
-
-site_df = pd.io.gbq.read_gbq(hpo_id_query, dialect='standard')
 
 get_full_names = f"""
 select * from {LOOKUP_TABLES}
@@ -81,7 +67,7 @@ full_names_df['src_hpo_id'] = full_names_df['src_hpo_id'].str.lower()
 # +
 cols_to_join = ['src_hpo_id']
 
-site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
+site_df = full_names_df
 # -
 
 # # Below is used to define the 'concept success rate' of the source_concept_ids

--- a/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
@@ -114,28 +114,28 @@ percentage_dict = {
     constants.achilles_errors: constants.false
 }
 
+
+# FIXME: for errors, we want target_low value to be true
+
 target_low_dict = {
+    # non-percentage values
     constants.duplicates: constants.true,
-    constants.data_after_death: constants.true,
-    constants.end_before_begin: constants.true,
+    constants.achilles_errors: constants.true,
+
+    # success rates
     constants.concept: constants.false,
     constants.measurement_units: constants.false,
     constants.drug_routes: constants.false,
     constants.drug_success: constants.false,
     constants.sites_measurement: constants.false,
+
+    constants.data_after_death: constants.true,
+    constants.end_before_begin: constants.true,
     constants.visit_date_disparity: constants.false,
 
-    # FIXME: the three below - by logic - should
-    # be 'True' but were calculated as showing
-    # the % of errors rather than (100 - % of errors)
-    # in the DQM scripts. This means they should be
-    # logged as 'False' here to make it an effective
-    # double negative.
-    constants.date_datetime_disparity: constants.false,
-    constants.erroneous_dates: constants.false,
-    constants.person_id_failure_rate: constants.false,
-
-    constants.achilles_errors: constants.true
+    constants.date_datetime_disparity: constants.true,
+    constants.erroneous_dates: constants.true,
+    constants.person_id_failure_rate: constants.true,
 }
 
 columns_to_document_for_sheet = {
@@ -192,7 +192,7 @@ table_based_on_column_provided = {
 
     # general concept success rate columns
     constants.observation_success: constants.observation_full,
-    constants.drug_success: constants.drug_exposure_full,
+    constants.drug_success_col: constants.drug_exposure_full,
     constants.procedure_success: constants.procedure_full,
     constants.condition_success: constants.condition_occurrence_full,
     constants.measurement_success: constants.measurement_full,

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_dqm_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_dqm_objects.py
@@ -92,7 +92,7 @@ def get_info(
 
             # data for table for site does not exist
             if number is None or number == constants.no_data:
-                data_dictionary[col_label] = float(constants.nan_string)
+                data_dictionary[col_label] = 0
 
             else:
                 try:
@@ -109,11 +109,11 @@ def get_info(
                     # actual info to be logged if sensible data
                     elif percentage and target_low:  # proportion w/ errors
                         data_dictionary[col_label] = round(
-                            100 - number, constants.rounding_val)
+                            number, constants.rounding_val)
 
                     elif percentage and not target_low:  # effective
                         data_dictionary[col_label] = round(
-                            number, constants.rounding_val)
+                            100 - number, constants.rounding_val)
 
                     elif not percentage and number > -1:
                         data_dictionary[col_label] = int(number)
@@ -124,6 +124,6 @@ def get_info(
     # HPOs for consistency and versatility
     for table in data_dictionary:
         if table not in data_dictionary.keys():
-            data_dictionary[table] = float(constants.nan_string)
+            data_dictionary[table] = 0
 
     return data_dictionary

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
@@ -11,7 +11,7 @@ from functions_to_create_dqm_objects import find_hpo_row, \
     get_info
 import datetime
 import constants
-
+import math
 
 def establish_hpo_objects(dqm_objects):
     """
@@ -173,6 +173,7 @@ def add_number_total_rows_for_hpo_and_date(
                 target_low=False)
 
             for table_name, value in num_rows_dictionary.items():
+
                 hpo.add_row_count_with_string(
                     table=table_name, value=value)
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/messages.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/messages.py
@@ -47,7 +47,7 @@ L. Person ID failure rate
 M. Number of ACHILLES Errors
 
 Please specify your choice by typing the corresponding letter.
-        """
+"""
 
 output_prompt = \
     """

--- a/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
@@ -275,7 +275,7 @@ def create_excel_files(
 
 
 # UNIONED EHR DATASET COMPARISON
-report1 = 'may_10_2019.xlsx'
+report1 = 'may_23_2019.xlsx'
 report2 = 'july_15_2019.xlsx'
 report3 = 'october_04_2019.xlsx'
 report4 = 'april_17_2020.xlsx'

--- a/data_steward/analytics/table_metrics/metrics_over_time/unweighted_aggregate_metric_functions.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/unweighted_aggregate_metric_functions.py
@@ -22,6 +22,8 @@ from auxillary_aggregate_functions import \
 
 import numpy as np
 import constants
+import math
+
 
 def create_unweighted_aggregate_metrics_for_tables(
         metric_dictionary, datetimes):
@@ -253,7 +255,8 @@ def create_unweighted_aggregate_metric_for_dates(
 
                     value_for_hpo = agg_hpo_metric.overall_rate
 
-                    values.append(value_for_hpo)
+                    if not math.isnan(value_for_hpo):
+                        values.append(value_for_hpo)
 
             # here's where the 'unweighted' aspect comes in - simple mean
             overall_rate = sum(values) / len(values)

--- a/data_steward/analytics/table_metrics/metrics_over_time/weighted_aggregate_metric_functions.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/weighted_aggregate_metric_functions.py
@@ -19,7 +19,7 @@ from auxillary_aggregate_functions import \
     find_unique_dates_and_metrics, \
     get_stats_for_unweighted_table_aggregate_metric
 
-import constants
+import constants, math
 
 
 def create_weighted_aggregate_metrics_for_tables(
@@ -216,7 +216,9 @@ def create_weighted_aggregate_metric_for_dates(aggregate_metrics):
             for agg_hpo_metric in aggregate_metrics:
                 if agg_hpo_metric.date == date \
                         and agg_hpo_metric.metric_type == metric\
-                        and isinstance(agg_hpo_metric, AggregateMetricForHPO):
+                        and isinstance(agg_hpo_metric, AggregateMetricForHPO)\
+                        and not math.isnan(agg_hpo_metric.num_total_rows)\
+                        and not math.isnan(agg_hpo_metric.num_pertinent_rows):
 
                     hpo_total_rows = agg_hpo_metric.num_total_rows
                     hpo_pert_rows = agg_hpo_metric.num_pertinent_rows

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/data_after_death.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/data_after_death.py
@@ -120,16 +120,16 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_death_date'] / temporal_df['total'], 1)
 temporal_df
 
 # - main reason death date entered as default value ("1890")
 
 visit_occurrence = temporal_df.rename(
-    columns={"success_rate": "visit_occurrence"})
+    columns={"failure_rate": "visit_occurrence"})
 visit_occurrence = visit_occurrence[["src_hpo_id", "visit_occurrence"]]
-visit_occurrence = visit_occurrence.fillna(100)
+visit_occurrence = visit_occurrence.fillna(0)
 visit_occurrence
 
 # ## Condition Occurrence Table
@@ -166,16 +166,16 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_death_date'] / temporal_df['total'], 1)
 temporal_df
 
 condition_occurrence = temporal_df.rename(
-    columns={"success_rate": "condition_occurrence"})
+    columns={"failure_rate": "condition_occurrence"})
 condition_occurrence = condition_occurrence[[
     "src_hpo_id", "condition_occurrence"
 ]]
-condition_occurrence = condition_occurrence.fillna(100)
+condition_occurrence = condition_occurrence.fillna(0)
 condition_occurrence
 
 # ## Drug Exposure Table
@@ -211,13 +211,13 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_death_date'] / temporal_df['total'], 1)
 temporal_df
 
-drug_exposure = temporal_df.rename(columns={"success_rate": "drug_exposure"})
+drug_exposure = temporal_df.rename(columns={"failure_rate": "drug_exposure"})
 drug_exposure = drug_exposure[["src_hpo_id", "drug_exposure"]]
-drug_exposure = drug_exposure.fillna(100)
+drug_exposure = drug_exposure.fillna(0)
 drug_exposure
 
 # ## Measurement Table
@@ -253,13 +253,13 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] =  round(
     100 * temporal_df['wrong_death_date'] / temporal_df['total'], 1)
 temporal_df
 
-measurement = temporal_df.rename(columns={"success_rate": "measurement"})
+measurement = temporal_df.rename(columns={"failure_rate": "measurement"})
 measurement = measurement[["src_hpo_id", "measurement"]]
-measurement = measurement.fillna(100)
+measurement = measurement.fillna(0)
 measurement
 
 # ## Procedure Occurrence Table
@@ -295,16 +295,16 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_death_date'] / temporal_df['total'], 1)
 temporal_df
 
 procedure_occurrence = temporal_df.rename(
-    columns={"success_rate": "procedure_occurrence"})
+    columns={"failure_rate": "procedure_occurrence"})
 procedure_occurrence = procedure_occurrence[[
     "src_hpo_id", "procedure_occurrence"
 ]]
-procedure_occurrence = procedure_occurrence.fillna(100)
+procedure_occurrence = procedure_occurrence.fillna(0)
 procedure_occurrence
 
 # ## Observation Table
@@ -341,13 +341,14 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_death_date'] / temporal_df['total'], 1)
 temporal_df
 
-observation = temporal_df.rename(columns={"success_rate": "observation"})
+observation = temporal_df.rename(columns={"failure_rate": "observation"})
+
 observation = observation[["src_hpo_id", "observation"]]
-observation = observation.fillna(100)
+observation = observation.fillna(0)
 observation
 
 # ## 4. Success Rate Temporal Data Points - Data After Death Date
@@ -364,7 +365,7 @@ for filename in datas:
 master_df
 
 success_rate = pd.merge(master_df, site_df, how='outer', on='src_hpo_id')
-success_rate = success_rate.fillna(100)
+success_rate = success_rate.fillna(0)
 
 success_rate
 

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/duplicates.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/duplicates.py
@@ -135,13 +135,16 @@ visit_occurrence = visit_occurrence.reset_index()
 visit_occurrence
 
 # ## condition_occurrence table
+#
+# #### NOTE: have to cast as date for the datetime objects to avoid a runtime error - temporary fix for a larger issue
 
 # +
 condition_query = f"""
     SELECT
      src_hpo_id,
-person_id, condition_concept_id, condition_start_date, condition_start_datetime, condition_end_date,
-condition_end_datetime, condition_type_concept_id, stop_reason, provider_id, visit_occurrence_id,
+person_id, condition_concept_id, condition_start_date,
+CAST(condition_start_datetime AS DATE) as condition_start_datetime, condition_end_date,
+CAST(condition_end_datetime AS DATE) as condition_end_datetime, condition_type_concept_id, stop_reason, provider_id, visit_occurrence_id,
 condition_source_value, condition_source_concept_id, condition_status_source_value, condition_status_concept_id,
         COUNT(*) as cnt
     FROM
@@ -481,5 +484,3 @@ sites_success = sites_success.fillna(0)
 sites_success
 
 sites_success.to_csv("{cwd}/duplicates.csv".format(cwd = cwd))
-
-

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/end_before_begin.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/end_before_begin.py
@@ -151,14 +151,14 @@ temporal_df = pd.io.gbq.read_gbq('''
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_date_rows'] / temporal_df['total_rows'], 1)
 temporal_df
 
 visit_occurrence = temporal_df.rename(
-    columns={"success_rate": "visit_occurrence"})
+    columns={"failure_rate": "visit_occurrence"})
 visit_occurrence = visit_occurrence[["src_hpo_id", "visit_occurrence"]]
-visit_occurrence = visit_occurrence.fillna(100)
+visit_occurrence = visit_occurrence.fillna(0)
 visit_occurrence
 
 total_wrong = temporal_df['wrong_date_rows'].sum()
@@ -226,16 +226,16 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_date_rows'] / temporal_df['total_rows'], 1)
 temporal_df
 
 condition_occurrence = temporal_df.rename(
-    columns={"success_rate": "condition_occurrence"})
+    columns={"failure_rate": "condition_occurrence"})
 condition_occurrence = condition_occurrence[[
     "src_hpo_id", "condition_occurrence"
 ]]
-condition_occurrence = condition_occurrence.fillna(100)
+condition_occurrence = condition_occurrence.fillna(0)
 condition_occurrence
 
 total_wrong = temporal_df['wrong_date_rows'].sum()
@@ -301,13 +301,13 @@ temporal_df.shape
 print(temporal_df.shape[0], 'records received.')
 # -
 
-temporal_df['success_rate'] = 100 - round(
+temporal_df['failure_rate'] = round(
     100 * temporal_df['wrong_date_rows'] / temporal_df['total_rows'], 1)
 temporal_df
 
-drug_exposure = temporal_df.rename(columns={"success_rate": "drug_exposure"})
+drug_exposure = temporal_df.rename(columns={"failure_rate": "drug_exposure"})
 drug_exposure = drug_exposure[["src_hpo_id", "drug_exposure"]]
-drug_exposure = drug_exposure.fillna(100)
+drug_exposure = drug_exposure.fillna(0)
 drug_exposure
 
 total_wrong = temporal_df['wrong_date_rows'].sum()
@@ -330,7 +330,7 @@ success_rate = pd.merge(success_rate, drug_exposure, how='outer', on='src_hpo_id
 
 
 success_rate = pd.merge(success_rate, site_df, how='outer', on='src_hpo_id')
-success_rate = success_rate.fillna(100)
+success_rate = success_rate.fillna(0)
 success_rate
 # -
 

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/visit_date_disparity.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/visit_date_disparity.py
@@ -232,13 +232,13 @@ final_procedure_df = final_procedure_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_procedure_df['procedure_date_adherece'] = \
-round((final_procedure_df['num_total_records'] - final_procedure_df['num_bad_records']) / final_procedure_df['num_total_records'] * 100, 2)
+final_procedure_df['procedure_failure_rate'] = \
+round((final_procedure_df['num_bad_records']) / final_procedure_df['num_total_records'] * 100, 2)
 
 # +
 final_procedure_df = final_procedure_df.fillna(0)
 
-final_procedure_df = final_procedure_df.sort_values(by=['procedure_date_adherece'], ascending = False)
+final_procedure_df = final_procedure_df.sort_values(by=['procedure_failure_rate'], ascending = False)
 # -
 
 final_procedure_df
@@ -388,13 +388,13 @@ final_observation_df = final_observation_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_observation_df['observation_date_adherence'] = \
-round((final_observation_df['num_total_records'] - final_observation_df['num_bad_records']) / final_observation_df['num_total_records'] * 100, 2)
+final_observation_df['observation_date_failure'] = \
+round((final_observation_df['num_bad_records']) / final_observation_df['num_total_records'] * 100, 2)
 
 # +
 final_observation_df = final_observation_df.fillna(0)
 
-final_observation_df = final_observation_df.sort_values(by=['observation_date_adherence'], ascending = False)
+final_observation_df = final_observation_df.sort_values(by=['observation_date_failure'], ascending = False)
 # -
 
 # ### Creating a shorter df
@@ -544,13 +544,13 @@ final_measurment_df = final_measurment_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_measurment_df['measurement_date_adherence'] = \
-round((final_measurment_df['num_total_records'] - final_measurment_df['num_bad_records']) / final_measurment_df['num_total_records'] * 100, 2)
+final_measurment_df['measurement_date_failure'] = \
+round((final_measurment_df['num_bad_records']) / final_measurment_df['num_total_records'] * 100, 2)
 
 # +
 final_measurment_df = final_measurment_df.fillna(0)
 
-final_measurment_df = final_measurment_df.sort_values(by=['measurement_date_adherence'], ascending = False)
+final_measurment_df = final_measurment_df.sort_values(by=['measurement_date_failure'], ascending = False)
 
 # +
 ### Creating a shorter df
@@ -675,13 +675,13 @@ final_condition_df = final_condition_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_condition_df['condition_date_adherence'] = \
-round((final_condition_df['num_total_records'] - final_condition_df['num_bad_records']) / final_condition_df['num_total_records'] * 100, 2)
+final_condition_df['condition_date_failure'] = \
+round((final_condition_df['num_bad_records']) / final_condition_df['num_total_records'] * 100, 2)
 
 # +
 final_condition_df = final_condition_df.fillna(0)
 
-final_condition_df = final_condition_df.sort_values(by=['condition_date_adherence'], ascending = False)
+final_condition_df = final_condition_df.sort_values(by=['condition_date_failure'], ascending = False)
 # -
 
 # ### Creating a shorter df
@@ -806,13 +806,13 @@ final_drug_df = final_drug_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_drug_df['drug_date_adherence'] = \
-round((final_drug_df['num_total_records'] - final_drug_df['num_bad_records']) / final_drug_df['num_total_records'] * 100, 2)
+final_drug_df['drug_date_failure'] = \
+round((final_drug_df['num_bad_records']) / final_drug_df['num_total_records'] * 100, 2)
 
 # +
 final_drug_df = final_drug_df.fillna(0)
 
-final_drug_df = final_drug_df.sort_values(by=['drug_date_adherence'], ascending = False)
+final_drug_df = final_drug_df.sort_values(by=['drug_date_failure'], ascending = False)
 # -
 
 # ### Creating a shorter dataframe
@@ -826,7 +826,7 @@ short_drug_df
 final_success_df = 0
 
 final_success_df = pd.merge(short_drug_df, site_df, how='outer', on='src_hpo_id') 
-final_success_df = final_success_df[['src_hpo_id', 'drug_date_adherence']]  #rearrang columnds
+final_success_df = final_success_df[['src_hpo_id', 'drug_date_failure']]  #rearrang columnds
 
 # +
 final_success_df = pd.merge(final_success_df, short_observation_df, how='outer', on='src_hpo_id') 

--- a/data_steward/analytics/tools/dq_issue_tracker/create_dq_issue_site_dfs.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/create_dq_issue_site_dfs.py
@@ -27,10 +27,10 @@ from cross_reference_functions import cross_reference_old_metrics
 
 import pandas as pd
 
-old_dashboards = 'march_26_2020_data_quality_issues.xlsx'
+old_dashboards = 'april_17_2020_data_quality_issues.xlsx'
 
-old_excel_file_name = 'march_19_2020.xlsx'
-excel_file_name = 'april_17_2020.xlsx'
+old_excel_file_name = 'april_17_2020.xlsx'
+excel_file_name = 'may_11_2020.xlsx'
 
 metric_names = list(metric_names.keys())  # sheets to be investigated
 


### PR DESCRIPTION
* Ensured consistency in the means of calculating error rates (reporting 'error rate' rather than a mix of 'error rate' and 'success rate')

* Implemented a temporary workaround for a bug within the duplicates notebook (regarding datetime casting)

* Uses 0 values instead of nan values in the metrics_over_time module

* Fixed the dictionaries and lists with respect to the constants file.

* Changed the means of generating the full site names in the combined/deid datasets

* Changed setup functions of the duplicates metric (relic of old setups)