### PR TITLE
[EDQ-513] Integrate the 'Visit Date Disparity' Metric into the Current Schema

### DIFF
--- a/data_steward/analytics/table_metrics/metrics_over_time/aggregate_metric_classes.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/aggregate_metric_classes.py
@@ -84,23 +84,15 @@ class AggregateMetricForTableOrClass:
         """
         time = self.date.strftime(constants.date_format)
 
-        attributes_str = """
-        Table/Class Name: {table_or_class_name}
-        Date: {date}
-        Metric Type: {metric_type}
-        Number of Total Rows: {total_rows}
-        Number of Pertinent Rows: {pert_rows}
-        Overall Rate: {rate}
-        Unweighted Metric?: {uw_metric}
-        """.format(
-            table_or_class_name=self.table_or_class_name,
-            date=time,
-            metric_type=self.metric_type,
-            total_rows=self.num_total_rows,
-            pert_rows=self.num_pertinent_rows,
-            rate=self.overall_rate,
-            uw_metric=self.unweighted_metric
-        )
+        attributes_str = f"""
+        Table/Class Name: {self.table_or_class_name}
+        Date: {time}
+        Metric Type: {self.metric_type}
+        Number of Total Rows: {self.num_total_rows}
+        Number of Pertinent Rows: {self.num_pertinent_rows}
+        Overall Rate: {self.overall_rate}
+        Unweighted Metric?: {self.unweighted_metric}
+        """
 
         print(attributes_str)
 
@@ -197,22 +189,15 @@ class AggregateMetricForHPO:
         """
         time = self.date.strftime(constants.date_format)
 
-        attributes_str = """
-        Date: {date}
-        HPO Name: {hpo_name}
-        Metric Type: {metric_type}
-        Number of Total Rows: {total_rows}
-        Number of Pertinent Rows: {pert_rows}
-        Overall Rate: {rate}
-        Unweighted Metric?: {uw_metric}
-        """.format(
-            hpo_name=self.hpo_name,
-            date=time,
-            metric_type=self.metric_type,
-            total_rows=self.num_total_rows,
-            pert_rows=self.num_pertinent_rows,
-            rate=self.overall_rate,
-            uw_metric=self.unweighted_metric)
+        attributes_str = f"""
+        Date: {time}
+        HPO Name: {self.hpo_name}
+        Metric Type: {self.metric_type}
+        Number of Total Rows: {self.num_total_rows}
+        Number of Pertinent Rows: {self.num_pertinent_rows}
+        Overall Rate: {self.overall_rate}
+        Unweighted Metric?: {self.unweighted_metric}
+        """
 
         print(attributes_str)
 
@@ -316,20 +301,14 @@ class AggregateMetricForDate:
         """
         time = self.date.strftime(constants.date_format)
 
-        attributes_str = """
-        Date: {date}
-        Metric Type: {metric_type}
-        Number of Total Rows: {total_rows}
-        Number of Pertinent Rows: {pert_rows}
-        Overall Rate: {rate}
-        Unweighted Metric?: {uw_metric}
-        """.format(
-            date=time,
-            metric_type=self.metric_type,
-            total_rows=self.num_total_rows,
-            pert_rows=self.num_pertinent_rows,
-            rate=self.overall_rate,
-            uw_metric=self.unweighted_metric)
+        attributes_str = f"""
+        Date: {time}
+        Metric Type: {self.metric_type}
+        Number of Total Rows: {self.num_total_rows}
+        Number of Pertinent Rows: {self.num_pertinent_rows}
+        Overall Rate: {self.overall_rate}
+        Unweighted Metric?: {self.unweighted_metric}
+        """
 
         print(attributes_str)
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/create_aggregate_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/create_aggregate_objects.py
@@ -139,9 +139,10 @@ def create_weighted_aggregate_metrics(
 
     elif sheet_output != constants.table_sheets:
         raise Exception(
-            """Bad parameter input for function
-             create_aggregate_master_function. Parameter provided
-            was: {param}""".format(param=sheet_output))
+            f"""
+            Bad parameter input for
+            create_aggregate_master_function. Parameter provided
+            was: {sheet_output}""")
 
     return aggregate_metrics
 
@@ -203,9 +204,9 @@ def create_unweighted_aggregate_metrics(
 
     elif sheet_output != constants.table_sheets:
         raise Exception(
-            """Bad parameter input for function
+            f"""Bad parameter input for function
              create_aggregate_master_function. Parameter provided
-            was: {param}""".format(param=sheet_output))
+            was: {sheet_output}""")
 
     return aggregate_metrics
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/data_quality_metric_class.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/data_quality_metric_class.py
@@ -67,17 +67,13 @@ class DataQualityMetric:
         all of the information to be displayed in a
         human-readable format.
         """
-        print("""
-            "HPO: {hpo}
-            "Table/Class: {table_or_class}
-            "Metric Type: {metric_type}
-            "Value: {value}
-            "Data Quality Dimension: {dqd}
-            "Date: {date}""".format(
-                hpo=self.hpo, table_or_class=self.table_or_class,
-                metric_type=self.metric_type,
-                value=self.value, dqd=self.data_quality_dimension,
-                date=self.date))
+        print(
+            f"""HPO: {self.hpo}
+            Table Or Class: {self.table_or_class}
+            Metric Type: {self.metric_type}
+            Value: {self.value}
+            Data Quality Dimension: {self.data_quality_dimension}
+            Date: {self.date}""")
 
     def get_list_of_attribute_names(self):
         """

--- a/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/dictionaries_and_lists.py
@@ -2,43 +2,55 @@
 This file is intended to serve as a 'storing place' for pieces of information
 that may change in the future. This also is a great means to sequester pieces
 of information that may otherwise 'bog down' the regular code.
+
 Dictionaries
 ------------
 thresholds: thresholds: the point at which a data quality metric (whether too
     high or too low) would be flagged as 'erroneous'. not used in the
     metrics_over_time script yet but has potential future implementations.
+
 choice_dict: correlates the user-specified choice to the corresponding
     page on the analytics report
+
 percentage_dict: correlated a particular analysis choice with whether or
     not it is intended to report out a fixed number (as in the case of
     duplicate records) or a  'percentage' (namely success or failure
     rates)
+
 columns_to_document_for_sheet: indicates which columns contain
     information that should be stored for the particular data
     quality metric that is being analyzed
+
 table_based_on_column_provided: allows us to determine the table that
     should be associated with a particular Data Quality Dimension object
     based upon the column that was used to get the associated 'value'
     float
+
 data_quality_dimension_dict: shows which attribute of Kahn's Data Quality
     framework the particular 'data quality metric' at hand relates to
+
 metric_type_to_english_dict: allows one to translate the 'metric type'
     that is normally associated with a 'DataQualityMetric' object to
     'English'. this is useful for printing the columns on a new
     dashboard
+
 full_names: allows one to use the hpo_id (shorter) name to find
     the longer (more human-readable) name
+
 Lists
 -----
 row_count_col_names: shows the column names where one can find the
     total row count for a particular date for each table
+
 unweighted_metric_already_integrated_for_hpo: shows which
     'unweighted metrics' do not need to be calculated for
     each HPO. these metrics do NOT need to be calculated because
     there already is an appropriate 'aggregate metric'
     established in the sheet.
+
 aggregate_metric_class_names: contains the 'names' of the aggregate
     metric objects that one can use
+
 no_aggregate_metric_needed_for_table_sheets: indicates instances where
     no 'aggregate' row needs to be calculated for the 'table' sheets
 """
@@ -63,7 +75,8 @@ thresholds = {
     constants.erroneous_dates_max: constants.achilles_max_value,
     constants.person_failure_rate_max: constants.achilles_max_value,
 
-    constants.achilles_errors_max: 15
+    constants.achilles_errors_max: 15,
+    constants.visit_date_disparity_max: constants.achilles_max_value
 }
 
 
