### PR TITLE
[DC-827] Update Numeric Free Text CR to New Base Class

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -16,13 +16,11 @@ import bq_utils
 import sandbox
 import cdr_cleaner.clean_cdr_engine as clean_engine
 import cdr_cleaner.cleaning_rules.backfill_pmi_skip_codes as back_fill_pmi_skip
-import cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters as ppi_numeric_fields
 import cdr_cleaner.cleaning_rules.clean_years as clean_years
 import cdr_cleaner.cleaning_rules.domain_alignment as domain_alignment
 import cdr_cleaner.cleaning_rules.drop_duplicate_states as drop_duplicate_states
 import cdr_cleaner.cleaning_rules.drop_participants_without_ppi_or_ehr as drop_participants_without_ppi_or_ehr
 import cdr_cleaner.cleaning_rules.drug_refills_days_supply as drug_refills_supply
-import cdr_cleaner.cleaning_rules.ensure_date_datetime_consistency as fix_datetimes
 import cdr_cleaner.cleaning_rules.fill_free_text_source_value as fill_source_value
 import cdr_cleaner.cleaning_rules.id_deduplicate as id_dedup
 import cdr_cleaner.cleaning_rules.maps_to_value_ppi_vocab_update as maps_to_value_vocab_update
@@ -53,6 +51,7 @@ from cdr_cleaner.cleaning_rules.clean_mapping import CleanMappingExtTables
 from cdr_cleaner.cleaning_rules.ensure_date_datetime_consistency import EnsureDateDatetimeConsistency
 from cdr_cleaner.cleaning_rules.rdr_observation_source_concept_id_suppression import ObservationSourceConceptIDRowSuppression
 from cdr_cleaner.cleaning_rules.null_concept_ids_for_numeric_ppi import NullConceptIDForNumericPPI
