### PR TITLE
[DC-1047] Change suspension_time to deactivated_date in _deactivated_participants table

### DIFF
--- a/data_steward/resource_files/fields/lookup_tables/_deactivated_participants.json
+++ b/data_steward/resource_files/fields/lookup_tables/_deactivated_participants.json
@@ -13,7 +13,7 @@
     },
     {
         "type": "TIMESTAMP",
-        "name": "suspension_time",
+        "name": "deactivated_date",
         "mode": "required",
         "description": "The date and time a participant's status was set to NO_CONTACT"
     }

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -148,7 +148,6 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
     }
 
     df = df.rename(columns=column_map)
-    print(f'this is the dataframe:\n {df}')
 
     # To store dataframe in a BQ dataset table
     destination_table = dataset_id + '.' + tablename

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -127,8 +127,7 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
 
     # Converts column `suspensionTime` from string to timestamp
     if 'suspensionTime' in deactivated_participants_cols:
-        df.rename(columns={'suspensionTime': 'deactivated_date'}, inplace=True)
-        df['deactivated_date'] = pandas.to_datetime(df['deactivated_date'])
+        df['suspensionTime'] = pandas.to_datetime(df['suspensionTime'])
 
     # Transforms participantId to an integer string
     df['participantId'] = df['participantId'].apply(participant_id_to_int)
@@ -141,11 +140,15 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
     bq_columns = [
         'person_id' if k == 'participant_id' else k for k in bq_columns
     ]
+    bq_columns = [
+        'deactivated_date' if k == 'suspension_time' else k for k in bq_columns
+    ]
     column_map = {
         k: v for k, v in zip(deactivated_participants_cols, bq_columns)
     }
 
     df = df.rename(columns=column_map)
+    print(f'this is the dataframe:\n {df}')
 
     # To store dataframe in a BQ dataset table
     destination_table = dataset_id + '.' + tablename

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -127,7 +127,8 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
 
     # Converts column `suspensionTime` from string to timestamp
     if 'suspensionTime' in deactivated_participants_cols:
-        df['suspensionTime'] = pandas.to_datetime(df['suspensionTime'])
+        df.rename(columns={'suspensionTime': 'deactivated_date'}, inplace=True)
+        df['deactivated_date'] = pandas.to_datetime(df['deactivated_date'])
 
     # Transforms participantId to an integer string
     df['participantId'] = df['participantId'].apply(participant_id_to_int)

--- a/tests/integration_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/integration_tests/data_steward/utils/participant_summary_requests_test.py
@@ -53,7 +53,7 @@ class ParticipantSummaryRequests(BaseTest.BigQueryTestBase):
 
     def setUp(self):
         self.columns = ['participantId', 'suspensionStatus', 'suspensionTime']
-        self.bq_columns = ['person_id', 'suspension_status', 'suspension_time']
+        self.bq_columns = ['person_id', 'suspension_status', 'deactivated_date']
         self.deactivated_participants = [[
             111, 'NO_CONTACT',
             pandas.Timestamp('2018-12-07T08:21:14')


### PR DESCRIPTION
Modified `participant_summary_requests.py` module to change `suspension_time` to `deactivated_date` in order to utilize the queries in the `retract_deactivated_pids.py` module