### PR TITLE
[EDQ-498] Make Logic for Data Quality issue Reporting Consistent

### DIFF
--- a/data_steward/analytics/cdr_ops/systematic_scripts/height_weight_cleaning_rule_models.py
+++ b/data_steward/analytics/cdr_ops/systematic_scripts/height_weight_cleaning_rule_models.py
@@ -733,6 +733,7 @@ m.person_id NOT IN ({persons_to_exclude_as_str})
 
 AND
 
+(
 -- between pounds and ounces
 (m.value_as_number > 325 AND
 m.value_as_number < 1600) 
@@ -747,6 +748,7 @@ OR
 
 -- beyond grams
 (m.value_as_number > 147418)
+)
 
 GROUP BY 1
 ORDER BY cnt DESC

--- a/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
@@ -13,9 +13,6 @@ percentage_dict: correlated a particular analysis choice with whether or
     not it is intended to report out a fixed number (as in the case of
     duplicate records) or a  'percentage' (namely success or failure
     rates)
-target_low_dict: indicates whether the metric is intended to be
-    minimized (in the case of an 'error') or maximized (in the
-    case of a 'success rate')
 columns_to_document_for_sheet: indicates which columns contain
     information that should be stored for the particular data
     quality metric that is being analyzed
@@ -99,30 +96,6 @@ percentage_dict = {
     constants.erroneous_dates: constants.true,
     constants.person_id_failure_rate: constants.true,
     constants.achilles_errors: constants.false
-}
-
-
-# FIXME: for errors, we want target_low value to be true
-
-target_low_dict = {
-    # non-percentage values
-    constants.duplicates: constants.true,
-    constants.achilles_errors: constants.true,
-
-    # success rates
-    constants.concept: constants.false,
-    constants.unit_success_rate: constants.false,
-    constants.drug_routes: constants.false,
-    constants.drug_success: constants.false,
-    constants.sites_measurement: constants.false,
-
-    constants.data_after_death: constants.true,
-    constants.end_before_begin: constants.true,
-    constants.visit_date_disparity: constants.false,
-
-    constants.date_datetime_disparity: constants.true,
-    constants.erroneous_dates: constants.true,
-    constants.person_id_failure_rate: constants.true,
 }
 
 columns_to_document_for_sheet = {

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_dqm_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_dqm_objects.py
@@ -41,7 +41,7 @@ def find_hpo_row(sheet, hpo):
 
 def get_info(
         sheet, row_num, percentage,
-        sheet_name, columns_to_collect, target_low):
+        sheet_name, columns_to_collect):
     """
     Function is used to create a dictionary that contains
     the number of flawed records for a particular site.
@@ -64,9 +64,6 @@ def get_info(
 
     columns_to_collect (lst): contains the tables that should be
         documented for every table and at every date.
-
-    target_low (bool): determines whether the number displayed
-        should be considered a positive or negative metric
 
     Returns
     -------
@@ -107,13 +104,9 @@ def get_info(
                             "{}".format(sheet_name, col_label))
 
                     # actual info to be logged if sensible data
-                    elif percentage and target_low:  # proportion w/ errors
+                    elif percentage:
                         data_dictionary[col_label] = round(
                             number, constants.rounding_val)
-
-                    elif percentage and not target_low:  # effective
-                        data_dictionary[col_label] = round(
-                            100 - number, constants.rounding_val)
 
                     elif not percentage and number > -1:
                         data_dictionary[col_label] = int(number)

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
@@ -169,8 +169,7 @@ def add_number_total_rows_for_hpo_and_date(
             num_rows_dictionary = get_info(
                 sheet=df_for_date, row_num=hpo_row,
                 percentage=False, sheet_name=sheet_name,
-                columns_to_collect=row_count_col_names,
-                target_low=False)
+                columns_to_collect=row_count_col_names)
 
             for table_name, value in num_rows_dictionary.items():
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/messages.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/messages.py
@@ -52,7 +52,7 @@ Please specify your choice by typing the corresponding letter.
 output_prompt = \
     """
 Would you prefer to generate:
-A. {} sheets detailing the data quality for each table.
+A. {} sheets detailing the data quality for each table/class.
 The HPO IDs would be displayed as rows.
 
 or
@@ -60,7 +60,7 @@ or
 B. {} sheets detailing the data quality for each HPO site.
 The table type would be displayed as rows. This will
 also include 1-3 table(s) with statistics on the
-aggregate data for each table type on each date.
+aggregate data for each table/class type on each date.
 """
 
 err_message_agg_for_table = """

--- a/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
@@ -66,7 +66,7 @@ import pandas as pd
 
 def create_dqm_objects_for_sheet(
         dataframe, hpo_names, user_choice, metric_is_percent,
-        target_low, date):
+        date):
     """
     Function is used to create DataQualityMetric objects for all of
     the pertinent values on the various sheets being loaded.
@@ -85,9 +85,6 @@ def create_dqm_objects_for_sheet(
     metric_is_percent (bool): determines whether the data will be seen
         as 'percentage complete' or individual instances of a
         particular error
-
-    target_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
 
     date (datetime): datetime object that represents the time that the
         data quality metric was documented (corresponding to the
@@ -118,8 +115,7 @@ def create_dqm_objects_for_sheet(
         data_dict = get_info(
             sheet=dataframe, row_num=row_number,
             percentage=metric_is_percent, sheet_name=user_choice,
-            columns_to_collect=columns,
-            target_low=target_low)
+            columns_to_collect=columns)
 
         # for each table / class (column) in the dataframe
         for table, data in data_dict.items():
@@ -137,7 +133,7 @@ def create_dqm_objects_for_sheet(
 
 
 def create_dqm_list(dfs, file_names, datetimes, user_choice,
-                    percent_bool, target_low, hpo_names):
+                    percent_bool, hpo_names):
     """
     Function is used to create all of the possible 'DataQualityMetric'
     objects that are needed given all of the inputted data.