+from cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters import CleanPPINumericFieldsUsingParameters
 from constants.cdr_cleaner.clean_cdr import DataStage as stage
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 
@@ -93,7 +92,7 @@ RDR_CLEANING_CLASSES = [
     (ObservationSourceConceptIDRowSuppression,),
     (maps_to_value_vocab_update.get_maps_to_value_ppi_vocab_update_queries,),
     (back_fill_pmi_skip.get_run_pmi_fix_queries,),
-    (ppi_numeric_fields.get_clean_ppi_num_fields_using_parameters_queries,),
+    (CleanPPINumericFieldsUsingParameters,),
     (NullConceptIDForNumericPPI,),
     (remove_multiple_race_answers.
      get_remove_multiple_race_ethnicity_answers_queries,),

--- a/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule.py
@@ -169,6 +169,7 @@ class BaseCleaningRule(AbstractBaseCleaningRule):
         self._sandbox_dataset_id = sandbox_dataset_id
         self._issue_urls = issue_urls if issue_urls else []
         self._depends_on_classes = depends_on if depends_on else []
+        self._affected_tables = affected_tables
 
         super().__init__()
 

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -33,8 +33,6 @@ jinja_env = Environment(
     comment_start_string='--',
     comment_end_string=' --')
 
-SAVE_TABLE_NAME = 'dc_827_obs_changed_rows_saved'
-
 # Query to create tables in sandbox with the rows that will be removed per cleaning rule
 SANDBOX_QUERY = jinja_env.from_string("""
 CREATE OR REPLACE TABLE
@@ -176,6 +174,7 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
         super().__init__(issue_numbers=['DC-827', 'DC-502', 'DC-487'],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],
+                         affected_tables=['observation'],
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id)
@@ -194,7 +193,7 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
                     project=self.get_project_id(),
                     dataset=self.get_dataset_id(),
                     sandbox_dataset=self.get_sandbox_dataset_id(),
-                    intermediary_table=SAVE_TABLE_NAME),
+                    intermediary_table=self.get_sandbox_tablenames()),
         }
 
         clean_ppi_numeric_fields_query = {
@@ -219,7 +218,10 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
         pass
 
     def get_sandbox_tablenames(self):
-        return [SAVE_TABLE_NAME]
+        sandbox_table_names = list()
+        sandbox_table_names.append(self._issue_numbers[0] +
+                                   self._affected_tables[0])
+        return sandbox_table_names
 
 
 if __name__ == '__main__':

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -139,7 +139,7 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
                     project=self.get_project_id(),
                     dataset=self.get_dataset_id(),
                     sandbox_dataset=self.get_sandbox_dataset_id(),
-                    intermediary_table=self.get_sandbox_tablenames()),
+                    intermediary_table=self.get_sandbox_tablenames()[0]),
         }
 
         clean_ppi_numeric_fields_query = {

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -79,9 +79,9 @@ END AS
     value_as_number,
     value_as_string,
 CASE
-    WHEN observation_concept_id IN (1585889, 1585890) AND (value_as_number < 0 OR value_as_number > 20) THEN NULL
-    WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN NULL
-    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN NULL
+    WHEN observation_concept_id IN (1585889, 1585890) AND (value_as_number < 0 OR value_as_number > 20) THEN 2000000010
+    WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
+    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
   ELSE value_as_concept_id
 END AS
     value_as_concept_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -212,11 +212,33 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
 
         return [save_changed_rows, clean_ppi_numeric_fields_query]
 
-    def setup_rule(self):
+    def setup_rule(self, client):
         """
         Function to run any data upload options before executing a query.
         """
         pass
+
+    def setup_validation(self, client):
+        """
+        Run required steps for validation setup
+
+        This abstract method was added to the base class after this rule was authored.
+        This rule needs to implement logic to setup validation on cleaning rules that
+        will be updating or deleting the values.
+        Until done no issue exists for this yet.
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+
+        This abstract method was added to the base class after this rule was authored.
+        This rule needs to implement logic to run validation on cleaning rules that will
+        be updating or deleting the values.
+        Until done no issue exists for this yet.
+        """
+        raise NotImplementedError("Please fix me.")
 
     def get_sandbox_tablenames(self):
         return [SAVE_TABLE_NAME]

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -71,72 +71,18 @@ SELECT
     observation_datetime,
     observation_type_concept_id,
 CASE
-    WHEN observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-    
-    WHEN observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-       
-    WHEN observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN NULL
-    
-    ELSE value_as_number
+    WHEN observation_concept_id IN (1585889, 1585890) AND (value_as_number < 0 OR value_as_number > 20) THEN NULL
+    WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN NULL
+    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN NULL
+  ELSE value_as_number
 END AS
     value_as_number,
     value_as_string,
 CASE
-    WHEN observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    WHEN observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)
-    THEN 2000000010
-    
-    ELSE value_as_concept_id
+    WHEN observation_concept_id IN (1585889, 1585890) AND (value_as_number < 0 OR value_as_number > 20) THEN NULL
+    WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN NULL
+    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN NULL
+  ELSE value_as_concept_id
 END AS
     value_as_concept_id,
     qualifier_concept_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -117,7 +117,7 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
         desc = (
             'Sets value_as_number to NULL and value_as_concept_id and observation_type_concept_id '
             'to new AOU custom concept 2000000010')
-        super().__init__(issue_numbers=['DC-827', 'DC-502', 'DC-487'],
+        super().__init__(issue_numbers=['DC827', 'DC502', 'DC487'],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],
                          affected_tables=['observation'],

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -157,9 +157,21 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
 
         return [save_changed_rows, clean_ppi_numeric_fields_query]
 
-    def setup_rule(self):
+    def setup_rule(self, client):
         """
         Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def setup_validation(self, client):
+        """
+        Run required steps for validation setup
+        """
+        pass
+
+    def validate_rule(self, client):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
         """
         pass
 

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -44,23 +44,23 @@ FROM
     `{{project}}.{{dataset}}.observation`
 WHERE
     (observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20))
-OR
+AND
     (observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20))
-OR
+AND
     (observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99))
-OR
+AND
     (observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99))
-OR
+AND
     (observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255))
-OR
+AND
     (observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99))
-OR
+AND
     (observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99))
-OR 
+AND 
     (observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99))
-OR
+AND
     (observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99))
-OR
+AND
     (observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)))
 """)
 
@@ -155,13 +155,110 @@ END AS
 FROM
     {{project}}.{{dataset}}.observation""")
 
+# CLEAN_PPI_NUMERIC_FIELDS = """
+# UPDATE
+#   `{project}.{dataset}.observation` u1
+# SET
+#   u1.value_as_number = NULL,
+#   u1.value_as_concept_id = 2000000010
+# FROM
+#   (
+#   SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99) ) a
+# WHERE
+#   u1.observation_id = a.observation_id
+# """
 
 class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
     """
     Apply value ranges to ensure that values are reasonable and to minimize the likelihood
     of sensitive information (like phone numbers) within the free text fields.
     """
-
     def __init__(self, project_id, dataset_id, sandbox_dataset_id):
         """
         Initialize the class with proper information.
@@ -199,9 +296,8 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
 
         clean_ppi_numeric_fields_query = {
             cdr_consts.QUERY:
-                CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(
-                    project=self.get_project_id(),
-                    dataset=self.get_dataset_id()),
+                CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.get_project_id(),
+                                                      dataset=self.get_dataset_id()),
             cdr_consts.DESTINATION_TABLE:
                 'observation',
             cdr_consts.DESTINATION_DATASET:
@@ -212,33 +308,11 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
 
         return [save_changed_rows, clean_ppi_numeric_fields_query]
 
-    def setup_rule(self, client):
+    def setup_rule(self):
         """
         Function to run any data upload options before executing a query.
         """
         pass
-
-    def setup_validation(self, client):
-        """
-        Run required steps for validation setup
-
-        This abstract method was added to the base class after this rule was authored.
-        This rule needs to implement logic to setup validation on cleaning rules that
-        will be updating or deleting the values.
-        Until done no issue exists for this yet.
-        """
-        raise NotImplementedError("Please fix me.")
-
-    def validate_rule(self):
-        """
-        Validates the cleaning rule which deletes or updates the data from the tables
-
-        This abstract method was added to the base class after this rule was authored.
-        This rule needs to implement logic to run validation on cleaning rules that will
-        be updating or deleting the values.
-        Until done no issue exists for this yet.
-        """
-        raise NotImplementedError("Please fix me.")
 
     def get_sandbox_tablenames(self):
         return [SAVE_TABLE_NAME]
@@ -251,8 +325,7 @@ if __name__ == '__main__':
     ARGS = parser.parse_args()
 
     clean_engine.add_console_logging(ARGS.console_log)
-    rdr_cleaner = CleanPPINumericFieldsUsingParameters(ARGS.project_id,
-                                                       ARGS.dataset_id,
+    rdr_cleaner = CleanPPINumericFieldsUsingParameters(ARGS.project_id, ARGS.dataset_id,
                                                        ARGS.sandbox_dataset_id)
     query_list = rdr_cleaner.get_query_specs()
 

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -1,123 +1,321 @@
-import constants.cdr_cleaner.clean_cdr as cdr_consts
+"""
+Apply value ranges to ensure that values are reasonable and to minimize the likelihood
+of sensitive information (like phone numbers) within the free text fields.
 
-CLEAN_PPI_NUMERIC_FIELDS = """
-UPDATE
-  `{project}.{dataset}.observation` u1
-SET
-  u1.value_as_number = NULL,
-  u1.value_as_concept_id = 2000000010
-FROM
-  (
-  SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
+Original Issues: DC-827, DC-502, DC-487
 
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
-
-UNION ALL
-
-SELECT
-  *
-FROM
-  `{project}.{dataset}.observation`
-WHERE
-  observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99) ) a
-WHERE
-  u1.observation_id = a.observation_id
+The intent is to ensure that numeric free-text fields that are not manipulated by de-id
+have value range restrictions applied to the value_as_number field across the entire dataset.
 """
 
+# Python imports
+import logging
 
-def get_clean_ppi_num_fields_using_parameters_queries(project_id, dataset_id):
+# Third party imports
+from jinja2 import Environment
+
+# Project imports
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from constants.bq_utils import WRITE_TRUNCATE
+
+LOGGER = logging.getLogger(__name__)
+
+jinja_env = Environment(
+    # help protect against cross-site scripting vulnerabilities
+    autoescape=True,
+    # block tags on their own lines
+    # will not cause extra white space
+    trim_blocks=True,
+    lstrip_blocks=True,
+    # syntax highlighting should be better
+    # with these comment delimiters
+    comment_start_string='--',
+    comment_end_string=' --')
+
+SAVE_TABLE_NAME = 'dc_827_obs_changed_rows_saved'
+
+# Query to create tables in sandbox with the rows that will be removed per cleaning rule
+SANDBOX_QUERY = jinja_env.from_string("""
+CREATE OR REPLACE TABLE
+    `{{project}}.{{sandbox_dataset}}.{{intermediary_table}}` AS (
+SELECT *
+FROM
+    `{{project}}.{{dataset}}.observation`
+WHERE
+    (observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20))
+AND
+    (observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20))
+AND
+    (observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99))
+AND
+    (observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99))
+AND
+    (observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255))
+AND
+    (observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99))
+AND
+    (observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99))
+AND 
+    (observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99))
+AND
+    (observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99))
+AND
+    (observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)))
+""")
+
+CLEAN_PPI_NUMERIC_FIELDS_QUERY = jinja_env.from_string("""
+SELECT 
+    observation_id,
+    person_id,
+    observation_concept_id,
+    observation_date,
+    observation_datetime,
+    observation_type_concept_id,
+CASE
+    WHEN observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+    
+    WHEN observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+       
+    WHEN observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN NULL
+    
+    ELSE value_as_number
+END AS
+    value_as_number,
+    value_as_string,
+CASE
+    WHEN observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    WHEN observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)
+    THEN 2000000010
+    
+    ELSE value_as_concept_id
+END AS
+    value_as_concept_id,
+    qualifier_concept_id,
+    unit_concept_id,
+    provider_id,
+    visit_occurrence_id,
+    observation_source_value,
+    observation_source_concept_id,
+    unit_source_value,
+    qualifier_source_value,
+    value_source_concept_id,
+    value_source_value,
+    questionnaire_response_id
+FROM
+    {{project}}.{{dataset}}.observation""")
+
+# CLEAN_PPI_NUMERIC_FIELDS = """
+# UPDATE
+#   `{project}.{dataset}.observation` u1
+# SET
+#   u1.value_as_number = NULL,
+#   u1.value_as_concept_id = 2000000010
+# FROM
+#   (
+#   SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
+#
+# UNION ALL
+#
+# SELECT
+#   *
+# FROM
+#   `{project}.{dataset}.observation`
+# WHERE
+#   observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99) ) a
+# WHERE
+#   u1.observation_id = a.observation_id
+# """
+
+class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
     """
-    runs the query which updates the ppi numeric fields in observation table based on the 
-    upper and lower bounds specified.
-    :param project_id: Name of the project
-    :param dataset_id: Name of the dataset where the queries should be run
-    :return:
+    Apply value ranges to ensure that values are reasonable and to minimize the likelihood
+    of sensitive information (like phone numbers) within the free text fields.
     """
-    queries_list = []
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper information.
 
-    query = dict()
-    query[cdr_consts.QUERY] = CLEAN_PPI_NUMERIC_FIELDS.format(
-        dataset=dataset_id,
-        project=project_id,
-    )
-    queries_list.append(query)
+        Set the issue numbers, description and affected datasets. As other tickets may affect
+        this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = (
+            'Sets value_as_number to NULL and value_as_concept_id and observation_type_concept_id '
+            'to new AOU custom concept 2000000010')
+        super().__init__(issue_numbers=['DC-827', 'DC-502', 'DC-487'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
 
-    return queries_list
+    def get_query_specs(self):
+        """
+        Return a list of dictionary query specifications.
+
+        :return:  A list of dictionaries. Each dictionary contains a single query
+            and a specification for how to execute that query. The specifications
+            are optional but the query is required.
+        """
+        save_changed_rows = {
+            cdr_consts.QUERY:
+                SANDBOX_QUERY.render(
+                    project=self.get_project_id(),
+                    dataset=self.get_dataset_id(),
+                    sandbox_dataset=self.get_sandbox_dataset_id(),
+                    intermediary_table=SAVE_TABLE_NAME),
+        }
+
+        clean_ppi_numeric_fields_query = {
+            cdr_consts.QUERY:
+                CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.get_project_id(),
+                                                      dataset=self.get_dataset_id()),
+            cdr_consts.DESTINATION_TABLE:
+                'observation',
+            cdr_consts.DESTINATION_DATASET:
+                self.get_dataset_id(),
+            cdr_consts.DISPOSITION:
+                WRITE_TRUNCATE
+        }
+
+        return [save_changed_rows, clean_ppi_numeric_fields_query]
+
+    def setup_rule(self):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def get_sandbox_tablenames(self):
+        return [SAVE_TABLE_NAME]
 
 
 if __name__ == '__main__':
@@ -125,7 +323,13 @@ if __name__ == '__main__':
     import cdr_cleaner.clean_cdr_engine as clean_engine
 
     ARGS = parser.parse_args()
+
     clean_engine.add_console_logging(ARGS.console_log)
-    query_list = get_clean_ppi_num_fields_using_parameters_queries(
-        ARGS.project_id, ARGS.dataset_id)
-    clean_engine.clean_dataset(ARGS.project_id, query_list)
+    rdr_cleaner = CleanPPINumericFieldsUsingParameters(ARGS.project_id, ARGS.dataset_id,
+                                                       ARGS.sandbox_dataset_id)
+    query_list = rdr_cleaner.get_query_specs()
+
+    if ARGS.list_queries:
+        rdr_cleaner.log_queries()
+    else:
+        clean_engine.clean_dataset(ARGS.project_id, query_list)

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -44,23 +44,23 @@ FROM
     `{{project}}.{{dataset}}.observation`
 WHERE
     (observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20))
-AND
+OR
     (observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20))