@@ -91,11 +104,11 @@ percentage_dict = {
     constants.drug_routes: constants.true,
     constants.drug_success: constants.true,
     constants.sites_measurement: constants.true,
-    constants.visit_date_disparity: constants.true,
     constants.date_datetime_disparity: constants.true,
     constants.erroneous_dates: constants.true,
     constants.person_id_failure_rate: constants.true,
-    constants.achilles_errors: constants.false
+    constants.achilles_errors: constants.false,
+    constants.visit_date_disparity: constants.true,
 }
 
 columns_to_document_for_sheet = {
@@ -122,10 +135,7 @@ columns_to_document_for_sheet = {
         'diabetics_w_drugs', 'diabetics_w_glucose',
         'diabetics_w_a1c', 'diabetics_w_insulin'],
 
-    constants.concept: [
-        constants.observation_success, constants.drug_success_col,
-        constants.procedure_success, constants.condition_success,
-        constants.measurement_success, constants.visit_success],
+    constants.concept: constants.concept_success_rate_columns,
 
     constants.date_datetime_disparity:
         constants.all_canonical_tables,
@@ -137,7 +147,13 @@ columns_to_document_for_sheet = {
         constants.all_canonical_tables,
 
     constants.achilles_errors:
-        ['num_distinct_ids']
+        ['num_distinct_ids'],
+
+    constants.visit_date_disparity:
+        [
+        constants.condition_occurrence, constants.drug_exposure,
+        constants.observation, constants.measurement,
+        constants.procedure_occurrence]
 }
 
 
@@ -163,25 +179,25 @@ table_based_on_column_provided = {
     constants.total_route_success_rate: constants.drug_exposure_full,
 
     # drug integration columns
-    constants.all_drugs: 'All Drugs',
-    constants.ace_inhibs: 'ACE Inhibitors',
-    constants.pain_nsaids: 'Pain NSAIDS',
-    constants.msk_nsaids: 'MSK NSAIDS',
-    constants.statins: 'Statins',
-    constants.antibiotics: 'Antibiotics',
-    constants.opioids: 'Opioids',
-    constants.oral_hypo: 'Oral Hypoglycemics',
-    constants.vaccine: 'Vaccine',
-    constants.ccb: 'Calcium Channel Blockers',
-    constants.diuretics: 'Diuretics',
+    constants.all_drugs: constants.all_drugs_full,
+    constants.ace_inhibs: constants.ace_inhibs_full,
+    constants.pain_nsaids: constants.pain_nsaids_full,
+    constants.msk_nsaids: constants.msk_nsaids_full,
+    constants.statins: constants.statins_full,
+    constants.antibiotics: constants.antibiotics_full,
+    constants.opioids: constants.opioids_full,
+    constants.oral_hypo: constants.oral_hypo_full,
+    constants.vaccine: constants.vaccine_full,
+    constants.ccb: constants.ccb_full,
+    constants.diuretics: constants.diuretics_full,
 
     # measurement integration columns
-    constants.all_measurements: 'All Measurements',
-    constants.physical_measurement: 'Physical Measurements',
-    constants.cmp: 'Comprehensive Metabolic Panel',
-    constants.cbc_w_diff: 'CBC with Differential',
-    constants.cbc: 'Complete Blood Count (CBC)',
-    constants.lipid: 'Lipid',
+    constants.all_measurements: constants.all_measurements_full,
+    constants.physical_measurement: constants.physical_measurements_full,
+    constants.cmp: constants.cmp_full,
+    constants.cbc_w_diff: constants.cbc_w_diff_full,
+    constants.cbc: constants.cbc_full,
+    constants.lipid: constants.lipid_full,
 
     'num_distinct_ids': 'All Tables'
 }
@@ -198,7 +214,8 @@ data_quality_dimension_dict = {
     constants.date_datetime_disparity: constants.conformance,
     constants.erroneous_dates: constants.plausibility,
     constants.person_id_failure_rate: constants.conformance,
-    constants.achilles_errors: constants.conformance
+    constants.achilles_errors: constants.conformance,
+    constants.visit_date_disparity: constants.conformance
 }
 
 metric_type_to_english_dict = {
@@ -220,7 +237,8 @@ metric_type_to_english_dict = {
     constants.duplicates: constants.duplicates_full,
     constants.erroneous_dates: constants.erroneous_dates_full,
     constants.person_id_failure_rate: constants.person_id_failure_rate_full,
-    constants.achilles_errors: constants.achilles_errors_full
+    constants.achilles_errors: constants.achilles_errors_full,
+    constants.visit_date_disparity: constants.visit_date_disparity_full
 }
 
 metrics_to_weight = [
@@ -228,7 +246,8 @@ metrics_to_weight = [
     constants.end_before_begin, constants.data_after_death,
     constants.concept, constants.duplicates,
     constants.date_datetime_disparity,
-    constants.erroneous_dates, constants.person_id_failure_rate]
+    constants.erroneous_dates, constants.person_id_failure_rate,
+    constants.visit_date_disparity]
 
 full_names = {
     "saou_uab_selma": "UAB Selma",
@@ -295,4 +314,5 @@ unweighted_metric_already_integrated_for_hpo = [
 no_aggregate_metric_needed_for_table_sheets = [
     constants.drug_success, constants.sites_measurement]
 
-aggregate_metric_class_names = ['All Measurements', 'All Drugs']
+aggregate_metric_class_names = [
+    constants.all_measurements_full, constants.all_drugs_full]

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_dqm_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_dqm_objects.py
@@ -12,14 +12,16 @@ def find_hpo_row(sheet, hpo):
     Finds the row index of a particular HPO site within
     a larger sheet.
 
-    :param
+    Parameters
+    ----------
     sheet (dataframe): dataframe with all of the data quality
         metrics for the sites.
 
     hpo (string): represents the HPO site whose row in
         the particular sheet needs to be determined
 
-    :return:
+    Returns
+    -------
     row_num (int): row number where the HPO site of question
         lies within the sheet. returns none if the row is not
         in the sheet in question but exists in other sheets
@@ -100,8 +102,8 @@ def get_info(
                     # to detect potential problems in excel file generator
                     if number < 0:
                         raise ValueError(
-                            "Negative number detected in sheet {} for column "
-                            "{}".format(sheet_name, col_label))
+                            f"""Negative number detected in sheet 
+                            {sheet_name} for column {col_label}""")
 
                     # actual info to be logged if sensible data
                     elif percentage:

--- a/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/functions_to_create_hpo_objects.py
@@ -63,7 +63,8 @@ def establish_hpo_objects(dqm_objects):
               route_success=[], unit_success=[],
               measurement_integration=[], ingredient_integration=[],
               date_datetime_disp=[], erroneous_dates=[],
-              person_id_failure=[], achilles_errors=[])
+              person_id_failure=[], achilles_errors=[],
+              visit_date_disparity=[])
 
             blank_hpo_objects.append(hpo)
 
@@ -144,7 +145,8 @@ def add_number_total_rows_for_hpo_and_date(
 
     for date_str in date_names:
         date_str = date_str[:-5]  # get rid of extension
-        date_obj = datetime.datetime.strptime(date_str, '%B_%d_%Y')
+        date_obj = datetime.datetime.strptime(
+            date_str, constants.date_format)
         dates_objs.append(date_obj)
 
     chosen_idx = -1
@@ -153,9 +155,7 @@ def add_number_total_rows_for_hpo_and_date(
         if date_object == date:
             chosen_idx = idx
 
-    assert chosen_idx > -1, "Invalid Date: {date}".format(
-        date=date
-    )
+    assert chosen_idx > -1, f"Invalid Date: {date}"
 
     df_for_date = dfs[chosen_idx]
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/metrics_over_time.py
@@ -63,6 +63,8 @@ from organize_dataframes import \
 
 import pandas as pd
 
+import constants
+
 
 def create_dqm_objects_for_sheet(
         dataframe, hpo_names, user_choice, metric_is_percent,
@@ -256,10 +258,10 @@ def create_excel_files(
     """
 
     output_file_name = metric_choice + "_" + sheet_output + \
-        "_analytics_report.xlsx"
+        constants.analytics_report_file_ending
 
     writer = pd.ExcelWriter(
-        output_file_name, engine='xlsxwriter')
+        output_file_name, engine=constants.xl_writer)
 
     for df_name, dataframe in df_dict.items():
         dataframe.to_excel(writer, sheet_name=df_name)

--- a/data_steward/analytics/table_metrics/metrics_over_time/setup_dataframes.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/setup_dataframes.py
@@ -89,9 +89,9 @@ def create_dataframe_skeletons(
 
     else:
         raise Exception(
-            """Bad parameter input for function
+            f"""Bad parameter input for function
              organize_dataframes_master_function. Parameter provided
-            was: {param}""".format(param=sheet_output))
+            was: {sheet_output}""")
 
     return dataframes_dict, tables_or_classes_for_metric
 

--- a/data_steward/analytics/table_metrics/metrics_over_time/startup_functions.py
+++ b/data_steward/analytics/table_metrics/metrics_over_time/startup_functions.py
@@ -96,10 +96,8 @@ def load_files(user_choice, file_names):
 
             if sheet.empty:
 
-                print("WARNING: No data found in the {user_choice} sheet "
-                      "in dataframe {file_name}".format(
-                       user_choice=user_choice,
-                       file_name=file_name))
+                print(f"""WARNING: No data found in the {user_choice} sheet
+                      in dataframe {file_name}""")
 
                 del file_names[num_files_indexed]
                 num_files_indexed -= 1  # skip over the date
@@ -115,9 +113,10 @@ def load_files(user_choice, file_names):
                 sys.exit(0)
 
             else:
-                print("WARNING: No {} sheet found in dataframe {}. "
-                      "This is a(n) {}.".format(
-                        user_choice, file_name, type(ex).__name__))
+                print(f"""
+                WARNING: No {user_choice} sheet
+                found in dataframe {file_name}. "
+                This is a(n) {type(ex).__name__}.""")
 
                 print(ex)
 
@@ -230,14 +229,14 @@ def convert_file_names_to_datetimes(file_names):
     # NOTE: requires files to have full month name and 4-digit year
     for date_str in file_names:
         date_str = date_str[:-5]  # get rid of extension
-        date = datetime.datetime.strptime(date_str, '%B_%d_%Y')
+        date = datetime.datetime.strptime(date_str, constants.date_format)
         ordered_dates_dt.append(date)
 
     ordered_dates_dt = sorted(ordered_dates_dt)
 
     # converting back to standard form to index into file
     ordered_dates_str = [
-        x.strftime('%B_%d_%Y').lower() + '.xlsx'
+        x.strftime(constants.date_format).lower() + '.xlsx'
         for x in ordered_dates_dt]
 
     return ordered_dates_str, ordered_dates_dt

--- a/data_steward/analytics/table_metrics/unioned_ehr_scripts/visit_date_disparity.py
+++ b/data_steward/analytics/table_metrics/unioned_ehr_scripts/visit_date_disparity.py
@@ -232,13 +232,13 @@ final_procedure_df = final_procedure_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_procedure_df['procedure_failure_rate'] = \
+final_procedure_df['procedure_occurrence'] = \
 round((final_procedure_df['num_bad_records']) / final_procedure_df['num_total_records'] * 100, 2)
 
 # +
 final_procedure_df = final_procedure_df.fillna(0)
 
-final_procedure_df = final_procedure_df.sort_values(by=['procedure_failure_rate'], ascending = False)
+final_procedure_df = final_procedure_df.sort_values(by=['procedure_occurrence'], ascending = False)
 # -
 
 final_procedure_df
@@ -388,13 +388,13 @@ final_observation_df = final_observation_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_observation_df['observation_date_failure'] = \
+final_observation_df['observation'] = \
 round((final_observation_df['num_bad_records']) / final_observation_df['num_total_records'] * 100, 2)
 
 # +
 final_observation_df = final_observation_df.fillna(0)
 
-final_observation_df = final_observation_df.sort_values(by=['observation_date_failure'], ascending = False)
+final_observation_df = final_observation_df.sort_values(by=['observation'], ascending = False)
 # -
 
 # ### Creating a shorter df
@@ -544,13 +544,13 @@ final_measurment_df = final_measurment_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_measurment_df['measurement_date_failure'] = \
+final_measurment_df['measurement'] = \
 round((final_measurment_df['num_bad_records']) / final_measurment_df['num_total_records'] * 100, 2)
 
 # +
 final_measurment_df = final_measurment_df.fillna(0)
 
-final_measurment_df = final_measurment_df.sort_values(by=['measurement_date_failure'], ascending = False)
+final_measurment_df = final_measurment_df.sort_values(by=['measurement'], ascending = False)
 
 # +
 ### Creating a shorter df
@@ -675,13 +675,13 @@ final_condition_df = final_condition_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_condition_df['condition_date_failure'] = \
+final_condition_df['condition_occurrence'] = \
 round((final_condition_df['num_bad_records']) / final_condition_df['num_total_records'] * 100, 2)
 
 # +
 final_condition_df = final_condition_df.fillna(0)
 
-final_condition_df = final_condition_df.sort_values(by=['condition_date_failure'], ascending = False)
+final_condition_df = final_condition_df.sort_values(by=['condition_occurrence'], ascending = False)
 # -
 
 # ### Creating a shorter df
@@ -806,13 +806,13 @@ final_drug_df = final_drug_df.fillna(0)
 
 # ### Now we can actually calculate the 'tangible success rate'
 
-final_drug_df['drug_date_failure'] = \
+final_drug_df['drug_exposure'] = \
 round((final_drug_df['num_bad_records']) / final_drug_df['num_total_records'] * 100, 2)
 
 # +
 final_drug_df = final_drug_df.fillna(0)
 
-final_drug_df = final_drug_df.sort_values(by=['drug_date_failure'], ascending = False)
+final_drug_df = final_drug_df.sort_values(by=['drug_exposure'], ascending = False)
 # -
 
 # ### Creating a shorter dataframe
@@ -826,7 +826,7 @@ short_drug_df
 final_success_df = 0
 
 final_success_df = pd.merge(short_drug_df, site_df, how='outer', on='src_hpo_id') 
-final_success_df = final_success_df[['src_hpo_id', 'drug_date_failure']]  #rearrang columnds
+final_success_df = final_success_df[['src_hpo_id', 'drug_exposure']]  #rearrang columnds
 
 # +
 final_success_df = pd.merge(final_success_df, short_observation_df, how='outer', on='src_hpo_id') 

--- a/data_steward/analytics/tools/dq_issue_tracker/constants.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/constants.py
@@ -7,23 +7,6 @@ to a cleaner-looking code (as strings tend to 'bog down' the script
 in general. Beyond legibility, this allows us to "mass change" certain
 attributes that appear many times in the file.
 """
-# Booleans
-# --------
-true = True
-false = False
-
-
-# Formatting
-# ----------
-date_format = '%B_%d_%Y'
-rounding_val = 2
-
-
-# misc_strings
-# ------------
-hpo_sheets = 'hpo_sheets'
-table_sheets = 'table_sheets'
-aggregate_info = 'aggregate_info'
 
 
 # Table Names
@@ -48,13 +31,6 @@ all_canonical_tables = [
 
 tables_with_one_date = [
     visit_occurrence, condition_occurrence, drug_exposure]
-
-observation_total_row = 'observation_total_row'
-drug_total_row = 'drug_total_row'
-procedure_total_row = 'procedure_total_row'
-condition_total_row = 'condition_total_row'
-measurement_total_row = 'measurement_total_row'
-visit_total_row = 'visit_total_row'
 
 
 # Measurement Class Names
@@ -185,19 +161,22 @@ measurement_success = 'measurement_success_rate'
 visit_success = 'visit_success_rate'
 
 concept_success_rate_columns = [
-    observation_success, condition_success, drug_success_col,
-    visit_success, measurement_success, procedure_success]
+    condition_success, drug_success_col,
+    condition_success, measurement_success, procedure_success]
 
 total_unit_success_rate = 'total_unit_success_rate'
 total_route_success_rate = 'total_route_success_rate'
 
+hpo_col_name = 'HPO'
+table_class_col_name = 'Table/Class'
+metric_type_col_name = 'Metric Type'
+data_quality_dimension_col_name = 'Data Quality Dimension'
+link_col_name = 'Link'
+first_reported_col_name = 'First Reported'
 
-# Values
-# ------
-nan_string = "NaN"
-no_data = 'No Data'
 
 # Other Strings
 # -------------
-analytics_report_file_ending = "_analytics_report.xlsx"
+date_format = '%B_%d_%Y'
+output_file_ending = "_data_quality_issues.xlsx"
 xl_writer = 'xlsxwriter'

--- a/data_steward/analytics/tools/dq_issue_tracker/create_dq_issue_site_dfs.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/create_dq_issue_site_dfs.py
@@ -17,7 +17,7 @@ internal DRC drive. This will allow someone to run this script.
 """
 
 from dictionaries_and_lists import relevant_links, full_names, \
-    desired_columns_dict, data_quality_dimension_dict, \
+    columns_to_document_for_sheet, data_quality_dimension_dict, \
     table_or_class_based_on_column_provided, metric_names, \
     metric_type_to_english_dict
 
@@ -30,13 +30,12 @@ from general_functions import load_files, \
 from cross_reference_functions import cross_reference_old_metrics
 
 import pandas as pd
+import constants
 
 old_dashboards = 'june_03_2020_data_quality_issues.xlsx'
 
 old_excel_file_name = 'june_03_2020.xlsx'
 excel_file_name = 'june_15_2020.xlsx'
-
-metric_names = list(metric_names.keys())  # sheets to be investigated
 
 
 def create_hpo_objects(file_name):
@@ -75,7 +74,8 @@ def create_hpo_objects(file_name):
             end_before_begin=[], data_after_death=[],
             route_success=[], unit_success=[], measurement_integration=[],
             ingredient_integration=[], date_datetime_disparity=[],
-            erroneous_dates=[], person_id_failure_rate=[])
+            erroneous_dates=[], person_id_failure_rate=[],
+            visit_date_disparity=[])
 
         hpo_objects.append(hpo)
 
@@ -121,7 +121,7 @@ def populate_hpo_objects_with_dq_metrics(
             row_num = find_hpo_row(sheet, hpo_name)
 
             # what we are looking for within each analytics sheet
-            desired_columns = desired_columns_dict[metric]
+            desired_columns = columns_to_document_for_sheet[metric]
 
             all_dqds_for_hpo_for_metric = []  # list of objects - to be filled
 
@@ -259,9 +259,9 @@ def main():
 
     # cut off previous extension
     output_file_name = excel_file_name[:-5] + \
-        "_data_quality_issues.xlsx"
+        constants.output_file_ending
 
-    writer = pd.ExcelWriter(output_file_name, engine='xlsxwriter')
+    writer = pd.ExcelWriter(output_file_name, engine=constants.xl_writer)
 
     for df_name, dataframe in df_dict.items():
         dataframe.to_excel(writer, sheet_name=df_name)

--- a/data_steward/analytics/tools/dq_issue_tracker/dictionaries_and_lists.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/dictionaries_and_lists.py
@@ -40,71 +40,84 @@ metric_type_to_english_dict: allows one to translate the 'metric type'
 english_to_metric_type_dict: effectively reverse engineers the
     dicitonary above. useful for going from an 'old' dashboard to
     comparing to the attributes of DataQualityMetrics
+
+new_metric: list of 'new metrics' that one would not expect to
+    see in older reports in terms of dates. see the application
+    in the cross_reference_functions file
 """
 
+import constants
+
 relevant_links = {
-    "concept":
+    constants.concept:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/concept-success-rate?authuser=0",
 
-    "duplicates":
+    constants.duplicates:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/duplicates?authuser=0",
 
-    "date_datetime_disparity":
+    constants.date_datetime_disparity:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/datedatetime-disparity?authuser=0",
 
-    "end_before_begin":
+    constants.end_before_begin:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/end-dates-preceding-start-dates?authuser=0",
 
-    "data_after_death":
+    constants.data_after_death:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/data-after-death?authuser=0",
 
-    "unit_success_rate":
+    constants.unit_success_rate:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/unit-concept-success-rate?authuser=0",
 
-    "drug_routes":
+    constants.drug_routes:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/route-concept-success-rate?authuser=0",
 
-    "sites_measurement":
+    constants.sites_measurement:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/measurement-integration-rate?authuser=0",
 
-    "drug_success":
+    constants.drug_success:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/drug-ingredient-integration-rate?authuser=0",
 
-    "erroneous_dates":
+    constants.erroneous_dates:
     "https://sites.google.com/view/ehrupload/"
     "data-quality-metrics/erroneous-dates?authuser=0",
 
-    "person_id_failure_rate":
+    constants.person_id_failure_rate:
     "https://sites.google.com/view/ehrupload/"
-    "data-quality-metrics/person-id-failure-rate?authuser=0"
+    "data-quality-metrics/person-id-failure-rate?authuser=0",
+
+    constants.visit_date_disparity:
+    "placeholder"
 }
 
 
 thresholds = {
-    'concept_success_min': 90,
-    'duplicates_max': 5,
+    constants.concept_success_min: 90,
+    constants.duplicates_max: 5,
 
-    'end_before_begin_max': 0,
-    'data_after_death_max': 0,
+    constants.end_before_begin_max: 0,
+    constants.data_after_death_max: 0,
 
-    'drug_ingredient_integration_min': 90,
-    'measurement_integration_min': 90,
+    constants.drug_ingredient_integration_min: constants.integration_minimum,
+    constants.measurement_integration_min: constants.integration_minimum,
 
-    'unit_success_min': 85,
-    'route_success_min': 85,
+    constants.unit_success_min: constants.field_population_minimum,
+    constants.route_success_min: constants.field_population_minimum,
 
-    'date_datetime_disparity_max': 0,
-    'erroneous_dates_max': 0.01,
-    'person_failure_rate_max': 0.01}
+    constants.date_datetime_disparity_max: constants.achilles_max_value,
+    constants.erroneous_dates_max: constants.achilles_max_value,
+    constants.person_failure_rate_max: constants.achilles_max_value,
+
+    constants.achilles_errors_max: 15,
+    constants.visit_date_disparity_max: constants.achilles_max_value
+}
 
 
 full_names = {
@@ -157,180 +170,156 @@ full_names = {
 }
 
 
-metric_names = {
+metric_names = [
     # field population metrics
-    'unit_success_rate': 'unit_success',
-    'drug_routes': 'route_success',
+    constants.unit_success_rate,
+    constants.drug_routes,
 
     # integration metrics
-    'drug_success': 'drug_integration',
-    'sites_measurement': 'measurement_integration',
+    constants.drug_success,
+    constants.sites_measurement,
 
     # ACHILLES errors
-    'end_before_begin': 'end_before_start',
-    'data_after_death': 'data_after_death',
+    constants.end_before_begin,
+    constants.data_after_death,
 
     # other metrics
-    'concept': 'concept_success',
-    'duplicates': 'duplicates',
+    constants.concept,
+    constants.duplicates,
+    constants.erroneous_dates,
+    constants.person_id_failure_rate,
+    constants.date_datetime_disparity,
+    constants.visit_date_disparity]
 
-    'erroneous_dates': 'erroneous_dates',
-    'person_id_failure_rate': 'person_id_failure_rate',
-    'date_datetime_disparity': 'date_datetime_disparity'}
 
+columns_to_document_for_sheet = {
+    constants.unit_success_rate: [constants.total_unit_success_rate],
 
-desired_columns_dict = {
-    # field population metrics
-    'unit_success_rate': ['total_unit_success_rate'],
+    constants.sites_measurement:
+        constants.measurement_categories,
 
-    'drug_routes': ['total_route_success_rate'],
+    constants.end_before_begin:
+        constants.tables_with_one_date,
 
-    # integration metrics
-    'drug_success': [
-        'ace_inhibitors', 'painnsaids', 'msknsaids',
-        'statins', 'antibiotics', 'opioids', 'oralhypoglycemics',
-        'vaccine', 'ccb', 'diuretics', 'all_drugs'],
+    constants.duplicates:
+        constants.all_canonical_tables,
 
-    'sites_measurement': [
-        'Physical_Measurement',	'CMP', 'CBCwDiff',
-        'CBC', 'Lipid',	'All_Measurements'],
+    constants.drug_routes: [constants.total_route_success_rate],
 
-    # ACHILLES errors
-    'end_before_begin': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure'],
+    constants.drug_success:
+        constants.drug_categories,
 
-    'data_after_death': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation'],
+    constants.data_after_death:
+        constants.all_canonical_tables,
 
-    # other metrics
-    'concept': [
-        'observation_success_rate', 'drug_success_rate',
-        'procedure_success_rate', 'condition_success_rate',
-        'measurement_success_rate', 'visit_success_rate'],
+    constants.diabetes: [
+        'diabetics_w_drugs', 'diabetics_w_glucose',
+        'diabetics_w_a1c', 'diabetics_w_insulin'],
 
-    'duplicates': ['visit_occurrence', 'condition_occurrence',
-                   'drug_exposure', 'measurement',
-                   'procedure_occurrence',
-                   'observation'],
+    constants.concept: constants.concept_success_rate_columns,
 
-    'date_datetime_disparity': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation'],
+    constants.date_datetime_disparity:
+        constants.all_canonical_tables,
 
-    'erroneous_dates': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation'],
+    constants.erroneous_dates:
+        constants.all_canonical_tables,
 
-    'person_id_failure_rate': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation']
+    constants.person_id_failure_rate:
+        constants.all_canonical_tables,
+
+    constants.achilles_errors:
+        ['num_distinct_ids'],
+
+    constants.visit_date_disparity:
+        [
+        constants.condition_occurrence, constants.drug_exposure,
+        constants.observation, constants.measurement,
+        constants.procedure_occurrence]
 }
 
 table_or_class_based_on_column_provided = {
-    'total_unit_success_rate': 'Measurement',
-    'measurement_success_rate': 'Measurement',
-    'measurement': 'Measurement',
+    # canonical columns
+    constants.visit_occurrence: constants.visit_occurrence_full,
+    constants.condition_occurrence: constants.condition_occurrence_full,
+    constants.drug_exposure: constants.drug_exposure_full,
+    constants.measurement: constants.measurement_full,
+    constants.procedure_occurrence: constants.procedure_full,
+    constants.observation: constants.observation_full,
 
-    'total_route_success_rate': 'Drug Exposure',
-    'drug_exposure': 'Drug Exposure',
-    'drug_success_rate': 'Drug Exposure',
+    # general concept success rate columns
+    constants.observation_success: constants.observation_full,
+    constants.drug_success_col: constants.drug_exposure_full,
+    constants.procedure_success: constants.procedure_full,
+    constants.condition_success: constants.condition_occurrence_full,
+    constants.measurement_success: constants.measurement_full,
+    constants.visit_success: constants.visit_occurrence_full,
 
+    # field concept success rate columns
+    constants.total_unit_success_rate: constants.measurement_full,
+    constants.total_route_success_rate: constants.drug_exposure_full,
 
-    'condition_occurrence': 'Condition Occurrence',
-    'condition_success_rate': 'Condition Occurrence',
+    # drug integration columns
+    constants.all_drugs: constants.all_drugs_full,
+    constants.ace_inhibs: constants.ace_inhibs_full,
+    constants.pain_nsaids: constants.pain_nsaids_full,
+    constants.msk_nsaids: constants.msk_nsaids_full,
+    constants.statins: constants.statins_full,
+    constants.antibiotics: constants.antibiotics_full,
+    constants.opioids: constants.opioids_full,
+    constants.oral_hypo: constants.oral_hypo_full,
+    constants.vaccine: constants.vaccine_full,
+    constants.ccb: constants.ccb_full,
+    constants.diuretics: constants.diuretics_full,
 
-    'procedure_occurrence': 'Procedure Occurrence',
+    # measurement integration columns
+    constants.all_measurements: constants.all_measurements_full,
+    constants.physical_measurement: constants.physical_measurements_full,
+    constants.cmp: constants.cmp_full,
+    constants.cbc_w_diff: constants.cbc_w_diff_full,
+    constants.cbc: constants.cbc_full,
+    constants.lipid: constants.lipid_full,
 
-    'observation': 'Observation',
-    'observation_success_rate': 'Observation',
-
-    'procedure_success_rate': 'Procedure',
-
-    'visit_success_rate': 'Visit Occurrence',
-    'visit_occurrence': 'Visit Occurrence',
-
-    'ace_inhibitors': 'ACE Inhibitors',
-    'painnsaids': "Pain NSAIDs",
-    "msknsaids": "MSK NSAIDs",
-    "statins": "Statins",
-    "antibiotics": "Antibiotics",
-    "opioids": "Opioids",
-    "oralhypoglycemics": "Oral Hypoglycemics",
-    "vaccine": "Vaccines",
-    "ccb": "Calcium Channel Blockers",
-    "diuretics": "Diuretics",
-    'all_drugs': 'All Drugs',
-
-    'Physical_Measurement': "Physical Measurement",
-    'CMP': "Comprehensive Metabolic Panel (CMP)",
-    'CBCwDiff': "Complete Blood Count (CBC) with Differential",
-    'CBC': "Complete Blood Count (CBC)",
-    'Lipid': "Lipid",
-    'All_Measurements': "All Measurements"
+    'num_distinct_ids': 'All Tables'
 }
 
 data_quality_dimension_dict = {
-    'concept': 'Conformance',
-    'duplicates': 'Plausibility',
-    'end_before_begin': 'Plausibility',
-    'data_after_death': 'Plausibility',
-    'sites_measurement': 'Completeness',
-    'drug_success': 'Completeness',
-    'drug_routes': 'Completeness',
-    'unit_success_rate': 'Completeness',
-    'date_datetime_disparity': 'Conformance',
-    'erroneous_dates': 'Plausibility',
-    'person_id_failure_rate': 'Conformance'
+    constants.concept: constants.conformance,
+    constants.duplicates: constants.plausibility,
+    constants.end_before_begin: constants.plausibility,
+    constants.data_after_death: constants.plausibility,
+    constants.sites_measurement: constants.completeness,
+    constants.drug_success: constants.completeness,
+    constants.drug_routes: constants.completeness,
+    constants.unit_success_rate: constants.completeness,
+    constants.date_datetime_disparity: constants.conformance,
+    constants.erroneous_dates: constants.plausibility,
+    constants.person_id_failure_rate: constants.conformance,
+    constants.achilles_errors: constants.conformance,
+    constants.visit_date_disparity: constants.conformance
 }
-
 
 metric_type_to_english_dict = {
     # field population metrics
-    'unit_success_rate': 'Unit Concept ID Success Rate',
-    'drug_routes': 'Route Concept ID Success Rate',
+    constants.unit_success_rate: constants.unit_success_full,
+    constants.drug_routes: constants.drug_routes_full,
 
     # integration metrics
-    'drug_success': 'Drug Ingredient Integration',
-    'sites_measurement': 'Measurement Integration',
+    constants.drug_success: constants.drug_success_full,
+    constants.sites_measurement: constants.sites_measurement_full,
 
     # ACHILLES errors
-    'end_before_begin': 'End Dates Preceding Start Dates',
-    'data_after_death': 'Data After Death',
+    constants.end_before_begin: constants.end_before_begin_full,
+    constants.data_after_death: constants.data_after_death_full,
+    constants.date_datetime_disparity: constants.date_datetime_disparity_full,
 
     # other metrics
-    'concept': 'Concept ID Success Rate',
-    'duplicates': 'Duplicate Records',
-
-    'erroneous_dates': 'Erroneous Dates',
-    'date_datetime_disparity': 'Date/Datetime Disparity',
-    'person_id_failure_rate': 'Person ID Failure Rate'
+    constants.concept: constants.concept_full,
+    constants.duplicates: constants.duplicates_full,
+    constants.erroneous_dates: constants.erroneous_dates_full,
+    constants.person_id_failure_rate: constants.person_id_failure_rate_full,
+    constants.achilles_errors: constants.achilles_errors_full,
+    constants.visit_date_disparity: constants.visit_date_disparity_full
 }
 
-
-english_to_metric_type_dict = {
-    # field population metrics
-    'Unit Concept ID Success Rate': 'unit_success_rate',
-    'Route Concept ID Success Rate': 'drug_routes',
-
-    # integration metrics
-    'Drug Ingredient Integration': 'drug_success',
-    'Measurement Integration': 'sites_measurement',
-
-    # ACHILLES errors
-    'End Dates Preceding Start Dates': 'end_before_begin',
-    'Data After Death': 'data_after_death',
-
-    # other metrics
-    'Concept ID Success Rate': 'concept',
-    'Duplicate Records': 'duplicates',
-
-    'Erroneous Dates': 'erroneous_dates',
-    'Date/Datetime Disparity': 'date_datetime_disparity',
-    'Person ID Failure Rate': 'person_id_failure_rate'
-}
+# currently blank - no new metrics expected
+new_metric_types = [constants.visit_date_disparity_full]

--- a/data_steward/analytics/tools/dq_issue_tracker/general_functions.py
+++ b/data_steward/analytics/tools/dq_issue_tracker/general_functions.py
@@ -11,7 +11,7 @@ import os
 import pandas as pd
 import sys
 import datetime
-from class_definitions import HPO
+import constants
 
 
 def load_files(sheet_name, file_name):
@@ -45,24 +45,24 @@ def load_files(sheet_name, file_name):
         sheet = pd.read_excel(file_name, sheet_name=sheet_name)
 
         if sheet.empty:
-            print("WARNING: No data found in the {} sheet "
-                  "in dataframe {}".format(
-                   sheet_name, file_name))
+            print(f"""WARNING: No data found in the {sheet_name} sheet
+                  in dataframe {file_name}""")
 
     except Exception as ex:  # sheet not in specified excel file
         if type(ex).__name__ == "FileNotFoundError":
-            print("{} not found in the current directory: {}. Please "
-                  "ensure that the file names are consistent between "
-                  "the Python script and the file name in your current "
-                  "directory. ".format(file_name, cwd))
+            print(f"""{file_name} not found in the current directory: {cwd}.
+                  Please ensure that the file names are consistent
+                  between the Python script and the file name in
+                  your current directory. """)
             sys.exit(0)
 
         else:
-            print("WARNING: No {} sheet found in dataframe {}. "
-                  "This is a(n) {}.".format(
-                    sheet_name, file_name, type(ex).__name__))
+            err_type = type(ex).__name__
 
-            print("The error message is as follows: {err}".format(err=ex))
+            print(f"""WARNING: No {sheet_name} sheet found in
+                  dataframe {file_name}. This is a(n) {err_type}.""")
+
+            print(f"The error message is as follows: {ex}")
             print(ex)
             sys.exit(0)
 
@@ -167,9 +167,7 @@ def get_err_rate(sheet, row_num, metric, hpo_name, column):
     if row_num is not None:
         data_info = sheet.iloc[row_num, :]  # series, column labels and values
     else:
-        print("{hpo_name} is not in the following sheet: {sheet}".format(
-            hpo_name=hpo_name, sheet=metric
-        ))
+        print(f"{hpo_name} is not in the following sheet: {metric}")
         sys.exit(0)
 
     val = data_info[column]
@@ -206,7 +204,7 @@ def sort_and_convert_dates(file_names):
     # NOTE: requires files to have full month name and 4-digit year
     for date_str in file_names:
         date_str = date_str[:-5]  # take off the .xlsx
-        date = datetime.datetime.strptime(date_str, '%B_%d_%Y')
+        date = datetime.datetime.strptime(date_str, constants.date_format)
         ordered_dates_dt.append(date)
 
     ordered_dates_dt = sorted(ordered_dates_dt)

--- a/data_steward/analytics/tools/email_generator/constants.py
+++ b/data_steward/analytics/tools/email_generator/constants.py
@@ -7,23 +7,6 @@ to a cleaner-looking code (as strings tend to 'bog down' the script
 in general. Beyond legibility, this allows us to "mass change" certain
 attributes that appear many times in the file.
 """
-# Booleans
-# --------
-true = True
-false = False
-
-
-# Formatting
-# ----------
-date_format = '%B_%d_%Y'
-rounding_val = 2
-
-
-# misc_strings
-# ------------
-hpo_sheets = 'hpo_sheets'
-table_sheets = 'table_sheets'
-aggregate_info = 'aggregate_info'
 
 
 # Table Names
@@ -55,7 +38,6 @@ procedure_total_row = 'procedure_total_row'
 condition_total_row = 'condition_total_row'
 measurement_total_row = 'measurement_total_row'
 visit_total_row = 'visit_total_row'
-
 
 # Measurement Class Names
 # -----------------------
@@ -185,19 +167,28 @@ measurement_success = 'measurement_success_rate'
 visit_success = 'visit_success_rate'
 
 concept_success_rate_columns = [
-    observation_success, condition_success, drug_success_col,
-    visit_success, measurement_success, procedure_success]
+    condition_success, drug_success_col,
+    condition_success, measurement_success, procedure_success]
 
 total_unit_success_rate = 'total_unit_success_rate'
 total_route_success_rate = 'total_route_success_rate'
 
+hpo_col_name = 'HPO'
+table_class_col_name = 'Table/Class'
+metric_type_col_name = 'Metric Type'
+data_quality_dimension_col_name = 'Data Quality Dimension'
+link_col_name = 'Link'
+first_reported_col_name = 'First Reported'
 
-# Values
-# ------
-nan_string = "NaN"
-no_data = 'No Data'
 
 # Other Strings
 # -------------
-analytics_report_file_ending = "_analytics_report.xlsx"
+date_format = '%B_%d_%Y'
+output_file_ending = "_data_quality_issues.xlsx"
 xl_writer = 'xlsxwriter'
+
+minimum = 'minimum'
+maximum = 'maximum'
+
+true = True
+false = False

--- a/data_steward/analytics/tools/email_generator/create_dqms.py
+++ b/data_steward/analytics/tools/email_generator/create_dqms.py
@@ -120,6 +120,7 @@ def create_dqm_list(dfs, file_names, datetimes, user_choice,
 
     # creating the DQM objects and assigning to HPOs
     for dataframe, file_name, date in zip(dfs, file_names, datetimes):
+
         dqm_objects, col_names = create_dqm_objects_for_sheet(
             dataframe=dataframe, hpo_names=hpo_names,
             user_choice=user_choice, metric_is_percent=percent_bool,

--- a/data_steward/analytics/tools/email_generator/data_quality_metric_class.py
+++ b/data_steward/analytics/tools/email_generator/data_quality_metric_class.py
@@ -67,16 +67,12 @@ class DataQualityMetric:
         human-readable format.
         """
         print(
-            "HPO: {hpo}\n"
-            "Table/Class: {table_or_class}\n"
-            "Metric Type: {metric_type}\n"
-            "Value: {value}\n"
-            "Data Quality Dimension: {dqd}\n"
-            "Date: {date}\n\n".format(
-                hpo=self.hpo, table_or_class=self.table_or_class,
-                metric_type=self.metric_type,
-                value=self.value, dqd=self.data_quality_dimension,
-                date=self.date))
+            f"""HPO: {self.hpo}
+            Table Or Class: {self.table_or_class}
+            Metric Type: {self.metric_type}
+            Value: {self.value}
+            Data Quality Dimension: {self.data_quality_dimension}
+            Date: {self.date}""")
 
     def get_list_of_attribute_names(self):
         """

--- a/data_steward/analytics/tools/email_generator/dictionaries_and_lists.py
+++ b/data_steward/analytics/tools/email_generator/dictionaries_and_lists.py
@@ -44,78 +44,109 @@ Lists
 row_count_col_names: shows the column names where one can find the
     total row count for a particular date for each table
 """
+import constants
+
+metric_names = [
+    # field population metrics
+    constants.unit_success_rate,
+    constants.drug_routes,
+
+    # integration metrics
+    constants.drug_success,
+    constants.sites_measurement,
+
+    # ACHILLES errors
+    constants.end_before_begin,
+    constants.data_after_death,
+
+    # other metrics
+    constants.concept,
+    constants.duplicates,
+    constants.erroneous_dates,
+    constants.person_id_failure_rate,
+    constants.date_datetime_disparity,
+    constants.visit_date_disparity]
 
 # ---------- Dictionaries ---------- #
 thresholds = {
-    'concept_success_min': 90,
-    'duplicates_max': 5,
+    constants.concept_success_min: 90,
+    constants.duplicates_max: 5,
 
-    'end_before_begin_max': 0,
-    'data_after_death_max': 0,
+    constants.end_before_begin_max: 0,
+    constants.data_after_death_max: 0,
 
-    'drug_ingredient_integration_min': 90,
-    'measurement_integration_min': 90,
+    constants.drug_ingredient_integration_min: constants.integration_minimum,
+    constants.measurement_integration_min: constants.integration_minimum,
 
-    'unit_success_min': 85,
-    'route_success_min': 85,
+    constants.unit_success_min: constants.field_population_minimum,
+    constants.route_success_min: constants.field_population_minimum,
 
-    'date_datetime_disparity_max': 0,
-    'erroneous_dates_max': 0.01,
-    'person_failure_rate_max': 0.01}
+    constants.date_datetime_disparity_max: constants.achilles_max_value,
+    constants.erroneous_dates_max: constants.achilles_max_value,
+    constants.person_failure_rate_max: constants.achilles_max_value,
+
+    constants.achilles_errors_max: 15,
+    constants.visit_date_disparity_max: constants.achilles_max_value,
+}
+
 
 thresholds_full_name = {
     # field population metrics
-    'Unit Concept ID Success Rate': 85,
-    'Route Concept ID Success Rate': 85,
+    constants.unit_success_full: constants.field_population_minimum,
+    constants.drug_routes_full: constants.field_population_minimum,
 
     # integration metrics
-    'Drug Ingredient Integration': 90,
-    'Measurement Integration': 90,
+    constants.drug_success_full: constants.integration_minimum,
+    constants.sites_measurement_full: constants.integration_minimum,
 
     # ACHILLES errors
-    'End Dates Preceding Start Dates': 0,
-    'Data After Death': 0,
-    'Date/Datetime Disparity': 0,
+    constants.end_before_begin_full: constants.achilles_max_value,
+    constants.data_after_death_full: constants.achilles_max_value,
+    constants.date_datetime_disparity_full: constants.achilles_max_value,
 
     # other metrics
-    'Concept ID Success Rate': 90,
-    'Duplicate Records': 5,
-    'Erroneous Dates': 0.01,
-    'Person ID Failure Rate': 0.01}
+    constants.concept_full: 90,
+    constants.duplicates_full: 5,
+    constants.erroneous_dates_full: constants.achilles_max_value,
+    constants.person_id_failure_rate_full: constants.achilles_max_value,
+    constants.visit_date_disparity_full: constants.achilles_max_value}
 
 min_or_max = {
     # field population metrics
-    'Unit Concept ID Success Rate': 'minimum',
-    'Route Concept ID Success Rate': 'minimum',
+    constants.unit_success_full: constants.minimum,
+    constants.drug_routes_full: constants.minimum,
 
     # integration metrics
-    'Drug Ingredient Integration': 'minimum',
-    'Measurement Integration': 'minimum',
+    constants.drug_success_full: constants.minimum,
+    constants.sites_measurement_full: constants.minimum,
 
     # ACHILLES errors
-    'End Dates Preceding Start Dates': 'maximum',
-    'Data After Death': 'maximum',
-    'Date/Datetime Disparity': 'maximum',
+    constants.end_before_begin_full: constants.maximum,
+    constants.data_after_death_full: constants.maximum,
+    constants.date_datetime_disparity_full: constants.maximum,
 
     # other metrics
-    'Concept ID Success Rate': 'minimum',
-    'Duplicate Records': 'maximum',
-    'Erroneous Dates': 'maximum',
-    'Person ID Failure Rate': 'maximum'}
+    constants.concept_full: constants.minimum,
+    constants.duplicates_full: constants.maximum,
+    constants.erroneous_dates_full: constants.maximum,
+    constants.person_id_failure_rate_full: constants.maximum,
+    constants.visit_date_disparity_full: constants.maximum}
 
 percentage_dict = {
-    'duplicates': False,
-    'data_after_death': True,
-    'end_before_begin': True,
-    'concept': True,
-    'unit_success_rate': True,
-    'drug_routes': True,
-    'drug_success': True,
-    'sites_measurement': True,
-    'visit_date_disparity': True,
-    'date_datetime_disparity': True,
-    'erroneous_dates': True,
-    'person_id_failure_rate': True}
+    constants.duplicates: constants.false,
+    constants.data_after_death: constants.true,
+    constants.end_before_begin: constants.true,
+    constants.concept: constants.true,
+    constants.unit_success_rate: constants.true,
+    constants.drug_routes: constants.true,
+    constants.drug_success: constants.true,
+    constants.sites_measurement: constants.true,
+    constants.date_datetime_disparity: constants.true,
+    constants.erroneous_dates: constants.true,
+    constants.person_id_failure_rate: constants.true,
+    constants.achilles_errors: constants.false,
+    constants.visit_date_disparity: constants.true,
+}
 
 
 # NOTE: This is actually different than what one would
@@ -123,133 +154,126 @@ percentage_dict = {
 # we want less granularity for the 'integration metrics'.
 
 columns_to_document_for_sheet_email = {
-    'unit_success_rate': ['total_unit_success_rate'],
+    constants.unit_success_rate: [constants.total_unit_success_rate],
 
-    'sites_measurement': [
-        'Physical_Measurement',	'CMP', 'CBCwDiff',
-        'CBC', 'Lipid',	'All_Measurements'],
+    constants.sites_measurement:
+        constants.measurement_categories,
 
-    'end_before_begin': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'device_exposure'],
+    constants.end_before_begin: constants.tables_with_one_date,
 
-    'duplicates': ['visit_occurrence', 'condition_occurrence',
-                   'drug_exposure', 'measurement',
-                   'procedure_occurrence', 'device_exposure',
-                   'observation'],
+    constants.duplicates: constants.all_canonical_tables,
 
-    'drug_routes': ['total_route_success_rate'],
+    constants.drug_routes: [constants.total_route_success_rate],
 
-    'drug_success': [
-        'ace_inhibitors', 'painnsaids', 'msknsaids',
-        'statins', 'antibiotics', 'opioids', 'oralhypoglycemics',
-        'vaccine', 'ccb', 'diuretics', 'all_drugs'],
+    constants.drug_success: constants.drug_categories,
 
-    'data_after_death': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation'],
+    constants.data_after_death: constants.all_canonical_tables,
 
-    'diabetes': [
+    constants.diabetes: [
         'diabetics_w_drugs', 'diabetics_w_glucose',
         'diabetics_w_a1c', 'diabetics_w_insulin'],
 
-    'concept': [
-        'observation_success_rate', 'drug_success_rate',
-        'procedure_success_rate', 'condition_success_rate',
-        'measurement_success_rate', 'visit_success_rate'],
+    constants.concept: constants.concept_success_rate_columns,
 
-    'date_datetime_disparity': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation'],
+    constants.date_datetime_disparity:
+        constants.all_canonical_tables,
 
-    'erroneous_dates': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation'],
+    constants.erroneous_dates:
+        constants.all_canonical_tables,
 
-    'person_id_failure_rate': [
-        'visit_occurrence', 'condition_occurrence',
-        'drug_exposure', 'measurement',
-        'procedure_occurrence', 'observation']}
+    constants.person_id_failure_rate:
+        constants.all_canonical_tables,
+
+    constants.visit_date_disparity:
+        [
+        constants.condition_occurrence, constants.drug_exposure,
+        constants.observation, constants.measurement,
+        constants.procedure_occurrence]}
 
 
 table_based_on_column_provided = {
     # canonical columns
-    'visit_occurrence': 'Visit Occurrence',
-    'condition_occurrence': 'Condition Occurrence',
-    'drug_exposure': 'Drug Exposure',
-    'device_exposure': 'Device Exposure',
-    'measurement': 'Measurement',
-    'procedure_occurrence': 'Procedure Occurrence',
-    'observation': 'Observation',
+    constants.visit_occurrence: constants.visit_occurrence_full,
+    constants.condition_occurrence: constants.condition_occurrence_full,
+    constants.drug_exposure: constants.drug_exposure_full,
+    constants.measurement: constants.measurement_full,
+    constants.procedure_occurrence: constants.procedure_full,
+    constants.observation: constants.observation_full,
 
     # general concept success rate columns
-    'observation_success_rate': 'Observation',
-    'drug_success_rate': 'Drug Exposure',
-    'procedure_success_rate': 'Procedure Occurrence',
-    'condition_success_rate': 'Condition Occurrence',
-    'measurement_success_rate': 'Measurement',
-    'visit_success_rate': 'Visit Occurrence',
+    constants.observation_success: constants.observation_full,
+    constants.drug_success_col: constants.drug_exposure_full,
+    constants.procedure_success: constants.procedure_full,
+    constants.condition_success: constants.condition_occurrence_full,
+    constants.measurement_success: constants.measurement_full,
+    constants.visit_success: constants.visit_occurrence_full,
 
     # field concept success rate columns
-    'total_unit_success_rate': 'Measurement',
-    'total_route_success_rate': 'Drug Exposure',
+    constants.total_unit_success_rate: constants.measurement_full,
+    constants.total_route_success_rate: constants.drug_exposure_full,
 
     # drug integration columns
-    'all_drugs': 'All Drugs',
-    'ace_inhibitors': 'ACE Inhibitors',
-    'painnsaids': 'Pain NSAIDS',
-    'msknsaids': 'MSK NSAIDS',
-    'statins': 'Statins',
-    'antibiotics': 'Antibiotics',
-    'opioids': 'Opioids',
-    'oralhypoglycemics': 'Oral Hypoglycemics',
-    'vaccine': 'Vaccine',
-    'ccb': 'Calcium Channel Blockers',
-    'diuretics': 'Diuretics',
+    constants.all_drugs: constants.all_drugs_full,
+    constants.ace_inhibs: constants.ace_inhibs_full,
+    constants.pain_nsaids: constants.pain_nsaids_full,
+    constants.msk_nsaids: constants.msk_nsaids_full,
+    constants.statins: constants.statins_full,
+    constants.antibiotics: constants.antibiotics_full,
+    constants.opioids: constants.opioids_full,
+    constants.oral_hypo: constants.oral_hypo_full,
+    constants.vaccine: constants.vaccine_full,
+    constants.ccb: constants.ccb_full,
+    constants.diuretics: constants.diuretics_full,
 
     # measurement integration columns
-    'All_Measurements': 'All Measurements',
-    "Physical_Measurement": 'Physical Measurements',
-    'CMP': 'Comprehensive Metabolic Panel',
-    'CBCwDiff': 'CBC with Differential',
-    'CBC': 'Complete Blood Count (CBC)',
-    'Lipid': 'Lipid'}
+    constants.all_measurements: constants.all_measurements_full,
+    constants.physical_measurement: constants.physical_measurements_full,
+    constants.cmp: constants.cmp_full,
+    constants.cbc_w_diff: constants.cbc_w_diff_full,
+    constants.cbc: constants.cbc_full,
+    constants.lipid: constants.lipid_full,
+
+    'num_distinct_ids': 'All Tables'
+}
 
 data_quality_dimension_dict = {
-    'concept': 'Conformance',
-    'duplicates': 'Plausibility',
-    'end_before_begin': 'Plausibility',
-    'data_after_death': 'Plausibility',
-    'sites_measurement': 'Completeness',
-    'drug_success': 'Completeness',
-    'drug_routes': 'Completeness',
-    'unit_success_rate': 'Completeness',
-    'date_datetime_disparity': 'Conformance',
-    'erroneous_dates': 'Plausibility',
-    'person_id_failure_rate': 'Conformance'}
+    constants.concept: constants.conformance,
+    constants.duplicates: constants.plausibility,
+    constants.end_before_begin: constants.plausibility,
+    constants.data_after_death: constants.plausibility,
+    constants.sites_measurement: constants.completeness,
+    constants.drug_success: constants.completeness,
+    constants.drug_routes: constants.completeness,
+    constants.unit_success_rate: constants.completeness,
+    constants.date_datetime_disparity: constants.conformance,
+    constants.erroneous_dates: constants.plausibility,
+    constants.person_id_failure_rate: constants.conformance,
+    constants.achilles_errors: constants.conformance,
+    constants.visit_date_disparity: constants.conformance
+}
 
 metric_type_to_english_dict = {
     # field population metrics
-    'unit_success_rate': 'Unit Concept ID Success Rate',
-    'drug_routes': 'Route Concept ID Success Rate',
+    constants.unit_success_rate: constants.unit_success_full,
+    constants.drug_routes: constants.drug_routes_full,
 
     # integration metrics
-    'drug_success': 'Drug Ingredient Integration',
-    'sites_measurement': 'Measurement Integration',
+    constants.drug_success: constants.drug_success_full,
+    constants.sites_measurement: constants.sites_measurement_full,
 
     # ACHILLES errors
-    'end_before_begin': 'End Dates Preceding Start Dates',
-    'data_after_death': 'Data After Death',
-    'date_datetime_disparity': 'Date/Datetime Disparity',
+    constants.end_before_begin: constants.end_before_begin_full,
+    constants.data_after_death: constants.data_after_death_full,
+    constants.date_datetime_disparity: constants.date_datetime_disparity_full,
 
     # other metrics
-    'concept': 'Concept ID Success Rate',
-    'duplicates': 'Duplicate Records',
-    'erroneous_dates': 'Erroneous Dates',
-    'person_id_failure_rate': 'Person ID Failure Rate'}
+    constants.concept: constants.concept_full,
+    constants.duplicates: constants.duplicates_full,
+    constants.erroneous_dates: constants.erroneous_dates_full,
+    constants.person_id_failure_rate: constants.person_id_failure_rate_full,
+    constants.achilles_errors: constants.achilles_errors_full,
+    constants.visit_date_disparity: constants.visit_date_disparity_full
+}
 
 full_names = {
     "saou_uab_selma": "UAB Selma",
@@ -303,9 +327,9 @@ full_names = {
 # ---------- Lists ---------- #
 
 row_count_col_names = [
-    'observation_total_row',
-    'drug_total_row',
-    'procedure_total_row',
-    'condition_total_row',
-    'measurement_total_row',
-    'visit_total_row']
+    constants.observation_total_row,
+    constants.drug_total_row,
+    constants.procedure_total_row,
+    constants.condition_total_row,
+    constants.measurement_total_row,
+    constants.visit_total_row]

--- a/data_steward/analytics/tools/email_generator/email_generator.py
+++ b/data_steward/analytics/tools/email_generator/email_generator.py
@@ -40,15 +40,11 @@ from dictionaries_and_lists import full_names
 
 from contact_list import recipient_dict
 
+from dictionaries_and_lists import metric_names
+
 report1 = 'june_15_2020.xlsx'
 
 report_names = [report1]
-
-sheet_names = [
-    'concept', 'data_after_death', 'date_datetime_disparity',
-    'drug_routes', 'drug_success', 'duplicates',
-    'end_before_begin', 'unit_success_rate', 'erroneous_dates',
-    'sites_measurement', 'person_id_failure_rate']
 
 
 def create_hpo_objects(dqm_objects, file_names, datetimes):
@@ -115,7 +111,7 @@ def assemble_final_messages(unique_metrics, hpo_id):
     """
     ehr_site = full_names[hpo_id]
     name = "Noah Engel"
-    num_metrics = len(sheet_names)
+    num_metrics = len(metric_names)
     date = "June 14th, 2020"
 
     message = introduction.format(
@@ -129,17 +125,16 @@ def assemble_final_messages(unique_metrics, hpo_id):
 
     relevant_persons = recipient_dict[hpo_id]
 
-    message += """\n
+    message += f"""
     Email Title:
     ------------
-    Data Check Feedback (June 2020) - {site}""".format(
-        site=ehr_site)
+    Data Check Feedback (June 2020) - {ehr_site}"""
 
-    message += """\n
+    message += f"""
     Contact the following individuals:
     ----------------------------------
     {relevant_persons}
-    """.format(relevant_persons=relevant_persons)
+    """
 
     print(message)
 
@@ -150,7 +145,8 @@ def main():
     """
     all_objects = []
 
-    for metric_choice in sheet_names:
+    for metric_choice in metric_names:
+
         dfs, hpo_names, percent_bool = \
             startup(file_names=report_names,
                     metric_choice=metric_choice)

--- a/data_steward/analytics/tools/email_generator/functions_to_create_dqm_objects.py
+++ b/data_steward/analytics/tools/email_generator/functions_to_create_dqm_objects.py
@@ -102,8 +102,8 @@ def get_info(
                     # to detect potential problems in excel file generator
                     if number < 0:
                         raise ValueError(
-                            "Negative number detected in sheet {} for column "
-                            "{}".format(sheet_name, col_label))
+                            f"""Negative number detected in sheet
+                            {sheet_name} for column {col_label}""")
 
                     elif percentage:  # effective
                         data_dictionary[col_label] = round(number, 2)

--- a/data_steward/analytics/tools/email_generator/functions_to_create_hpo_objects.py
+++ b/data_steward/analytics/tools/email_generator/functions_to_create_hpo_objects.py
@@ -10,6 +10,7 @@ from startup_functions import load_files
 from functions_to_create_dqm_objects import find_hpo_row, \
     get_info
 import datetime
+import constants
 
 
 def establish_hpo_objects(dqm_objects):
@@ -62,7 +63,8 @@ def establish_hpo_objects(dqm_objects):
               route_success=[], unit_success=[],
               measurement_integration=[], ingredient_integration=[],
               date_datetime_disp=[], erroneous_dates=[],
-              person_id_failure=[])
+              person_id_failure=[], achilles_errors=[],
+              visit_date_disparity=[])
 
             blank_hpo_objects.append(hpo)
 
