### PR TITLE
[DC-967] add build failure alerts to slack alerts channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2.1
 
 orbs:
+  # Send notifications for failed builds on master, develop branches using Slack orb (https://circleci.com/orbs/registry/orb/circleci/slack). Refer to the
+  # For channels to notify and webhook URL refer to the CircleCI Slack App page (https://slack.com/apps/A0F7VRE7N-circleci).
   slack: circleci/slack@3.4.2
 
 job_defaults: &job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@3.4.2
+
 job_defaults: &job_defaults
     working_directory: ~/curation/data_steward
     parallelism: 1
@@ -42,6 +45,9 @@ commands:
           paths:
             ~/curation_venv
           key: pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
+      - slack/status:
+          fail_only: true
+          only_for_branches: master,develop
   test_setup:
     steps:
       - checkout:
@@ -102,6 +108,9 @@ commands:
       - store_artifacts:
           path: ~/curation/tests/results/coverage
           destination: test_results
+      - slack/status:
+          fail_only: true
+          only_for_branches: master,develop
 
 jobs:
   linting_checks:


### PR DESCRIPTION
* for any failure on develop or master, a slack alert will be generated.