-AND
+OR
     (observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99))
-AND
+OR
     (observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99))
-AND
+OR
     (observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255))
-AND
+OR
     (observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99))
-AND
+OR
     (observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99))
-AND 
+OR 
     (observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99))
-AND
+OR
     (observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99))
-AND
+OR
     (observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99)))
 """)
 
@@ -155,110 +155,13 @@ END AS
 FROM
     {{project}}.{{dataset}}.observation""")
 
-# CLEAN_PPI_NUMERIC_FIELDS = """
-# UPDATE
-#   `{project}.{dataset}.observation` u1
-# SET
-#   u1.value_as_number = NULL,
-#   u1.value_as_concept_id = 2000000010
-# FROM
-#   (
-#   SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585889 AND (value_as_number < 0 OR value_as_number > 20)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585890 AND (value_as_number < 0 OR value_as_number > 20)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99)
-#
-# UNION ALL
-#
-# SELECT
-#   *
-# FROM
-#   `{project}.{dataset}.observation`
-# WHERE
-#   observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99) ) a
-# WHERE
-#   u1.observation_id = a.observation_id
-# """
 
 class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
     """
     Apply value ranges to ensure that values are reasonable and to minimize the likelihood
     of sensitive information (like phone numbers) within the free text fields.
     """