@@ -135,7 +137,7 @@ def add_number_total_rows_for_hpo_and_date(
     hpos (list): list of the HPO objects. now should have the
         attributes for the number of rows filled in.
     """
-    sheet_name = 'concept'  # where row count is stored
+    sheet_name = constants.concept  # where row count is stored
     dfs = load_files(
         user_choice=sheet_name, file_names=date_names)
 
@@ -143,7 +145,7 @@ def add_number_total_rows_for_hpo_and_date(
 
     for date_str in date_names:
         date_str = date_str[:-5]  # get rid of extension
-        date_obj = datetime.datetime.strptime(date_str, '%B_%d_%Y')
+        date_obj = datetime.datetime.strptime(date_str, constants.date_format)
         dates_objs.append(date_obj)
 
     chosen_idx = -1
@@ -152,9 +154,7 @@ def add_number_total_rows_for_hpo_and_date(
         if date_object == date:
             chosen_idx = idx
 
-    assert chosen_idx > -1, "Invalid Date: {date}".format(
-        date=date
-    )
+    assert chosen_idx > -1, f"Invalid Date: {date}"
 
     df_for_date = dfs[chosen_idx]
 

--- a/data_steward/analytics/tools/email_generator/hpo_class.py
+++ b/data_steward/analytics/tools/email_generator/hpo_class.py
@@ -2,9 +2,11 @@
 File is intended to establish an 'HPO class' that can be used
 to store data quality metrics in an easy and
 identifiable fashion.
+
 Class was used as a means for storing information as the ability
 to add functions could prove useful in future iterations of the
 script.
+
 Please note that many of the functions and parameters outlined
 in this class are highly contingent upon the DataQualityMetric
 class. Please familiarize yourself with the aforementioned
@@ -13,6 +15,7 @@ class before learning more about the HPO class.
 
 from dictionaries_and_lists import thresholds
 import sys
+import constants
 
 
 class HPO:
@@ -32,7 +35,8 @@ class HPO:
             end_before_begin, data_after_death,
             route_success, unit_success, measurement_integration,
             ingredient_integration, date_datetime_disp,
-            erroneous_dates, person_id_failure,
+            erroneous_dates, person_id_failure, achilles_errors,
+            visit_date_disparity,
 
             # number of rows for the 6 canonical tables
             num_measurement_rows=0,
@@ -44,10 +48,10 @@ class HPO:
 
         """
         Used to establish the attributes of the HPO object being instantiated.
+
         Parameters
         ----------
         self (HPO object): the object to be created
-
         name (str): name of the HPO ID to create (e.g. nyc_cu)
 
         full_name (str): full name of the HPO
@@ -116,6 +120,14 @@ class HPO:
             each of the tables have a 'failing' person_id
             (one that does not exist in the person table)
 
+        achilles_errors (list): list of DataQualityMetric
+            objects that show the number of ACHILLES errors
+            for the particular date
+
+        visit_date_disparity (list): list of DataQualityMetric
+            objects that show the percentage of rows that have
+            inconsistencies with respect to the visit date
+
         num_measurement_rows (float): number of rows in the
             measurement table
 
@@ -147,72 +159,59 @@ class HPO:
         self.date_datetime_disp = date_datetime_disp
         self.erroneous_dates = erroneous_dates
         self.person_id_failure = person_id_failure
+        self.visit_date_disparity = visit_date_disparity
 
-        # only relates to one table
+        # only relates to one table / entity
         self.route_success = route_success
         self.unit_success = unit_success
         self.measurement_integration = measurement_integration
         self.ingredient_integration = ingredient_integration
+        self.achilles_errors = achilles_errors
 
         # number of rows in each table
-        self.num_measurement_rows = num_measurement_rows,
-        self.num_visit_rows = num_visit_rows,
-        self.num_procedure_rows = num_procedure_rows,
-        self.num_condition_rows = num_condition_rows,
-        self.num_drug_rows = num_drug_rows,
+        self.num_measurement_rows = num_measurement_rows
+        self.num_visit_rows = num_visit_rows
+        self.num_procedure_rows = num_procedure_rows
+        self.num_condition_rows = num_condition_rows
+        self.num_drug_rows = num_drug_rows
         self.num_observation_rows = num_observation_rows
 
     def print_attributes(self):
         """
         Function is used to generate a string that can be
         used to display the various attributes as a string.
+
         This string is then printed to display on the
         program.
         """
-        attributes_str = """
-        HPO ID: {hpo_id}\n
-        Full Name: {full_name}\n
-        Date: {date}\n\n
-        Number of Metrics: \n
-        \t Concept Success Rate: {num_concepts}\n
-        \t Duplicates: {duplicates}\n
-        \t End Dates Preceding Start Dates: {end_before_start}\n
-        \t Data After Death: {d_a_d}\n
-        \t Route Success: {route_success}\n
-        \t Unit Success: {unit_success}\n
-        \t Measurement Integration: {measurement_integration}\n
-        \t Ingredient Integration: {ingredient_integration}\n
-        \t Date/Datetime Disagreement: {date_datetime} \n
-        \t Erroneous Dates: {erroneous_dates}\n
-        \t Person ID Failure: {person_id_failure}\n
-        \n
-        Number of Rows:\n
-        \t Measurement: {measurement}\n
-        \t Visit Occurrence: {visit}\n
-        \t Procedure Occurrence: {procedure}\n
-        \t Condition Occurrence: {condition}\n
-        \t Drug Exposure: {drug}\n
-        \t Observation: {observation}
-        """.format(
-            hpo_id=self.name, full_name=self.full_name,
-            date=self.date, num_concepts=len(self.concept_success),
-            duplicates=len(self.duplicates),
-            end_before_start=len(self.end_before_begin),
-            d_a_d=len(self.data_after_death),
-            route_success=len(self.route_success),
-            unit_success=len(self.unit_success),
-            measurement_integration=len(self.measurement_integration),
-            ingredient_integration=len(self.ingredient_integration),
-            date_datetime=len(self.date_datetime_disp),
-            erroneous_dates=len(self.erroneous_dates),
-            person_id_failure=len(self.person_id_failure),
-            measurement=self.num_measurement_rows,
-            visit=self.num_visit_rows,
-            procedure=self.num_procedure_rows,
-            condition=self.num_condition_rows,
-            drug=self.num_drug_rows,
-            observation=self.num_observation_rows
-        )
+        attributes_str = f"""
+        HPO ID: {self.name}
+        Full Name: {self.full_name}
+        Date: {self.date}
+        
+        Number of Metrics:
+            Concept Success Rate: {len(self.concept_success)}
+            Duplicates: {len(self.duplicates)}
+            End Dates Preceding Start Dates: {len(self.end_before_begin)}
+            Data After Death: {len(self.data_after_death)}
+            Route Success: {len(self.route_success)}
+            Unit Success: {len(self.unit_success)}
+            Measurement Integration: {len(self.measurement_integration)}
+            Ingredient Integration: {len(self.ingredient_integration)}
+            Date/Datetime Disagreement: {len(self.date_datetime_disp)}
+            Erroneous Dates: {len(self.erroneous_dates)}
+            Person ID Failure: {len(self.person_id_failure)}
+            Number of ACHILLES Errors: {len(self.achilles_errors)}
+            Visit Date Disparity: {len(self.visit_date_disparity)}
+        
+        Number of Rows:
+            Measurement: {self.num_measurement_rows}
+            Visit Occurrence: {self.num_visit_rows}
+            Procedure Occurrence: {self.num_procedure_rows}
+            Condition Occurrence: {self.num_condition_rows}
+            Drug Exposure: {self.num_drug_rows}
+            Observation: {self.num_observation_rows}
+        """
 
         print(attributes_str)
 
@@ -235,42 +234,48 @@ class HPO:
             equal self.name whenever this is used)
         """
 
-        if metric == 'Concept ID Success Rate':
+        if metric == constants.concept_full:
             self.concept_success.append(dq_object)
 
-        elif metric == 'Duplicate Records':
+        elif metric == constants.duplicates_full:
             self.duplicates.append(dq_object)
 
-        elif metric == 'End Dates Preceding Start Dates':
+        elif metric == constants.end_before_begin_full:
             self.end_before_begin.append(dq_object)
 
-        elif metric == 'Data After Death':
+        elif metric == constants.data_after_death_full:
             self.data_after_death.append(dq_object)
 
-        elif metric == 'Measurement Integration':
+        elif metric == constants.sites_measurement_full:
             self.measurement_integration.append(dq_object)
 
-        elif metric == 'Drug Ingredient Integration':
+        elif metric == constants.drug_success_full:
             self.ingredient_integration.append(dq_object)
 
-        elif metric == 'Route Concept ID Success Rate':
+        elif metric == constants.drug_routes_full:
             self.route_success.append(dq_object)
 
-        elif metric == 'Unit Concept ID Success Rate':
+        elif metric == constants.unit_success_full:
             self.unit_success.append(dq_object)
 
-        elif metric == 'Date/Datetime Disparity':
+        elif metric == constants.date_datetime_disparity_full:
             self.date_datetime_disp.append(dq_object)
 
-        elif metric == 'Erroneous Dates':
+        elif metric == constants.erroneous_dates_full:
             self.erroneous_dates.append(dq_object)
 
-        elif metric == 'Person ID Failure Rate':
+        elif metric == constants.person_id_failure_rate_full:
             self.person_id_failure.append(dq_object)
 
+        elif metric == constants.achilles_errors_full:
+            self.achilles_errors.append(dq_object)
+
+        elif metric == constants.visit_date_disparity_full:
+            self.visit_date_disparity.append(dq_object)
+
         else:
-            print("Unrecognized metric input: {metric} for {hpo}".format(
-                metric=metric, hpo=self.name))
+            hpo_name = self.name
+            print(f"Unrecognized metric input: {metric} for {hpo_name}")
             sys.exit(0)
 
     def add_row_count_with_string(self, table, value):
@@ -291,21 +296,21 @@ class HPO:
             table
         """
 