@@ -163,9 +159,6 @@ def create_dqm_list(dfs, file_names, datetimes, user_choice,
         as 'percentage complete' or individual instances of a
         particular error
 
-    target_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
-
     hpo_names (list): list of the strings that should go
         into an HPO ID column. for use in generating subsequent
         dataframes.
@@ -181,7 +174,7 @@ def create_dqm_list(dfs, file_names, datetimes, user_choice,
         dqm_objects, col_names = create_dqm_objects_for_sheet(
             dataframe=dataframe, hpo_names=hpo_names,
             user_choice=user_choice, metric_is_percent=percent_bool,
-            target_low=target_low, date=date)
+            date=date)
 
         dqm_list.extend(dqm_objects)
 
@@ -275,10 +268,10 @@ def create_excel_files(
 
 
 # EHR Ops Dataset Comparisons
-report1 = 'july_15_2019.xlsx'
-report2 = 'october_04_2019.xlsx'
-report3 = 'april_17_2020.xlsx'
-report4 = 'may_14_2020.xlsx'
+report1 = 'october_04_2019.xlsx'
+report2 = 'april_17_2020.xlsx'
+report3 = 'may_18_2020.xlsx'
+report4 = 'june_03_2020.xlsx'
 
 report_names = [report1, report2, report3, report4]
 
@@ -287,7 +280,7 @@ def main():
     """
     Function that executes the entirety of the program.
     """
-    user_choice, percent_bool, target_low, dfs, hpo_names = \
+    user_choice, percent_bool, dfs, hpo_names = \
         startup(file_names=report_names)
 
     file_names, datetimes = convert_file_names_to_datetimes(
@@ -296,7 +289,7 @@ def main():
     dqm_list = create_dqm_list(
         dfs=dfs, file_names=file_names, datetimes=datetimes,
         user_choice=user_choice, percent_bool=percent_bool,
-        target_low=target_low, hpo_names=hpo_names)
+        hpo_names=hpo_names)
 
     hpo_objects = create_hpo_objects(
         dqm_objects=dqm_list, file_names=file_names,

--- a/data_steward/analytics/table_metrics/metrics_over_time/startup_functions.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/startup_functions.py
@@ -21,7 +21,7 @@ import constants
 
 from dictionaries_and_lists import \
     choice_dict, percentage_dict, \
-    target_low_dict, metric_type_to_english_dict
+    metric_type_to_english_dict
 
 
 from messages import \
@@ -41,9 +41,6 @@ def get_user_analysis_choice():
     percent_bool (bool): determines whether the data will be seen
         as 'percentage complete' or individual instances of a
         particular error
-
-    target_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
     """
 
     user_command = input(analysis_type_prompt).lower()
@@ -55,9 +52,8 @@ def get_user_analysis_choice():
 
     analytics_type = choice_dict[user_command]
     percent_bool = percentage_dict[analytics_type]
-    target_low = target_low_dict[analytics_type]
 
-    return analytics_type, percent_bool, target_low
+    return analytics_type, percent_bool
 
 
 def load_files(user_choice, file_names):
@@ -269,9 +265,6 @@ def startup(file_names):
         as 'percentage complete' or individual instances of a
         particular error
 
-    ideal_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
-
     file_names (list): list of the user-specified Excel files that are
         in the current directory. Files are analytics reports to be
         scanned.
@@ -284,11 +277,11 @@ def startup(file_names):
         into an HPO ID column. for use in generating subsequent
         dataframes.
     """
-    metric_choice, metric_is_percent, ideal_low = get_user_analysis_choice()
+    metric_choice, metric_is_percent = get_user_analysis_choice()
     sheets = load_files(metric_choice, file_names)
     hpo_name_col = generate_hpo_id_col(file_names)
 
-    return metric_choice, metric_is_percent, ideal_low, \
+    return metric_choice, metric_is_percent, \
         sheets, hpo_name_col
 
 

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/data_after_death.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/data_after_death.py
@@ -20,7 +20,7 @@ client = bigquery.Client()
 
 # +
 from notebooks import parameters
-DATASET = parameters.EHR_OPS_Q1_2019
+DATASET = parameters.LATEST_DATASET
 LOOKUP_TABLES = parameters.LOOKUP_TABLES
 
 print(f"Dataset to use: {DATASET}")

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/drug_integration_success_rate.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/drug_integration_success_rate.py
@@ -85,6 +85,8 @@ cols_to_join = ['src_hpo_id']
 site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
 # -
 
+site_df
+
 # # Improve the Definitions of Drug Ingredient
 
 diuretics = (974166, 956874, 970250, 1395058, 904542, 942350, 932745,

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/duplicates.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/duplicates.py
@@ -20,7 +20,7 @@ client = bigquery.Client()
 
 # +
 from notebooks import parameters
-DATASET = parameters.EHR_OPS_Q4_2019
+DATASET = parameters.LATEST_DATASET
 LOOKUP_TABLES = parameters.LOOKUP_TABLES
 
 print(f"Dataset to use: {DATASET}")

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/end_before_begin.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/end_before_begin.py
@@ -28,7 +28,7 @@ client = bigquery.Client()
 
 # +
 from notebooks import parameters
-DATASET = parameters.EHR_OPS_Q1_2019
+DATASET = parameters.LATEST_DATASET
 LOOKUP_TABLES = parameters.LOOKUP_TABLES
 
 print(f"Dataset to use: {DATASET}")
@@ -94,6 +94,8 @@ cols_to_join = ['src_hpo_id']
 
 site_df = pd.merge(site_df, full_names_df, on=['src_hpo_id'], how='left')
 # -
+
+site_df
 
 # # All temporal data points should be consistent such that end dates should NOT be before a start date.
 

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/unit_success_rate.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/unit_success_rate.py
@@ -250,11 +250,7 @@ final_all_units_df = pd.merge(final_all_units_df, potential_floats, on = 'src_hp
 
 final_all_units_df = pd.merge(final_all_units_df, successful_unit_concept_ids_by_site, on = 'src_hpo_id', how = 'left')
 
-# +
 final_all_units_df['percentage_float_rows'] = round(final_all_units_df['number_of_float_source_values'] / final_all_units_df['number_total_rows'] * 100, 2)
-
-
-# -
 
 final_all_units_df['total_unit_success_rate'] = round(final_all_units_df['number_successful_units']/ final_all_units_df['number_of_float_source_values'] * 100, 2)
 
@@ -425,10 +421,12 @@ final_all_units_df['proportion_sel_meas'] = round(final_all_units_df['number_tot
 
 
 
+
 final_all_units_df['percentage_float_rows_selected_measurements'] = round(final_all_units_df['number_of_float_source_values_selected_measures'] / final_all_units_df['number_total_selected_measurements'] * 100, 2)
 
 
 final_all_units_df['selected_measurements_unit_success_rate'] = round(final_all_units_df['number_successful_units_selected_measures']/ final_all_units_df['number_of_float_source_values_selected_measures'] * 100, 2)
+
 
 
 

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/visit_date_disparity.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/visit_date_disparity.py
@@ -19,7 +19,7 @@ client = bigquery.Client()
 
 # +
 from notebooks import parameters
-DATASET = parameters.EHR_OPS_Q1_2019
+DATASET = parameters.LATEST_DATASET
 LOOKUP_TABLES = parameters.LOOKUP_TABLES
 
 print(f"Dataset to use: {DATASET}")

--- a/data_steward/analytics/tools/dq_issue_tracker/create_dq_issue_site_dfs.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/create_dq_issue_site_dfs.py
@@ -27,10 +27,10 @@ from cross_reference_functions import cross_reference_old_metrics
 
 import pandas as pd
 
-old_dashboards = 'april_17_2020_data_quality_issues.xlsx'
+old_dashboards = 'may_11_2020_data_quality_issues.xlsx'
 
-old_excel_file_name = 'april_17_2020.xlsx'
-excel_file_name = 'may_11_2020.xlsx'
+old_excel_file_name = 'may_11_2020.xlsx'
+excel_file_name = 'june_03_2020.xlsx'
 
 metric_names = list(metric_names.keys())  # sheets to be investigated
 

--- a/data_steward/analytics/tools/dq_issue_tracker/cross_reference_functions.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/cross_reference_functions.py
@@ -56,7 +56,7 @@ def cross_reference_old_metrics(failing_metrics, old_failing_metrics,
                         new_metric.link == old_metric.link)
 
                     if metrics_the_same:
-                            found_in_old = True
+                        found_in_old = True
 
                 if found_in_old:
                     # found the metric in previous sheet - need to find the
@@ -122,7 +122,7 @@ def find_report_date(prev_dashboards, new_metric):
 
     # check that it is reassigned - just in case
     assert isinstance(report_date, pd.Timestamp), \
-        "Date not found in the old dashboard. This applies to" \
+        "Date not found in the old dashboard. This applies to " \
         "the following DataQualityMetric object: {dq}".format(
             dq=new_metric.print_dqd_attributes()
         )

--- a/data_steward/analytics/tools/dq_issue_tracker/dictionaries_and_lists.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/dictionaries_and_lists.py
@@ -63,7 +63,7 @@ relevant_links = {
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/data-after-death?authuser=0",
 
-    "measurement_units":
+    "unit_success_rate":
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/unit-concept-success-rate?authuser=0",
 
@@ -158,7 +158,7 @@ full_names = {
 
 metric_names = {
     # field population metrics
-    'measurement_units': 'unit_success',
+    'unit_success_rate': 'unit_success',
     'drug_routes': 'route_success',
 
     # integration metrics
@@ -180,7 +180,7 @@ metric_names = {
 
 desired_columns_dict = {
     # field population metrics
-    'measurement_units': ['total_unit_success_rate'],
+    'unit_success_rate': ['total_unit_success_rate'],
 
     'drug_routes': ['total_route_success_rate'],
 
@@ -282,7 +282,7 @@ data_quality_dimension_dict = {
     'sites_measurement': 'Completeness',
     'drug_success': 'Completeness',
     'drug_routes': 'Completeness',
-    'measurement_units': 'Completeness',
+    'unit_success_rate': 'Completeness',
     'date_datetime_disparity': 'Conformance',
     'erroneous_dates': 'Plausibility',
     'person_id_failure_rate': 'Conformance'
@@ -291,7 +291,7 @@ data_quality_dimension_dict = {
 
 metric_type_to_english_dict = {
     # field population metrics
-    'measurement_units': 'Unit Concept ID Success Rate',
+    'unit_success_rate': 'Unit Concept ID Success Rate',
     'drug_routes': 'Route Concept ID Success Rate',
 
     # integration metrics
@@ -314,7 +314,7 @@ metric_type_to_english_dict = {
 
 english_to_metric_type_dict = {
     # field population metrics
-    'Unit Concept ID Success Rate': 'measurement_units',
+    'Unit Concept ID Success Rate': 'unit_success_rate',
     'Route Concept ID Success Rate': 'drug_routes',
 
     # integration metrics

--- a/data_steward/analytics/tools/dq_issue_tracker/general_functions.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/general_functions.py
@@ -165,16 +165,12 @@ def get_err_rate(sheet, row_num, metric, hpo_name, column):
     if row_num is not None:
         data_info = sheet.iloc[row_num, :]  # series, column labels and values
     else:
-        print("{hpo_name} is now in the following sheet: {sheet}".format(
+        print("{hpo_name} is not in the following sheet: {sheet}".format(
             hpo_name=hpo_name, sheet=metric
         ))
         sys.exit(0)
 
-    # tend to reverse the reported metric for ACHILLES errors
-    if metric in ['end_before_begin', 'data_after_death']:
-        val = round(100 - data_info[column], 2)
-    else:
-        val = data_info[column]
+    val = data_info[column]
 
     # to ensure that comparisons can be drawn across
     # the threshold

--- a/data_steward/analytics/tools/email_generator/create_dqms.py
+++ b/data_steward/analytics/tools/email_generator/create_dqms.py
@@ -15,7 +15,7 @@ from data_quality_metric_class import DataQualityMetric
 
 def create_dqm_objects_for_sheet(
         dataframe, hpo_names, user_choice, metric_is_percent,
-        target_low, date):
+        date):
     """
     Function is used to create DataQualityMetric objects for all of
     the pertinent values on the various sheets being loaded.
@@ -34,9 +34,6 @@ def create_dqm_objects_for_sheet(
     metric_is_percent (bool): determines whether the data will be seen
         as 'percentage complete' or individual instances of a
         particular error
-
-    target_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
 
     date (datetime): datetime object that represents the time that the
         data quality metric was documented (corresponding to the
@@ -67,8 +64,7 @@ def create_dqm_objects_for_sheet(
         data_dict = get_info(
             sheet=dataframe, row_num=row_number,
             percentage=metric_is_percent, sheet_name=user_choice,
-            columns_to_collect=columns,
-            target_low=target_low)
+            columns_to_collect=columns)
 
         # for each table / class (column) in the dataframe
         for table, data in data_dict.items():
@@ -86,7 +82,7 @@ def create_dqm_objects_for_sheet(
 
 
 def create_dqm_list(dfs, file_names, datetimes, user_choice,
-                    percent_bool, target_low, hpo_names):
+                    percent_bool, hpo_names):
     """
     Function is used to create all of the possible 'DataQualityMetric'
     objects that are needed given all of the inputted data.
@@ -112,9 +108,6 @@ def create_dqm_list(dfs, file_names, datetimes, user_choice,
         as 'percentage complete' or individual instances of a
         particular error
 
-    target_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
-
     hpo_names (list): list of the strings that should go
         into an HPO ID column. for use in generating subsequent
         dataframes.
@@ -130,7 +123,7 @@ def create_dqm_list(dfs, file_names, datetimes, user_choice,
         dqm_objects, col_names = create_dqm_objects_for_sheet(
             dataframe=dataframe, hpo_names=hpo_names,
             user_choice=user_choice, metric_is_percent=percent_bool,
-            target_low=target_low, date=date)
+            date=date)
 
         dqm_list.extend(dqm_objects)
 

--- a/data_steward/analytics/tools/email_generator/dictionaries_and_lists.py
+++ b/data_steward/analytics/tools/email_generator/dictionaries_and_lists.py
@@ -18,10 +18,6 @@ percentage_dict: correlated a particular analysis choice with whether or
     duplicate records) or a  'percentage' (namely success or failure
     rates)
 
-target_low_dict: indicates whether the metric is intended to be
-    minimized (in the case of an 'error') or maximized (in the
-    case of a 'success rate')
-
 columns_to_document_for_sheet: indicates which columns contain
     information that should be stored for the particular data
     quality metric that is being analyzed
@@ -112,7 +108,7 @@ percentage_dict = {
     'data_after_death': True,
     'end_before_begin': True,
     'concept': True,
-    'measurement_units': True,
+    'unit_success_rate': True,
     'drug_routes': True,
     'drug_success': True,
     'sites_measurement': True,
@@ -121,34 +117,13 @@ percentage_dict = {
     'erroneous_dates': True,
     'person_id_failure_rate': True}
 
-target_low_dict = {
-    'duplicates': True,
-    'data_after_death': True,
-    'end_before_begin': True,
-    'concept': False,
-    'measurement_units': False,
-    'drug_routes': False,
-    'drug_success': False,
-    'sites_measurement': False,
-    'visit_date_disparity': False,
-
-    # FIXME: the three below - by logic - should
-    # be 'True' but were calculated as showing
-    # the % of errors rather than (100 - % of errors)
-    # in the DQM scripts. This means they should be
-    # logged as 'False' here to make it an effective
-    # double negative.
-    'date_datetime_disparity': False,
-    'erroneous_dates': False,
-    'person_id_failure_rate': False}
-
 
 # NOTE: This is actually different than what one would
 # find in the metrics_over_time generator. This is because
 # we want less granularity for the 'integration metrics'.
 
 columns_to_document_for_sheet_email = {
-    'measurement_units': ['total_unit_success_rate'],
+    'unit_success_rate': ['total_unit_success_rate'],
 
     'sites_measurement': [
         'Physical_Measurement',	'CMP', 'CBCwDiff',
@@ -251,14 +226,14 @@ data_quality_dimension_dict = {
     'sites_measurement': 'Completeness',
     'drug_success': 'Completeness',
     'drug_routes': 'Completeness',
-    'measurement_units': 'Completeness',
+    'unit_success_rate': 'Completeness',
     'date_datetime_disparity': 'Conformance',
     'erroneous_dates': 'Plausibility',
     'person_id_failure_rate': 'Conformance'}
 
 metric_type_to_english_dict = {
     # field population metrics
-    'measurement_units': 'Unit Concept ID Success Rate',
+    'unit_success_rate': 'Unit Concept ID Success Rate',
     'drug_routes': 'Route Concept ID Success Rate',
 
     # integration metrics

--- a/data_steward/analytics/tools/email_generator/email_generator.py
+++ b/data_steward/analytics/tools/email_generator/email_generator.py
@@ -40,14 +40,14 @@ from dictionaries_and_lists import full_names
 
 from contact_list import recipient_dict
 
-report1 = 'april_17_2020.xlsx'
+report1 = 'june_03_2020.xlsx'
 
 report_names = [report1]
 
 sheet_names = [
     'concept', 'data_after_death', 'date_datetime_disparity',
     'drug_routes', 'drug_success', 'duplicates',
-    'end_before_begin', 'measurement_units', 'erroneous_dates',
+    'end_before_begin', 'unit_success_rate', 'erroneous_dates',
     'sites_measurement', 'person_id_failure_rate']
 
 
@@ -116,7 +116,7 @@ def assemble_final_messages(unique_metrics, hpo_id):
     ehr_site = full_names[hpo_id]
     name = "Noah Engel"
     num_metrics = len(sheet_names)
-    date = "April 17th, 2020"
+    date = "June 3rd, 2020"
 
     message = introduction.format(
         ehr_site=ehr_site, name=name,
@@ -132,7 +132,7 @@ def assemble_final_messages(unique_metrics, hpo_id):
     message += """\n
     Email Title:
     ------------
-    Data Check Feedback (April 2020) - {site}""".format(
+    Data Check Feedback (June 2020) - {site}""".format(
         site=ehr_site)
 
     message += """\n
@@ -151,7 +151,7 @@ def main():
     all_objects = []
 
     for metric_choice in sheet_names:
-        dfs, hpo_names, target_low, percent_bool = \
+        dfs, hpo_names, percent_bool = \
             startup(file_names=report_names,
                     metric_choice=metric_choice)
 
@@ -161,7 +161,7 @@ def main():
         dqm_list = create_dqm_list(
             dfs=dfs, file_names=file_names, datetimes=datetimes,
             user_choice=metric_choice, percent_bool=percent_bool,
-            target_low=target_low, hpo_names=hpo_names)
+            hpo_names=hpo_names)
 
         hpo_objects = create_hpo_objects(
             dqm_objects=dqm_list, file_names=file_names,

--- a/data_steward/analytics/tools/email_generator/functions_to_create_dqm_objects.py
+++ b/data_steward/analytics/tools/email_generator/functions_to_create_dqm_objects.py
@@ -42,7 +42,7 @@ def find_hpo_row(sheet, hpo):
 
 def get_info(
         sheet, row_num, percentage,
-        sheet_name, columns_to_collect, target_low):
+        sheet_name, columns_to_collect):
     """
     Function is used to create a dictionary that contains
     the number of flawed records for a particular site.
@@ -65,9 +65,6 @@ def get_info(
 
     columns_to_collect (lst): contains the tables that should be
         documented for every table and at every date.
-
-    target_low (bool): determines whether the number displayed
-        should be considered a positive or negative metric
 
     Returns
     -------
@@ -108,10 +105,7 @@ def get_info(
                             "Negative number detected in sheet {} for column "
                             "{}".format(sheet_name, col_label))
 
-                    # actual info to be logged if sensible data
-                    elif percentage and target_low:  # proportion w/ errors
-                        data_dictionary[col_label] = round(100 - number, 2)
-                    elif percentage and not target_low:  # effective
+                    elif percentage:  # effective
                         data_dictionary[col_label] = round(number, 2)
                     elif not percentage and number > -1:
                         data_dictionary[col_label] = int(number)

--- a/data_steward/analytics/tools/email_generator/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/tools/email_generator/functions_to_create_hpo_objects.py
@@ -168,8 +168,7 @@ def add_number_total_rows_for_hpo_and_date(
             num_rows_dictionary = get_info(
                 sheet=df_for_date, row_num=hpo_row,
                 percentage=False, sheet_name=sheet_name,
-                columns_to_collect=row_count_col_names,
-                target_low=False)
+                columns_to_collect=row_count_col_names)
 
             for table_name, value in num_rows_dictionary.items():
                 hpo.add_row_count_with_string(

--- a/data_steward/analytics/tools/email_generator/messages.py
+++ b/data_steward/analytics/tools/email_generator/messages.py
@@ -23,7 +23,7 @@ great_job = """
     """
 
 sign_off = """
-If have questions about our metrics, please consult the AoU EHR website at this link: {link} under the 'Data Quality Metrics' tab at the top of the page. This site contains descriptions, videos, and SQL queries that can help you troubleshoot your data quality.
+If you have questions about our metrics, please consult the AoU EHR website at this link: {link} under the 'Data Quality Metrics' tab at the top of the page. This site contains descriptions, videos, and SQL queries that can help you troubleshoot your data quality.
 
 Please also be sure to visit the 'results.html' file populated in your Google bucket to find other potential errors related to your EHR submissions.
 

--- a/data_steward/analytics/tools/email_generator/startup_functions.py
+++ b/data_steward/analytics/tools/email_generator/startup_functions.py
@@ -7,7 +7,7 @@ import os
 import sys
 from messages import fnf_error
 from dictionaries_and_lists import \
-    target_low_dict, percentage_dict
+    percentage_dict
 import datetime
 
 
@@ -36,9 +36,6 @@ def startup(file_names, metric_choice):
         into an HPO ID column. for use in generating subsequent
         dataframes.
 
-    target_low (bool): determines whether the number displayed should
-        be considered a desirable or undesirable characteristic
-
     percent_bool (bool): determines whether the data will be seen
         as 'percentage complete' or individual instances of a
         particular error
@@ -47,9 +44,8 @@ def startup(file_names, metric_choice):
     hpo_name_col = generate_hpo_id_col(file_names)
 
     percent_bool = percentage_dict[metric_choice]
-    target_low = target_low_dict[metric_choice]
 
-    return sheets, hpo_name_col, target_low, percent_bool
+    return sheets, hpo_name_col, percent_bool
 
 
 def load_files(user_choice, file_names):

--- a/data_steward/analytics/tools/visualizations/plausibility/end_dates_before_start_dates.py
+++ b/data_steward/analytics/tools/visualizations/plausibility/end_dates_before_start_dates.py
@@ -163,7 +163,7 @@ sns.heatmap(new_hpo_sheets[idx_of_interest], annot=True, annot_kws={"size": 14},
             fmt='g', linewidths=.5, ax=ax, yticklabels=table_id_cols,
             xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
 
-ax.set_title("End Dates Preceding Start Dates for {name_of_interest}", size=14)
+ax.set_title(f"End Dates Preceding Start Dates for {name_of_interest}", size=14)
 
 plt.tight_layout()
 img_name = name_of_interest + "_end_before_begin.png"
@@ -266,7 +266,7 @@ for table, values_over_time in success_rates.items():
         plt.plot(date_idxs[non_nan_idx], new_lst, 'o', label=table)
 
 plt.legend(loc="upper left", bbox_to_anchor=(1,1))
-plt.title("{name_of_interest} End Dates Preceding Start Dates")
+plt.title(f"{name_of_interest} End Dates Preceding Start Dates")
 plt.ylabel("End Dates Preceding Start Dates (%)")
 plt.xlabel("")
 plt.xticks(date_idxs, times, rotation = 'vertical')

--- a/data_steward/analytics/tools/visualizations/plausibility/erroneous_dates.py
+++ b/data_steward/analytics/tools/visualizations/plausibility/erroneous_dates.py
@@ -197,7 +197,7 @@ sns.heatmap(new_hpo_sheets[idx_of_interest], annot=True, annot_kws={"size": 14},
             fmt='g', linewidths=.5, ax=ax, yticklabels=table_id_cols,
             xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
 
-ax.set_title("Erroneous Dates Rates for {name_of_interest}", size=14)
+ax.set_title(f"Erroneous Dates Rates for {name_of_interest}", size=14)
 
 plt.tight_layout()
 img_name = name_of_interest + "_erroneous_dates.png"
@@ -300,7 +300,7 @@ for table, values_over_time in success_rates.items():
         plt.plot(date_idxs[non_nan_idx], new_lst, 'o', label=table)
 
 plt.legend(loc="upper left", bbox_to_anchor=(1,1))
-plt.title("{name_of_interest} Erroneous Date Rates Over Time")
+plt.title(f"{name_of_interest} Erroneous Date Rates Over Time")
 plt.ylabel("Disparity Rate (%)")
 plt.xlabel("")
 plt.xticks(date_idxs, times, rotation = 'vertical')


### PR DESCRIPTION
* Fixed issue with understanding the distribution behind erroneous weights.
* Ensured all f-strings were present in the visualization notebooks.
* Got rid of target low information in metrics_over_time and email_generator - not needed now that all of the upstream report-outs are correct.
* Made small changes to data quality issue tracker. Issue mostly lied with the difference in calculation methods for some of the 'error metrics'.
* Variable changes for the updated unit success rate name.