+
     def __init__(self, project_id, dataset_id, sandbox_dataset_id):
         """
         Initialize the class with proper information.
@@ -296,8 +199,9 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
 
         clean_ppi_numeric_fields_query = {
             cdr_consts.QUERY:
-                CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.get_project_id(),
-                                                      dataset=self.get_dataset_id()),
+                CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(
+                    project=self.get_project_id(),
+                    dataset=self.get_dataset_id()),
             cdr_consts.DESTINATION_TABLE:
                 'observation',
             cdr_consts.DESTINATION_DATASET:
@@ -325,7 +229,8 @@ if __name__ == '__main__':
     ARGS = parser.parse_args()
 
     clean_engine.add_console_logging(ARGS.console_log)
-    rdr_cleaner = CleanPPINumericFieldsUsingParameters(ARGS.project_id, ARGS.dataset_id,
+    rdr_cleaner = CleanPPINumericFieldsUsingParameters(ARGS.project_id,
+                                                       ARGS.dataset_id,
                                                        ARGS.sandbox_dataset_id)
     query_list = rdr_cleaner.get_query_specs()
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -1,0 +1,123 @@
+"""
+Integration test for clean_ppi_numeric_fields_using_parameters module
+
+Apply value ranges to ensure that values are reasonable and to minimize the likelihood
+of sensitive information (like phone numbers) within the free text fields.
+
+Original Issues: DC-827, DC-502, DC-487
+
+The intent is to ensure that numeric free-text fields that are not manipulated by de-id
+have value range restrictions applied to the value_as_number field across the entire dataset.
+"""
+
+# Python Imports
+import os
+
+# Project Imports
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters import CleanPPINumericFieldsUsingParameters
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+
+class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # Set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # Set the expected test datasets
+        dataset_id = os.environ.get('RDR_DATASET_ID')
+        sandbox_id = dataset_id + '_sandbox'
+
+        cls.query_class = CleanPPINumericFieldsUsingParameters(
+            project_id, dataset_id, sandbox_id)
+
+        sb_table_names = cls.query_class.get_sandbox_tablenames()
+        for table_name in sb_table_names:
+            cls.fq_sandbox_table_names.append(
+                f'{project_id}.{sandbox_id}.{table_name}')
+
+        cls.fq_table_names = [f'{project_id}.{dataset_id}.observation']
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and a common
+        fully qualified (fq) dataset name string to load the data.
+        """
+        self.value_as_number = 'NULL'
+        self.value_as_concept_id = 2000000010
+
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+    def test_field_cleaning(self):
+        """
+        Tests that the specifications for the SANDBOX_QUERY and CLEAN_PPI_NUMERIC_FIELDS_QUERY
+        perform as designed.
+
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+
+        tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{fq_dataset_name}}.observation`
+            (observation_id, person_id, observation_concept_id, observation_date, 
+             observation_type_concept_id, value_as_number, value_as_concept_id)
+            VALUES
+                (123, 111111, 1585889, date('2015-07-15'), 0, 21, 111),
+                (345, 222222, 1585890, date('2015-07-15'), 0, -21, 222),
+                (567, 333333, 1585795, date('2015-07-15'), 0, 100, 333),
+                (789, 444444, 1585802, date('2015-07-15'), 0, -100, 444),
+                (555, 555555, 1585820, date('2015-07-15'), 0, 256, 111),
+                (121, 121212, 1585820, date('2015-07-15'), 0, -256, 111),
+                (666, 666666, 1585864, date('2015-07-15'), 0, 100, 222),
+                (777, 777777, 1585870, date('2015-07-15'), 0, -100, 333),
+                (888, 888888, 1585873, date('2015-07-15'), 0, 15, 444),
+                (999, 999999, 1586159, date('2015-07-15'), 0, 16, 444),
+                (321, 000000, 1586162, date('2015-07-15'), 0, 17, 444)""")
+
+        query = tmpl.render(fq_dataset_name=self.fq_dataset_name)
+        self.load_test_data([query])
+
+        # Expected results list
+        tables_and_counts = [{
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, 'observation']),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
+            'loaded_ids': [123, 345, 567, 789, 555, 121, 666, 777, 888, 999, 321],
+            'sandboxed_ids': [123, 345, 567, 789, 555, 121, 666, 777],
+            'fields': [
+                'observation_id', 'observation_concept_id',
+                'value_as_number', 'value_as_concept_id'
+            ],
+            'cleaned_values': [
+                (123, 1585889, self.value_as_number, self.value_as_concept_id),
+                (345, 1585890, self.value_as_number, self.value_as_concept_id),
+                (567, 1585795, self.value_as_number, self.value_as_concept_id),
+                (789, 1585802, self.value_as_number, self.value_as_concept_id),
+                (555, 1585820, self.value_as_number, self.value_as_concept_id),
+                (121, 1585820, self.value_as_number, self.value_as_concept_id),
+                (666, 1585864, self.value_as_number, self.value_as_concept_id),
+                (777, 1585870, self.value_as_number, self.value_as_concept_id),
+                (888, 1585873, 15, 444),
+                (999, 1586159, 16, 444),
+                (321, 1586162, 17, 444)]
+        }]
+
+        self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -59,7 +59,7 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
         Creates common expected parameter types from cleaned tables and a common
         fully qualified (fq) dataset name string to load the data.
         """
-        self.value_as_number = 'NULL'
+        self.value_as_number = None
         self.value_as_concept_id = 2000000010
 
         fq_dataset_name = self.fq_table_names[0].split('.')
@@ -100,11 +100,13 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
                 '.'.join([self.fq_dataset_name, 'observation']),
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'loaded_ids': [123, 345, 567, 789, 555, 121, 666, 777, 888, 999, 321],
+            'loaded_ids': [
+                123, 345, 567, 789, 555, 121, 666, 777, 888, 999, 321
+            ],
             'sandboxed_ids': [123, 345, 567, 789, 555, 121, 666, 777],
             'fields': [
-                'observation_id', 'observation_concept_id',
-                'value_as_number', 'value_as_concept_id'
+                'observation_id', 'observation_concept_id', 'value_as_number',
+                'value_as_concept_id'
             ],
             'cleaned_values': [
                 (123, 1585889, self.value_as_number, self.value_as_concept_id),
@@ -115,9 +117,9 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
                 (121, 1585820, self.value_as_number, self.value_as_concept_id),
                 (666, 1585864, self.value_as_number, self.value_as_concept_id),
                 (777, 1585870, self.value_as_number, self.value_as_concept_id),
-                (888, 1585873, 15, 444),
-                (999, 1586159, 16, 444),
-                (321, 1586162, 17, 444)]
+                (888, 1585873, 15, 444), (999, 1586159, 16, 444),
+                (321, 1586162, 17, 444)
+            ]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -59,7 +59,7 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
         Creates common expected parameter types from cleaned tables and a common
         fully qualified (fq) dataset name string to load the data.
         """