-        if table == 'observation_total_row':
+        if table == constants.observation_total_row:
             self.num_observation_rows = value
-        elif table == 'drug_total_row':
+        elif table == constants.drug_total_row:
             self.num_drug_rows = value
-        elif table == 'procedure_total_row':
+        elif table == constants.procedure_total_row:
             self.num_procedure_rows = value
-        elif table == 'condition_total_row':
+        elif table == constants.condition_total_row:
             self.num_condition_rows = value
-        elif table == 'measurement_total_row':
+        elif table == constants.measurement_total_row:
             self.num_measurement_rows = value
-        elif table == 'visit_total_row':
+        elif table == constants.visit_total_row:
             self.num_visit_rows = value
         else:
-            print("Unrecognized table input: {table} for {hpo}".format(
-                table=table, hpo=self.name))
+            hpo_name = self.name
+            print(f"Unrecognized table input: {table} for {hpo_name}")
             sys.exit(0)
 
     def use_table_or_class_name_to_find_rows(
@@ -334,89 +339,97 @@ class HPO:
             table being queried
         """
 
-        if metric == 'Concept ID Success Rate':
+        if metric == constants.concept_full:
             for obj in self.concept_success:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Duplicate Records':
+        elif metric == constants.duplicates_full:
             for obj in self.duplicates:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'End Dates Preceding Start Dates':
+        elif metric == constants.end_before_begin_full:
             for obj in self.end_before_begin:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Data After Death':
+        elif metric == constants.data_after_death_full:
             for obj in self.data_after_death:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Measurement Integration':
+        elif metric == constants.sites_measurement_full:
             for obj in self.measurement_integration:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Drug Ingredient Integration':
+        elif metric == constants.drug_success_full:
             for obj in self.ingredient_integration:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Route Concept ID Success Rate':
+        elif metric == constants.drug_routes_full:
             for obj in self.route_success:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Unit Concept ID Success Rate':
+        elif metric == constants.unit_success_full:
             for obj in self.unit_success:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Date/Datetime Disparity':
+        elif metric == constants.date_datetime_disparity_full:
             for obj in self.date_datetime_disp:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Erroneous Dates':
+        elif metric == constants.erroneous_dates_full:
             for obj in self.erroneous_dates:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        elif metric == 'Person ID Failure Rate':
+        elif metric == constants.person_id_failure_rate_full:
             for obj in self.person_id_failure:
                 if obj.table_or_class == table_or_class:
                     succ_rate = obj.value
 
-        else:
-            raise Exception(
-                "Unexpected metric type:"
-                "{metric} found for table or class"
-                "{table_or_class}".format(
-                    metric=metric, table_or_class=table_or_class))
+        elif metric == constants.achilles_errors_full:
+            for obj in self.achilles_errors:
+                if obj.table_or_class == table_or_class:
+                    succ_rate = obj.value
 
-        if table_or_class == "Measurement":
+        elif metric == constants.visit_date_disparity_full:
+            for obj in self.visit_date_disparity:
+                if obj.table_or_class == table_or_class:
+                    succ_rate = obj.value
+
+        else:
+            raise Exception(f"""
+                Unexpected metric type:
+                {metric} found for table or class
+                {table_or_class}""")
+
+        if table_or_class == constants.measurement_full:
             total_rows = self.num_measurement_rows
-        elif table_or_class == "Visit Occurrence":
+        elif table_or_class == constants.visit_occurrence_full:
             total_rows = self.num_visit_rows
-        elif table_or_class == "Procedure Occurrence":
+        elif table_or_class == constants.procedure_full:
             total_rows = self.num_procedure_rows
-        elif table_or_class == "Condition Occurrence":
+        elif table_or_class == constants.condition_occurrence_full:
             total_rows = self.num_condition_rows
-        elif table_or_class == "Drug Exposure":
+        elif table_or_class == constants.drug_exposure_full:
             total_rows = self.num_drug_rows
-        elif table_or_class == "Observation":
+        elif table_or_class == constants.observation_full:
             total_rows = self.num_observation_rows
         elif table_or_class == "Device Exposure":  # ignore for now
             total_rows = 0
         else:
             raise Exception(
-                "Unexpected table type:"
-                "{table_or_class} found for metric {metric}".format(
-                    table_or_class=table_or_class, metric=metric))
+                f"""Unexpected table type:
+                {table_or_class} found for metric {metric}""")
 
-        if metric == 'Duplicate Records':
+        if metric == constants.duplicates_full:
             rel_rows = succ_rate  # want to report out the total #
 
         else:
@@ -464,10 +477,9 @@ class HPO:
                         metric=metric)
 
         # making sure we could calculate the row_count
-        assert row_count is not None, "The row count for the following " \
-            "data quality metric could not be found for the " \
-            "table {table_or_class} and the metric {metric}".format(
-                table_or_class=table_or_class, metric=metric)
+        assert row_count is not None, f"""The row count for the following
+            data quality metric could not be found for the
+            table {table_or_class} and the metric {metric}"""
 
         return row_count
 
@@ -488,43 +500,49 @@ class HPO:
             objects that are related to both the HPO
             and metric provided
         """
-        if metric == 'Concept ID Success Rate':
+        if metric == constants.concept_full:
             relevant_objects = self.concept_success
 
-        elif metric == 'Duplicate Records':
+        elif metric == constants.duplicates_full:
             relevant_objects = self.duplicates
 
-        elif metric == 'End Dates Preceding Start Dates':
+        elif metric == constants.end_before_begin_full:
             relevant_objects = self.end_before_begin
 
-        elif metric == 'Data After Death':
+        elif metric == constants.data_after_death_full:
             relevant_objects = self.data_after_death
 
-        elif metric == 'Measurement Integration':
+        elif metric == constants.sites_measurement_full:
             relevant_objects = self.measurement_integration
 
-        elif metric == 'Drug Ingredient Integration':
+        elif metric == constants.drug_success_full:
             relevant_objects = self.ingredient_integration
 
-        elif metric == 'Route Concept ID Success Rate':
+        elif metric == constants.drug_routes_full:
             relevant_objects = self.route_success
 
-        elif metric == 'Unit Concept ID Success Rate':
+        elif metric == constants.unit_success_full:
             relevant_objects = self.unit_success
 
-        elif metric == 'Date/Datetime Disparity':
+        elif metric == constants.date_datetime_disparity_full:
             relevant_objects = self.date_datetime_disp
 
-        elif metric == 'Erroneous Dates':
+        elif metric == constants.erroneous_dates_full:
             relevant_objects = self.erroneous_dates
 
-        elif metric == 'Person ID Failure Rate':
+        elif metric == constants.person_id_failure_rate_full:
             relevant_objects = self.person_id_failure
+
+        elif metric == constants.achilles_errors_full:
+            relevant_objects = self.achilles_errors
+
+        elif metric == constants.visit_date_disparity_full:
+            relevant_objects = self.visit_date_disparity
 
         else:
             raise Exception(
-                "The following was identified as a metric: "
-                "{metric}".format(metric=metric))
+                f"""The following was identified as a metric:
+                {metric}""")
 
         return relevant_objects
 
