### PR TITLE
[DC-961] google-api-core causing ValidateAllHpoSites cron job to fail

### DIFF
--- a/data_steward/requirements.txt
+++ b/data_steward/requirements.txt
@@ -16,7 +16,7 @@ entrypoints==0.3
 enum34==1.1.6
 flask==0.10
 funcsigs==1.0.2
-google-api-core>=1.14.3
+google-api-core==1.17.0
 google-api-python-client==1.6.4
 google-auth>=1.9.0
 google-auth-httplib2==0.0.3


### PR DESCRIPTION
Updated google-api-core version to 1.17.0