-        self.value_as_number = None
+        self.value_as_number = 'NULL'
         self.value_as_concept_id = 2000000010
 
         fq_dataset_name = self.fq_table_names[0].split('.')
@@ -100,13 +100,11 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
                 '.'.join([self.fq_dataset_name, 'observation']),
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'loaded_ids': [
-                123, 345, 567, 789, 555, 121, 666, 777, 888, 999, 321
-            ],
+            'loaded_ids': [123, 345, 567, 789, 555, 121, 666, 777, 888, 999, 321],
             'sandboxed_ids': [123, 345, 567, 789, 555, 121, 666, 777],
             'fields': [
-                'observation_id', 'observation_concept_id', 'value_as_number',
-                'value_as_concept_id'
+                'observation_id', 'observation_concept_id',
+                'value_as_number', 'value_as_concept_id'
             ],
             'cleaned_values': [
                 (123, 1585889, self.value_as_number, self.value_as_concept_id),
@@ -117,9 +115,9 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
                 (121, 1585820, self.value_as_number, self.value_as_concept_id),
                 (666, 1585864, self.value_as_number, self.value_as_concept_id),
                 (777, 1585870, self.value_as_number, self.value_as_concept_id),
-                (888, 1585873, 15, 444), (999, 1586159, 16, 444),
-                (321, 1586162, 17, 444)
-            ]
+                (888, 1585873, 15, 444),
+                (999, 1586159, 16, 444),
+                (321, 1586162, 17, 444)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -31,6 +31,7 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
         self.project_id = 'foo_project'
         self.dataset_id = 'bar_dataset'
         self.sandbox_id = 'baz_sandbox'