@@ -584,6 +602,7 @@ class HPO:
         -----
         1. if no data quality problems are found, however, the
         function will return 'None' to signify that no issues arose
+
         2. this funciton is not currently implemented in our current
         iteration of metrics_over_time. this function, however, holds
         potential to be useful in future iterations.
@@ -594,53 +613,63 @@ class HPO:
         # below we can find the data quality metrics for several tables -
         # need to iterate through a list to get the objects for each table
         for concept_success_obj in self.concept_success:
-            if concept_success_obj.value < thresholds['concept_success_min']:
+            if concept_success_obj.value < thresholds[constants.concept_success_min]:
                 failing_metrics.append(concept_success_obj)
 
         for duplicates_obj in self.duplicates:
-            if duplicates_obj.value > thresholds['duplicates_max']:
+            if duplicates_obj.value > thresholds[constants.duplicates_max]:
                 failing_metrics.append(duplicates_obj)
 
         for end_before_begin_obj in self.end_before_begin:
-            if end_before_begin_obj.value > thresholds['end_before_begin_max']:
+            if end_before_begin_obj.value > thresholds[constants.end_before_begin_max]:
                 failing_metrics.append(end_before_begin_obj)
 
         for data_after_death_obj in self.data_after_death:
-            if data_after_death_obj.value > thresholds['data_after_death_max']:
+            if data_after_death_obj.value > thresholds[constants.data_after_death_max]:
                 failing_metrics.append(data_after_death_obj)
 
         for route_obj in self.route_success:
