### PR TITLE
[DC-707] clean rules reporter

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/drop_duplicate_ppi_questions_and_answers.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_duplicate_ppi_questions_and_answers.py
@@ -129,9 +129,9 @@ class DropDuplicatePpiQuestionsAndAnswers(BaseCleaningRule):
         sandbox_answers = {
             cdr_consts.QUERY:
                 SANDBOX_PPI_ANSWERS.render(
-                    project=self.get_project_id(),
-                    sandbox_dataset=self.get_sandbox_dataset_id(),
-                    dataset=self.get_dataset_id(),
+                    project=self.project_id,
+                    sandbox_dataset=self.sandbox_dataset_id,
+                    dataset=self.dataset_id,
                     ans_table=self.get_sandbox_tablenames()[0],
                     clinical_table_name=OBSERVATION),
         }
@@ -139,9 +139,9 @@ class DropDuplicatePpiQuestionsAndAnswers(BaseCleaningRule):
         sandbox_questions = {
             cdr_consts.QUERY:
                 SANDBOX_PPI_QUESTIONS.render(
-                    project=self.get_project_id(),
-                    sandbox_dataset=self.get_sandbox_dataset_id(),
-                    dataset=self.get_dataset_id(),
+                    project=self.project_id,
+                    sandbox_dataset=self.sandbox_dataset_id,
+                    dataset=self.dataset_id,
                     ques_table=self.get_sandbox_tablenames()[1],
                     clinical_table_name=OBSERVATION),
         }
@@ -149,15 +149,15 @@ class DropDuplicatePpiQuestionsAndAnswers(BaseCleaningRule):
         delete_ppi_duplicate_answers = {
             cdr_consts.QUERY:
                 DELETE_DUPLICATE_ANSWERS.render(
-                    project=self.get_project_id(),
-                    dataset=self.get_dataset_id(),
+                    project=self.project_id,
+                    dataset=self.dataset_id,
                     clinical_table_name=OBSERVATION,
-                    sandbox_dataset=self.get_sandbox_dataset_id(),
+                    sandbox_dataset=self.sandbox_dataset_id,
                     ans_table=self.get_sandbox_tablenames()[0]),
             cdr_consts.DESTINATION_TABLE:
                 'observation',
             cdr_consts.DESTINATION_DATASET:
-                self.get_dataset_id(),
+                self.dataset_id,
             cdr_consts.DISPOSITION:
                 WRITE_TRUNCATE
         }
@@ -165,15 +165,15 @@ class DropDuplicatePpiQuestionsAndAnswers(BaseCleaningRule):
         delete_ppi_duplicate_questions = {
             cdr_consts.QUERY:
                 DELETE_DUPLICATE_QUESTIONS.render(
-                    project=self.get_project_id(),
-                    dataset=self.get_dataset_id(),
+                    project=self.project_id,
+                    dataset=self.dataset_id,
                     clinical_table_name=OBSERVATION,
-                    sandbox_dataset=self.get_sandbox_dataset_id(),
+                    sandbox_dataset=self.sandbox_dataset_id,
                     ques_table=self.get_sandbox_tablenames()[1]),
             cdr_consts.DESTINATION_TABLE:
                 'observation',
             cdr_consts.DESTINATION_DATASET:
-                self.get_dataset_id(),
+                self.dataset_id,
             cdr_consts.DISPOSITION:
                 WRITE_TRUNCATE
         }

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_duplicate_ppi_questions_and_answers_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_duplicate_ppi_questions_and_answers_test.py
@@ -45,10 +45,9 @@ class DropDuplicatePpiQuestionsAndAnswersTest(unittest.TestCase):
         self.query_class = DropDuplicatePpiQuestionsAndAnswers(
             self.project_id, self.dataset_id, self.sandbox_id)
 
-        self.assertEquals(self.query_class.get_project_id(), self.project_id)
-        self.assertEquals(self.query_class.get_dataset_id(), self.dataset_id)
-        self.assertEquals(self.query_class.get_sandbox_dataset_id(),
-                          self.sandbox_id)
+        self.assertEquals(self.query_class.project_id, self.project_id)
+        self.assertEquals(self.query_class.dataset_id, self.dataset_id)
+        self.assertEquals(self.query_class.sandbox_dataset_id, self.sandbox_id)
 
     def test_setup_rule(self):
         # Test
@@ -58,8 +57,7 @@ class DropDuplicatePpiQuestionsAndAnswersTest(unittest.TestCase):
 
     def test_get_query_specs(self):
         # Pre conditions
-        self.assertEqual(self.query_class.get_affected_datasets(),
-                         [clean_consts.RDR])
+        self.assertEqual(self.query_class.affected_datasets, [clean_consts.RDR])
 
         # Test
         results_list = self.query_class.get_query_specs()
@@ -115,8 +113,7 @@ class DropDuplicatePpiQuestionsAndAnswersTest(unittest.TestCase):
 
     def test_log_queries(self):
         # Pre conditions
-        self.assertEqual(self.query_class.get_affected_datasets(),
-                         [clean_consts.RDR])
+        self.assertEqual(self.query_class.affected_datasets, [clean_consts.RDR])
 
         sandbox_answers = SANDBOX_PPI_ANSWERS.render(
             project=self.project_id,


### PR DESCRIPTION
* broke because it wasn't updated to the pythonic properties setting
* fixed it.