### PR TITLE
[DC-879] Clean extension table mapping rule uses incorrect description

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/clean_mapping.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_mapping.py
@@ -74,10 +74,9 @@ class CleanMappingExtTables(BaseCleaningRule):
         tickets may affect this SQL, append them to the list of Jira Issues.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
-        desc = (
-            'Sandboxes the mapping table records and rows dropped '
-            'when the record of the row reference has been dropped '
-            'by a cleaning rule')
+        desc = ('Sandboxes the mapping table records and rows dropped '
+                'when the record of the row reference has been dropped '
+                'by a cleaning rule')
         super().__init__(issue_numbers=[ISSUE_NUMBER],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_mapping.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_mapping.py
@@ -75,8 +75,9 @@ class CleanMappingExtTables(BaseCleaningRule):
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
         desc = (
-            'Remove records from the rdr dataset where '
-            'observation_source_concept_id in (43530490, 43528818, 43530333)')
+            'Sandboxes the mapping table records and rows dropped '
+            'when the record of the row reference has been dropped '
+            'by a cleaning rule')
         super().__init__(issue_numbers=[ISSUE_NUMBER],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],


### PR DESCRIPTION
Updated description in `clean_mapping.py`