-            if route_obj.value < thresholds['route_success_min']:
+            if route_obj.value < thresholds[constants.route_success_min]:
                 failing_metrics.append(route_obj)
 
         for unit_obj in self.unit_success:
-            if unit_obj.value < thresholds['unit_success_min']:
+            if unit_obj.value < thresholds[constants.unit_success_min]:
                 failing_metrics.append(unit_obj)
 
         for measurement_integration_obj in self.measurement_integration:
             if measurement_integration_obj.value < \
-                    thresholds['measurement_integration_min']:
+                    thresholds[constants.measurement_integration_min]:
                 failing_metrics.append(measurement_integration_obj)
 
         for ingredient_integration_obj in self.ingredient_integration:
             if ingredient_integration_obj.value < \
-                    thresholds['route_success_min']:
+                    thresholds[constants.route_success_min]:
                 failing_metrics.append(ingredient_integration_obj)
 
         for date_datetime_obj in self.date_datetime_disp:
             if date_datetime_obj.value > \
-                    thresholds['date_datetime_disparity_max']:
+                    thresholds[constants.date_datetime_disparity_max]:
                 failing_metrics.append(date_datetime_obj)
 
         for erroneous_date_obj in self.erroneous_dates:
             if erroneous_date_obj.value > \
-                    thresholds['erroneous_dates_max']:
+                    thresholds[constants.erroneous_dates_max]:
                 failing_metrics.append(erroneous_date_obj)
 
         for person_id_failure_obj in self.person_id_failure:
             if person_id_failure_obj.value > \