+        self.client = None
 
         self.query_class = CleanPPINumericFieldsUsingParameters(
             self.project_id, self.dataset_id, self.sandbox_id)
@@ -42,7 +43,7 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
 
     def test_setup_rule(self):
         # Test
-        self.query_class.setup_rule()
+        self.query_class.setup_rule(self.client)
 
         # No errors are raised, nothing will happen
 

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -65,12 +65,9 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
             clean_consts.QUERY:
                 CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.project_id,
                                                       dataset=self.dataset_id),
-            clean_consts.DESTINATION_TABLE:
-                'observation',
-            clean_consts.DESTINATION_DATASET:
-                self.dataset_id,
-            clean_consts.DISPOSITION:
-                WRITE_TRUNCATE
+            clean_consts.DESTINATION_TABLE: 'observation',
+            clean_consts.DESTINATION_DATASET: self.dataset_id,
+            clean_consts.DISPOSITION: WRITE_TRUNCATE
         }]
 
         self.assertEqual(results_list, expected_list)
@@ -87,7 +84,8 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
             intermediary_table=SAVE_TABLE_NAME)
 
         select_rows_to_be_changed = CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(
-            project=self.project_id, dataset=self.dataset_id)
+            project=self.project_id,
+            dataset=self.dataset_id)
 
         # Test
         with self.assertLogs(level='INFO') as cm:

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -16,7 +16,8 @@ import unittest
 # Project imports
 from constants.bq_utils import WRITE_TRUNCATE
 from constants.cdr_cleaner import clean_cdr as clean_consts