-                    thresholds['person_failure_rate_max']:
+                    thresholds[constants.person_failure_rate_max]:
                 failing_metrics.append(person_id_failure_obj)
+
+        for achilles_error_obj in self.achilles_errors:
+            if achilles_error_obj.value > \
+                    thresholds[constants.achilles_errors_max]:
+                failing_metrics.append(achilles_error_obj)
+
+        for visit_date_disparity_obj in self.visit_date_disparity:
+            if visit_date_disparity_obj.value > \
+                    thresholds[constants.visit_date_disparity_max]:
+                failing_metrics.append(visit_date_disparity_obj)
 
         if not failing_metrics:  # no errors logged
             return None

--- a/data_steward/analytics/tools/email_generator/messages.py
+++ b/data_steward/analytics/tools/email_generator/messages.py
@@ -5,22 +5,25 @@ These messages can include:
     - Text for the introduction/conclusion of the email
 """
 
-introduction = \
-    "Dear {ehr_site},\n\n" \
-    "My name is {name} and I am a Data Analyst at Columbia University Medical Center with the All of Us precision medicine initiative. CUMC has been reviewing your file submissions for the past few weeks and would like to share its findings with you.\n\n" \
-    "In this e-mail, we will list out any errors that apply to your most recent submission (as of {date}) that fall below the DRC's standards for the specified data quality metrics. Similarly, we will provide you with a 'panel' that lists out these errors in an Excel format.\n\n" \
-    "Finally, we will provide you with images that display data quality values for all {num_metrics} monitored metrics, regardless of whether or not they meet the DRC's standards as noted here.\n\n"
+introduction = """
+Dear {ehr_site},
+
+My name is {name} and I am a Data Analyst at Columbia University Medical Center with the All of Us precision medicine initiative. CUMC has been reviewing your file submissions for the past few weeks and would like to share its findings with you.
+
+In this e-mail, we will list out any errors that apply to your most recent submission (as of {date}) that fall below the DRC's standards for the specified data quality metrics. Similarly, we will provide you with a 'panel' that lists out these errors in an Excel format.
+
+Finally, we will provide you with images that display data quality values for all {num_metrics} monitored metrics, regardless of whether or not they meet the DRC's standards as noted here.\n\n"""
 
 fnf_error = \
-    "{file} not found in the current directory: {cwd}. " \
-    "Please ensure that the file names are " \
-    "consistent between the Python script and the " \
-    "file name in your current directory."
+    """{file} not found in the current directory: {cwd}.
+    Please ensure that the file names are
+    consistent between the Python script and the
+    file name in your current directory."""
 
 great_job = """
-    All of the issues regarding the 11 monitored metrics have met or
-    exceeded the DRC's expectations.
-    """
+All of the issues regarding the 11 monitored metrics have met or
+exceeded the DRC's expectations.
+ """
 
 sign_off = """
 If you have questions about our metrics, please consult the AoU EHR website at this link: {link} under the 'Data Quality Metrics' tab at the top of the page. This site contains descriptions, videos, and SQL queries that can help you troubleshoot your data quality.

--- a/data_steward/analytics/tools/email_generator/organize_relevant_dqms.py
+++ b/data_steward/analytics/tools/email_generator/organize_relevant_dqms.py
@@ -18,9 +18,9 @@ def get_hpo_site():
     hpo_id (str): string that represents the HPO ID whose email
         is to be generated
     """
-    prompt = "Please input the site ID of the HPO site that " \
-             "you would like to use for an auto-generated e-mail. " \
-             "(e.g. nyc_hh)\n"
+    prompt = """
+    Please input the site ID of the HPO site that you would 
+    like to use for an auto-generated e-mail (e.g. nyc_hh)."""
 
     hpo_id = input(prompt)
     hpo_id = hpo_id.lower()  # case sensitivity
@@ -96,7 +96,7 @@ def create_string_for_failing_metrics(hpo_objects):
 
     issue_num = 1
 
-    issue_report = ""
+    issue_report = ""  #empty string
 
     for metric_type, tables_or_classes in unique_metrics.items():
 

--- a/data_steward/analytics/tools/email_generator/startup_functions.py
+++ b/data_steward/analytics/tools/email_generator/startup_functions.py
@@ -9,6 +9,7 @@ from messages import fnf_error
 from dictionaries_and_lists import \
     percentage_dict
 import datetime
+import constants
 
 
 def startup(file_names, metric_choice):
@@ -86,10 +87,8 @@ def load_files(user_choice, file_names):
 
             if sheet.empty:
 
-                print("WARNING: No data found in the {user_choice} sheet "
-                      "in dataframe {file_name}".format(
-                       user_choice=user_choice,
-                       file_name=file_name))
+                print(f"WARNING: No data found in the {user_choice} sheet "
+                      "in dataframe {file_name}")
 
                 del file_names[num_files_indexed]
                 num_files_indexed -= 1  # skip over the date
@@ -105,9 +104,9 @@ def load_files(user_choice, file_names):
                 sys.exit(0)
 
             else:
-                print("WARNING: No {} sheet found in dataframe {}. "
-                      "This is a(n) {}.".format(
-                        user_choice, file_name, type(ex).__name__))
+                print(f"WARNING: No {user_choice} sheet found "
+                      f"in dataframe {file_name}. This is a(n) "
+                      f"{type(ex).__name__}.")
 
                 print(ex)
 
@@ -154,7 +153,7 @@ def generate_hpo_id_col(file_names):
 
     # use concept sheet; always has all of the HPO IDs
     dataframes = load_files(
-        user_choice='concept', file_names=file_names)
+        user_choice=constants.concept, file_names=file_names)
     hpo_col_name = 'src_hpo_id'
     selective_rows, total_hpo_id_columns = [], []
 
@@ -217,14 +216,14 @@ def convert_file_names_to_datetimes(file_names):
     # NOTE: requires files to have full month name and 4-digit year
     for date_str in file_names:
         date_str = date_str[:-5]  # get rid of extension
-        date = datetime.datetime.strptime(date_str, '%B_%d_%Y')
+        date = datetime.datetime.strptime(date_str, constants.date_format)
         ordered_dates_dt.append(date)
 
     ordered_dates_dt = sorted(ordered_dates_dt)
 
     # converting back to standard form to index into file
     ordered_dates_str = [
-        x.strftime('%B_%d_%Y').lower() + '.xlsx'
+        x.strftime(constants.date_format).lower() + '.xlsx'
         for x in ordered_dates_dt]
 
     return ordered_dates_str, ordered_dates_dt

--- a/data_steward/analytics/tools/visualizations/conformance/visit_date_disparity.py
+++ b/data_steward/analytics/tools/visualizations/conformance/visit_date_disparity.py
@@ -1,0 +1,301 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.4.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# NOTES:
+# 1. matplotlib MUST be in 3.1.0; 3.1.1 ruins the heatmap
+
+# # Across-Site Statistics for Visit Date Disparity Rates
+#
+# ### NOTE: Aggregate info is weighted by the contribution of each site
+
+import pandas as pd
+import xlrd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from math import pi
+# %matplotlib inline
+
+# +
+sheets = []
+
+fn1 = 'visit_date_disparity_table_sheets_analytics_report.xlsx'
+file_names = [fn1]
+
+s1 = 'Observation'
+s2 = 'Measurement'
+s3 = 'Procedure Occurrence'
+s4 = 'Drug Exposure'
+s5 = 'Condition Occurrence'
+
+sheet_names = [s1, s2, s3, s4, s5]
+
+# +
+table_sheets = []
+
+for file in file_names:
+    for sheet in sheet_names:
+        s = pd.read_excel(file, sheet)
+        table_sheets.append(s)
+
+date_cols = table_sheets[0].columns
+date_cols = (list(date_cols))
+
+hpo_id_cols = table_sheets[0].index
+hpo_id_cols = (list(hpo_id_cols))
+# -
+
+# ### Converting the numbers as needed and putting into a dictionary
+
+# +
+new_table_sheets = {}
+
+for name, sheet in zip(sheet_names, table_sheets):
+    sheet_cols = sheet.columns
+    sheet_cols = sheet_cols[0:]
+    new_df = pd.DataFrame(columns=sheet_cols)
+
+    for col in sheet_cols:
+        old_col = sheet[col]
+        new_col = pd.to_numeric(old_col, errors='coerce')
+        new_df[col] = new_col
+
+    new_table_sheets[name] = new_df
+# -
+
+# ### Fixing typos
+
+# +
+fig, ax = plt.subplots(figsize=(18, 12))
+
+sns.heatmap(new_table_sheets['Condition Occurrence'], annot=True, annot_kws={"size": 10},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=hpo_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
+
+ax.set_title("Condition Table Visit Date Disparity Rate", size=14)
+
+plt.show()
+# plt.savefig("condition_table_visit_date_disparity.jpg")
+
+# +
+fig, ax = plt.subplots(figsize=(18, 12))
+sns.heatmap(new_table_sheets['Drug Exposure'], annot=True, annot_kws={"size": 10},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=hpo_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
+
+ax.set_title("Drug Table Visit Date Disparity Rate", size=14)
+# plt.savefig("drug_table_visit_date_disparity.jpg")
+
+# +
+fig, ax = plt.subplots(figsize=(18, 12))
+sns.heatmap(new_table_sheets['Measurement'], annot=True, annot_kws={"size": 10},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=hpo_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
+
+ax.set_title("Measurement Table Visit Date Disparity Rate", size=14)
+# plt.savefig("measurement_table_visit_date_disparity.jpg")
+
+# +
+fig, ax = plt.subplots(figsize=(18, 12))
+sns.heatmap(new_table_sheets['Observation'], annot=True, annot_kws={"size": 10},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=hpo_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
+
+ax.set_title("Observation Table Visit Date Disparity Rate", size=14)
+# plt.savefig("observation_table_visit_date_disparity.jpg")
+
+# +
+fig, ax = plt.subplots(figsize=(18, 12))
+sns.heatmap(new_table_sheets['Procedure Occurrence'], annot=True, annot_kws={"size": 10},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=hpo_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
+
+ax.set_title("Procedure Table Visit Date Disparity Rate", size=14)
+# plt.savefig("procedure_table_visit_date_disparity.jpg")
+# -
+
+# # Now let's look at the metrics for particular sites with respect to visit date disparity. This will allow us to send them the appropriate information.
+
+fn1_hpo_sheets = 'visit_date_disparity_hpo_sheets_analytics_report.xlsx'
+file_names_hpo_sheets = [fn1_hpo_sheets]
+
+x1 = pd.ExcelFile(fn1_hpo_sheets)
+site_name_list = x1.sheet_names
+
+# +
+num_hpo_sheets = len(site_name_list)
+
+print(f"There are {num_hpo_sheets} HPO sheets.")
+
+# +
+name_of_interest = 'aggregate_info'
+
+if name_of_interest not in site_name_list:
+    raise ValueError("Name not found in the list of HPO site names.")    
+
+for idx, site in enumerate(site_name_list):
+    if site == name_of_interest:
+        idx_of_interest = idx
+
+# +
+hpo_sheets = []
+
+for file in file_names_hpo_sheets:
+    for sheet in site_name_list:
+        s = pd.read_excel(file, sheet)
+        hpo_sheets.append(s)
+
+table_id_cols = list(hpo_sheets[0].index)
+
+date_cols = table_sheets[0].columns
+date_cols = (list(date_cols))
+
+# +
+new_hpo_sheets = []
+start_idx = 0
+
+for sheet in hpo_sheets:
+    sheet_cols = sheet.columns
+    sheet_cols = sheet_cols[start_idx:]
+    new_df = pd.DataFrame(columns=sheet_cols)
+
+    for col in sheet_cols:
+        old_col = sheet[col]
+        new_col = pd.to_numeric(old_col, errors='coerce')
+        new_df[col] = new_col
+
+    new_hpo_sheets.append(new_df)
+# -
+
+# ### Showing for one particular site
+
+# +
+fig, ax = plt.subplots(figsize=(9, 6))
+sns.heatmap(new_hpo_sheets[idx_of_interest], annot=True, annot_kws={"size": 14},
+            fmt='g', linewidths=.5, ax=ax, yticklabels=table_id_cols,
+            xticklabels=date_cols, cmap="YlGnBu", vmin=0, vmax=100)
+
+ax.set_title(f"Visit Date Disparity Rates for {name_of_interest}", size=14)
+
+plt.tight_layout()
+img_name = name_of_interest + "_visit_date_disparity.png"
+
+plt.savefig(img_name)
+# -
+
+dates = new_hpo_sheets[0].columns.tolist()
+
+# ## NOTE: This is more experimental than anything else. Could be improved upon in the future. This particular graphic is also only quasi-informative.
+
+# +
+num_tables = len(new_hpo_sheets[0]) - 1  # do not include aggregate
+
+angles = [(angle / num_tables) * (2 * pi) for angle in range(num_tables)]
+angles += angles[:1] # back to the start
+
+
+# +
+max_val = 0
+
+site = new_hpo_sheets[idx_of_interest]
+site_name = site_name_list[idx_of_interest]
+
+for date in dates:
+    date_vals = site[date].values
+    date_vals = date_vals.flatten().tolist()[:-1]  # cut off aggregate
+    
+    for value in date_vals:
+        if value > max_val:
+            max_val = value
+
+y_ticks = [max_val / 5, max_val * 2 / 5, max_val * 3 / 5, max_val * 4 / 5, max_val]
+y_ticks_str = []
+
+for val in y_ticks:
+    string = str(val)
+    y_ticks_str.append(string)
+
+# +
+fig, ax = plt.subplots(figsize=(9, 6))
+ax = plt.subplot(111, polar = True)  # initialize
+
+ax.set_theta_offset(pi / 2)  # flip to top
+ax.set_theta_direction(-1)
+
+plt.xticks(angles[:-1],table_id_cols)
+
+# Draw ylabels
+ax.set_rlabel_position(0)
+plt.yticks(y_ticks, y_ticks_str, color="grey", size=8)
+plt.ylim(0, max_val)
+
+
+for date_idx in range(len(dates)):
+    date_vals = site[dates[date_idx]].values
+    date = date_vals.flatten().tolist()[:-1]  # cut off aggregate
+    date += date[:1]  # round out the graph
+    
+    ax.plot(angles, date, linewidth=1, linestyle='solid', label=dates[date_idx])
+    ax.fill(angles, date, alpha=0.1)
+
+plt.title(f"Visit Date Disparity: {name_of_interest}", size=15, y = 1.1)
+plt.legend(loc='upper right', bbox_to_anchor=(0.1, 0.1))
+# -
+
+dates = new_hpo_sheets[idx_of_interest].columns
+
+# ## Want a line chart over time.
+
+times=new_hpo_sheets[idx_of_interest].columns.tolist()
+
+# +
+success_rates = {}
+
+for table_num, table_type in enumerate(table_id_cols):
+    table_metrics_over_time = new_hpo_sheets[idx_of_interest].iloc[table_num]
+    success_rates[table_type] = table_metrics_over_time.values.tolist()
+
+date_idxs = []
+for x in range(len(dates)):
+    date_idxs.append(x)
+
+# +
+for table, values_over_time in success_rates.items():
+    sample_list = [x for x in success_rates[table] if str(x) != 'nan']
+    if len(sample_list) > 1:
+        plt.plot(date_idxs, success_rates[table], '--', label=table)
+    
+for table, values_over_time in success_rates.items():
+    non_nan_idx = 0
+    new_lst = []
+    
+    for idx, x in enumerate(success_rates[table]):
+        if str(x) != 'nan':
+            new_lst.append(x)
+            non_nan_idx = idx
+    
+    if len(new_lst) == 1:
+        plt.plot(date_idxs[non_nan_idx], new_lst, 'o', label=table)
+
+plt.legend(loc="upper left", bbox_to_anchor=(1,1))
+plt.title(f"{name_of_interest} Visit Date Disparity Rates Over Time")
+plt.ylabel("Disparity Rate (%)")
+plt.xlabel("")
+plt.xticks(date_idxs, times, rotation = 'vertical')
+
+handles, labels = ax.get_legend_handles_labels()
+lgd = ax.legend(handles, labels, loc='upper center', bbox_to_anchor=(0.5,-0.1))
+
+img_name = name_of_interest + "_visit_date_disparity_line_graph.jpg"
+# plt.savefig(img_name, bbox_extraartist=(lgd,), bbox_inches='tight')


### PR DESCRIPTION
* Reworked the metrics_over_time module by implementing f-strings, leveraging a more robust 'constants' file, and adding visit_date_disparity metrics where applicable
* Reworked the dq_issue_tracker module by implementing f-strings, implementing a 'constants' file, and adding visit_date_disparity metrics where applicable
* Reworked the email_generator module by implementing f-strings, implementing a 'constants' file, and adding visit_date_disparity metrics where applicable
* Changed the column names for the two visit_date_disparity notebooks to ensure they more closely resemble the names of similar notebooks
* Added a visit_date_disparity visualization notebook.