-from cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters import CleanPPINumericFieldsUsingParameters, SAVE_TABLE_NAME, SANDBOX_QUERY, CLEAN_PPI_NUMERIC_FIELDS_QUERY
+from cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters import CleanPPINumericFieldsUsingParameters, \
+    SANDBOX_QUERY, CLEAN_PPI_NUMERIC_FIELDS_QUERY
 
 
 class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
@@ -61,7 +62,8 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
                 SANDBOX_QUERY.render(project=self.project_id,
                                      dataset=self.dataset_id,
                                      sandbox_dataset=self.sandbox_id,
-                                     intermediary_table=SAVE_TABLE_NAME)
+                                     intermediary_table=self.query_class.
+                                     get_sandbox_tablenames()[0])
         }, {
             clean_consts.QUERY:
                 CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.project_id,
@@ -85,7 +87,7 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
             project=self.project_id,
             dataset=self.dataset_id,
             sandbox_dataset=self.sandbox_id,
-            intermediary_table=SAVE_TABLE_NAME)
+            intermediary_table=self.query_class.get_sandbox_tablenames()[0])
 
         select_rows_to_be_changed = CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(
             project=self.project_id, dataset=self.dataset_id)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -1,0 +1,102 @@
+"""
+Unit test for clean_ppi_numeric_fields_using_parameters module
+
+Apply value ranges to ensure that values are reasonable and to minimize the likelihood
+of sensitive information (like phone numbers) within the free text fields.
+
+Original Issues: DC-827, DC-502, DC-487
+
+The intent is to ensure that numeric free-text fields that are not manipulated by de-id
+have value range restrictions applied to the value_as_number field across the entire dataset.
+"""
+
+# Python imports
+import unittest
+
+# Project imports
+from constants.bq_utils import WRITE_TRUNCATE
+from constants.cdr_cleaner import clean_cdr as clean_consts
+from cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters import CleanPPINumericFieldsUsingParameters, SAVE_TABLE_NAME, SANDBOX_QUERY, CLEAN_PPI_NUMERIC_FIELDS_QUERY
+
+
+class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'foo_project'
+        self.dataset_id = 'bar_dataset'
+        self.sandbox_id = 'baz_sandbox'
+
+        self.query_class = CleanPPINumericFieldsUsingParameters(
+            self.project_id, self.dataset_id, self.sandbox_id)
+
+        self.assertEquals(self.query_class.get_project_id(), self.project_id)
+        self.assertEquals(self.query_class.get_dataset_id(), self.dataset_id)
+        self.assertEquals(self.query_class.get_sandbox_dataset_id(),
+                          self.sandbox_id)
+
+    def test_setup_rule(self):
+        # Test
+        self.query_class.setup_rule()
+
+        # No errors are raised, nothing will happen
+
+    def test_get_query_specs(self):
+        # Pre conditions
+        self.assertEqual(self.query_class.get_affected_datasets(),
+                         [clean_consts.RDR])
+
+        # Test
+        results_list = self.query_class.get_query_specs()
+
+        # Post conditions
+        expected_list = [{
+            clean_consts.QUERY:
+                SANDBOX_QUERY.render(project=self.project_id,
+                                     dataset=self.dataset_id,
+                                     sandbox_dataset=self.sandbox_id,
+                                     intermediary_table=SAVE_TABLE_NAME)
+        }, {
+            clean_consts.QUERY:
+                CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.project_id,
+                                                      dataset=self.dataset_id),
+            clean_consts.DESTINATION_TABLE: 'observation',
+            clean_consts.DESTINATION_DATASET: self.dataset_id,
+            clean_consts.DISPOSITION: WRITE_TRUNCATE
+        }]
+
+        self.assertEqual(results_list, expected_list)
+
+    def test_log_queries(self):
+        # Pre conditions
+        self.assertEqual(self.query_class.get_affected_datasets(),
+                         [clean_consts.RDR])
+
+        store_rows_to_be_changed = SANDBOX_QUERY.render(
+            project=self.project_id,
+            dataset=self.dataset_id,
+            sandbox_dataset=self.sandbox_id,
+            intermediary_table=SAVE_TABLE_NAME)
+
+        select_rows_to_be_changed = CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(
+            project=self.project_id,
+            dataset=self.dataset_id)
+
+        # Test
+        with self.assertLogs(level='INFO') as cm:
+            self.query_class.log_queries()
+
+            expected = [
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                + store_rows_to_be_changed,
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                + select_rows_to_be_changed
+            ]
+
+            # Post condition
+            self.assertEqual(cm.output, expected)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -65,9 +65,12 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
             clean_consts.QUERY:
                 CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(project=self.project_id,
                                                       dataset=self.dataset_id),
-            clean_consts.DESTINATION_TABLE: 'observation',
-            clean_consts.DESTINATION_DATASET: self.dataset_id,
-            clean_consts.DISPOSITION: WRITE_TRUNCATE
+            clean_consts.DESTINATION_TABLE:
+                'observation',
+            clean_consts.DESTINATION_DATASET:
+                self.dataset_id,
+            clean_consts.DISPOSITION:
+                WRITE_TRUNCATE
         }]
 
         self.assertEqual(results_list, expected_list)
@@ -84,8 +87,7 @@ class CleanPPINumericFieldsUsingParametersTest(unittest.TestCase):
             intermediary_table=SAVE_TABLE_NAME)
 
         select_rows_to_be_changed = CLEAN_PPI_NUMERIC_FIELDS_QUERY.render(
-            project=self.project_id,
-            dataset=self.dataset_id)
+            project=self.project_id, dataset=self.dataset_id)
 
         # Test
         with self.assertLogs(level='INFO') as cm:


### PR DESCRIPTION
- Updated `clean_ppi_numeric_fields_using_parameters.py` to use new base class `base_cleaning_rule.py` with DML statements changed to SQL SELECT statements

- Replaced `ppi_numeric_fields` with  `CleanPPINumericFieldsUsingparameters` class in `clean_cdr.py` 

- Created unit and integration tests `clean_ppi_numeric_fields_using_parameters_test.py`