### PR TITLE
[DC-686] Remove EHR data past date of deactivation for deactivated participants

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -94,8 +94,8 @@ UNIONED_EHR_CLEANING_CLASSES = [
     (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
     ),
     (invalid_procedure_source.get_remove_invalid_procedure_source_queries,),
-    (CleanMappingExtTables,),
     (remove_ehr_data.remove_ehr_data_queries,),
+    (CleanMappingExtTables,),
 ]
 
 RDR_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -95,7 +95,7 @@ UNIONED_EHR_CLEANING_CLASSES = [
     ),
     (invalid_procedure_source.get_remove_invalid_procedure_source_queries,),
     (CleanMappingExtTables,),
-    (remove_ehr_data,),
+    (remove_ehr_data.remove_ehr_data,),
 ]
 
 RDR_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -95,7 +95,7 @@ UNIONED_EHR_CLEANING_CLASSES = [
     ),
     (invalid_procedure_source.get_remove_invalid_procedure_source_queries,),
     (CleanMappingExtTables,),
-    (remove_ehr_data.remove_ehr_data,),
+    (remove_ehr_data.remove_ehr_data_queries,),
 ]
 
 RDR_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -39,6 +39,7 @@ import cdr_cleaner.cleaning_rules.round_ppi_values_to_nearest_integer as round_p
 import cdr_cleaner.cleaning_rules.temporal_consistency as bad_end_dates
 import cdr_cleaner.cleaning_rules.update_family_history_qa_codes as update_family_history
 import cdr_cleaner.cleaning_rules.valid_death_dates as valid_death_dates
+import cdr_cleaner.cleaning_rules.remove_ehr_data_past_deactivation_date as remove_ehr_data
 import cdr_cleaner.manual_cleaning_rules.clean_smoking_ppi as smoking
 import cdr_cleaner.manual_cleaning_rules.negative_ppi as negative_ppi
 import cdr_cleaner.manual_cleaning_rules.ppi_drop_duplicate_responses as ppi_drop_duplicates
@@ -93,7 +94,8 @@ UNIONED_EHR_CLEANING_CLASSES = [
     (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
     ),
     (invalid_procedure_source.get_remove_invalid_procedure_source_queries,),
-    (CleanMappingExtTables,)
+    (CleanMappingExtTables,),
+    (remove_ehr_data,),
 ]
 
 RDR_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
                                                       ARGS.ticket_number,
                                                       ARGS.pids_project_id,
                                                       ARGS.pids_dataset_id,
-                                                      ARGS.tablename)
+                                                      ARGS.pids_table)
 
     client = rdp.get_client(ARGS.project_id)
     rdp.run_queries(remove_ehr_data_queries, client)

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
@@ -10,6 +10,9 @@ who have deactivated from the Program.
 # Python imports
 import logging
 
+# Third party imports
+import bq_utils
+
 # Project imports
 import retraction.retract_deactivated_pids as rdp
 import utils.participant_summary_requests as psr
@@ -36,6 +39,8 @@ def remove_ehr_data_queries(project_id, ticket_number, pids_project_id,
     :param tablename: The name of the table to house the deactivated participant data
     """
 
+    ehr_union_dataset = bq_utils.get_unioned_dataset_id()
+
     # gets the deactivated participant dataset to ensure it's up-to-date
     psr.get_deactivated_participants(pids_project_id, pids_dataset_id,
                                      tablename,
@@ -43,7 +48,7 @@ def remove_ehr_data_queries(project_id, ticket_number, pids_project_id,
 
     # creates sandbox and truncate queries to run for deactivated participant data drops
     queries = rdp.create_queries(project_id, ticket_number, pids_project_id,
-                                 pids_dataset_id, tablename)
+                                 pids_dataset_id, tablename, ehr_union_dataset)
 
     return queries
 

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
@@ -23,7 +23,7 @@ DEACTIVATED_PARTICIPANTS_COLUMNS = [
 ]
 
 
-def remove_ehr_data(project_id, ticket_number, pids_project_id, pids_dataset_id,
+def remove_ehr_data_queries(project_id, ticket_number, pids_project_id, pids_dataset_id,
                     tablename):
     """
     Creates sandboxes and drops all EHR data found for deactivated participants after

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
@@ -1,0 +1,63 @@
+"""
+Ensures there is no EHR data past the deactivation date for deactivated participants.
+
+Original Issue: DC-686
+
+The intent is to sandbox and drop records dated after the date of deactivation for participants
+who have deactivated from the Program.
+"""
+
+# Python imports
+import logging
+
+# Project imports
+import retraction.retract_deactivated_pids as rdp
+import utils.participant_summary_requests as psr
+
+LOGGER = logging.getLogger(__name__)
+
+TICKET_NUMBER = ['dc686']
+
+DEACTIVATED_PARTICIPANTS_COLUMNS = [
+    'participantId', 'suspensionStatus', 'suspensionTime'
+]
+
+
+def remove_ehr_data(project_id, ticket_number, pids_project_id, pids_dataset_id,
+                    tablename):
+    """
+    Creates sandboxes and drops all EHR data found for deactivated participants after
+    their deactivation date
+
+    :param project_id: BQ name of the project
+    :param ticket_number: Jira ticket number to identify and title sandbox tables
+    :param pids_project_id: deactivated participants PIDs table in BQ's project_id
+    :param pids_dataset_id: deactivated participants PIDs table in BQ's dataset_id
+    :param tablename: The name of the table to house the deactivated participant data
+    """
+
+    # gets the deactivated participant dataset to ensure it's up-to-date
+    psr.get_deactivated_participants(pids_project_id, pids_dataset_id,
+                                     tablename,
+                                     DEACTIVATED_PARTICIPANTS_COLUMNS)
+
+    # creates sandbox and truncate queries to run for deactivated participant data drops
+    queries = rdp.create_queries(project_id, ticket_number, pids_project_id,
+                                 pids_dataset_id, tablename)
+
+    return queries
+
+
+if __name__ == '__main__':
+    ARGS = rdp.parse_args()
+    rdp.add_console_logging(ARGS.console_log)
+
+    remove_ehr_data_queries = remove_ehr_data(ARGS.project_id,
+                                              ARGS.ticket_number,
+                                              ARGS.pids_project_id,
+                                              ARGS.pids_dataset_id,
+                                              ARGS.tablename)
+
+    client = rdp.get_client(ARGS.project_id)
+    rdp.run_queries(remove_ehr_data_queries, client)
+    LOGGER.info("Removal of ehr data from deactivated participants complete")

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
@@ -23,8 +23,8 @@ DEACTIVATED_PARTICIPANTS_COLUMNS = [
 ]
 
 
-def remove_ehr_data_queries(project_id, ticket_number, pids_project_id, pids_dataset_id,
-                    tablename):
+def remove_ehr_data_queries(project_id, ticket_number, pids_project_id,
+                            pids_dataset_id, tablename):
     """
     Creates sandboxes and drops all EHR data found for deactivated participants after
     their deactivation date

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date.py
@@ -52,11 +52,11 @@ if __name__ == '__main__':
     ARGS = rdp.parse_args()
     rdp.add_console_logging(ARGS.console_log)
 
-    remove_ehr_data_queries = remove_ehr_data(ARGS.project_id,
-                                              ARGS.ticket_number,
-                                              ARGS.pids_project_id,
-                                              ARGS.pids_dataset_id,
-                                              ARGS.tablename)
+    remove_ehr_data_queries = remove_ehr_data_queries(ARGS.project_id,
+                                                      ARGS.ticket_number,
+                                                      ARGS.pids_project_id,
+                                                      ARGS.pids_dataset_id,
+                                                      ARGS.tablename)
 
     client = rdp.get_client(ARGS.project_id)
     rdp.run_queries(remove_ehr_data_queries, client)

--- a/data_steward/resource_files/fields/lookup_tables/_deactivated_participants.json
+++ b/data_steward/resource_files/fields/lookup_tables/_deactivated_participants.json
@@ -12,7 +12,7 @@
         "description": "The status of suspension for a participant. Enumerated values: NOT_SUSPENDED and NO_CONTACT"
     },
     {
-        "type": "TIMESTAMP",
+        "type": "DATE",
         "name": "deactivated_date",
         "mode": "required",
         "description": "The date and time a participant's status was set to NO_CONTACT"

--- a/data_steward/retraction/retract_deactivated_pids.py
+++ b/data_steward/retraction/retract_deactivated_pids.py
@@ -368,6 +368,7 @@ def create_queries(project_id,
     :param pids_project_id: deactivated ehr pids table in bq's project_id
     :param pids_dataset_id: deactivated ehr pids table in bq's dataset_id
     :param pids_table: deactivated pids table in bq's table name
+    :param datasets: optional parameter to give list of datasets, otherwise will loop through all datasets in project_id
     :return: list of queries to run
     """
     queries_list = []

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -132,6 +132,7 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
     # Converts column `suspensionTime` from string to timestamp
     if 'suspensionTime' in deactivated_participants_cols:
         df['suspensionTime'] = pandas.to_datetime(df['suspensionTime'])
+        df['suspensionTime'] = df['suspensionTime'].dt.date
 
     # Transforms participantId to an integer string
     df['participantId'] = df['participantId'].apply(participant_id_to_int)

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -197,5 +197,5 @@ def store_participant_data(df, project_id, destination_table):
     return pandas_gbq.to_gbq(df,
                              destination_table,
                              project_id,
-                             if_exists="append",
+                             if_exists="replace",
                              table_schema=table_schema)

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -82,7 +82,7 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
     :param tablename: The name of the table to house the deactivated participant data
     :param columns: columns to be pushed to a table in BigQuery in the form of a list of strings
 
-    :return: returns dataframe of deactivated participants
+    :return: returns dataset of deactivated participants
     """
 
     # Parameter checks

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -14,6 +14,7 @@ import unittest
 
 # Third party imports
 import google.cloud.exceptions as gc_exc
+from google.api_core.retry import Retry
 from google.cloud import bigquery
 from jinja2 import Environment
 
@@ -119,7 +120,8 @@ class BaseTest:
             """
             query = f"delete from {fq_table_name} where true"
 
-            response = self.client.query(query)
+            query_retry = Retry()
+            response = self.client.query(query, retry=query_retry, timeout=30)
 
             # start the job and wait for it to complete
             self.assertIsNotNone(response.result())

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -46,14 +46,19 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
         self.tablename = '_deactivated_participants'
         self.ticket_number = 'DC12345'
 
-        self.deactivated_participants = [(1, 'NO_CONTACT', '2018-12-07T08:21:14'),
-                                         (2, 'NO_CONTACT', '2019-12-07T08:21:14'),
-                                         (3, 'NO_CONTACT', '2017-12-07T08:21:14')]
+        self.deactivated_participants = [
+            (1, 'NO_CONTACT', '2018-12-07T08:21:14'),
+            (2, 'NO_CONTACT', '2019-12-07T08:21:14'),
+            (3, 'NO_CONTACT', '2017-12-07T08:21:14')
+        ]
         self.columns = ['participantId', 'suspensionStatus', 'suspensionTime']
         self.deactivated_participants_data = {
             'person_id': [1, 2, 3],
             'suspension_status': ['NO_CONTACT', 'NO_CONTACT', 'NO_CONTACT'],
-            'deactivation_date': ['2018-12-07T08:21:14', '2019-12-07T08:21:14', '2017-12-07T08:21:14']
+            'deactivation_date': [
+                '2018-12-07T08:21:14', '2019-12-07T08:21:14',
+                '2017-12-07T08:21:14'
+            ]
         }
         self.deactivated_participants_df = pandas.DataFrame(
             columns=self.columns, data=self.deactivated_participants_data)
@@ -91,7 +96,8 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
     @mock.patch('utils.participant_summary_requests.requests.get')
     @mock.patch(
         'retraction.retract_deactivated_pids.get_date_info_for_pids_tables')
-    def test_remove_ehr_data_past_deactivation_date(self, mock_retraction_info, mock_get):
+    def test_remove_ehr_data_past_deactivation_date(self, mock_retraction_info,
+                                                    mock_get):
         # pre conditions for participant summary API module
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = self.json_response_entry
@@ -232,20 +238,20 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
             if query_dict['destination_table_id'] in expected_kept_row_count:
                 expected_kept_row_count[query_dict['destination_table_id']] -= (
                     (row_count_before_retraction[
-                         query_dict['destination_table_id']] -
+                        query_dict['destination_table_id']] -
                      result.total_rows))
             else:
                 expected_kept_row_count[query_dict['destination_table_id']] = (
-                        row_count_before_retraction[
-                            query_dict['destination_table_id']] -
-                        (row_count_before_retraction[
-                             query_dict['destination_table_id']] -
-                         result.total_rows))
+                    row_count_before_retraction[
+                        query_dict['destination_table_id']] -
+                    (row_count_before_retraction[
+                        query_dict['destination_table_id']] -
+                     result.total_rows))
 
         # Perform retraction
-        query_list = red.remove_ehr_data(
-            self.project_id, self.ticket_number, self.project_id,
-            self.dataset_id, self.tablename)
+        query_list = red.remove_ehr_data(self.project_id, self.ticket_number,
+                                         self.project_id, self.dataset_id,
+                                         self.tablename)
         rdp.run_queries(query_list, self.client)
 
         # Find actual deleted rows

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -140,6 +140,7 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
         job_ids = []
         dropped_row_count_queries = []
         kept_row_count_queries = []
+        sandbox_row_count_queries = []
         hpo_table_list = []
 
         # Load the cdm files into dataset
@@ -187,6 +188,15 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
                         pid=pid,
                         start_date_column=row.start_date_column,
                         end_date_column=row.end_date_column)
+                    sandbox_query = rdp.SANDBOX_QUERY_END_DATE.render(
+                        project=self.project_id,
+                        dataset=self.dataset_id,
+                        table=self.sandbox_id,
+                        pid=pid,
+                        end_date_column=row.end_date_column,
+                        deactivated_pids_project=self.project_id,
+                        deactivated_pids_dataset=self.dataset_id,
+                        deactivated_pids_table=self.tablename)
                 else:
                     dropped_query = rdpt.EXPECTED_DROPPED_ROWS_QUERY.format(
                         dataset_id=self.dataset_id,
@@ -200,6 +210,15 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
                         pid_table_id=self.tablename,
                         pid=pid,
                         date_column=row.date_column)
+                    sandbox_query = rdp.SANDBOX_QUERY_DATE.render(
+                        project=self.project_id,
+                        dataset=self.dataset_id,
+                        table=row.table,
+                        pid=pid,
+                        date_column=row.date_column,
+                        deactivated_pids_project=self.project_id,
+                        deactivated_pids_dataset=self.dataset_id,
+                        deactivated_pids_table=self.tablename)
                 dropped_row_count_queries.append({
                     clean_consts.QUERY: dropped_query,
                     clean_consts.DESTINATION_DATASET: self.dataset_id,
@@ -209,6 +228,11 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
                     clean_consts.QUERY: kept_query,
                     clean_consts.DESTINATION_DATASET: self.dataset_id,
                     clean_consts.DESTINATION_TABLE: row.table
+                })
+                sandbox_row_count_queries.append({
+                    clean_consts.QUERY: sandbox_query,
+                    clean_consts.DESTINATION_DATASET: self.dataset_id,
+                    clean_consts.DESTINATION_TABLE: self.tablename
                 })
 
         # Use query results to count number of expected dropped row deletions

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -268,5 +268,3 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
     def tearDown(self):
         test_util.delete_all_tables(self.dataset_id)
         test_util.delete_all_tables(self.sandbox_id)
-        self.client.delete_dataset(self.sandbox_id)
-

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -42,7 +42,8 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
         self.hpo_id = 'fake'
         self.project_id = app_identity.get_application_id()
         self.dataset_id = bq_utils.get_dataset_id()
-        self.sandbox_id = check_and_create_sandbox_dataset(self.project_id, self.dataset_id)
+        self.sandbox_id = check_and_create_sandbox_dataset(
+            self.project_id, self.dataset_id)
         self.tablename = '_deactivated_participants'
         self.ticket_number = 'DC12345'
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -249,9 +249,11 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
                      result.total_rows))
 
         # Perform retraction
-        query_list = red.remove_ehr_data(self.project_id, self.ticket_number,
-                                         self.project_id, self.dataset_id,
-                                         self.tablename)
+        query_list = red.remove_ehr_data_queries(self.project_id,
+                                                 self.ticket_number,
+                                                 self.project_id,
+                                                 self.dataset_id,
+                                                 self.tablename)
         rdp.run_queries(query_list, self.client)
 
         # Find actual deleted rows

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -1,0 +1,269 @@
+"""
+Integration test for the remove_ehr_data_past_deactivation_date module
+
+Original Issue: DC-686
+
+The intent is to sandbox and drop records dated after the date of deactivation for participants
+who have deactivated from the Program.
+"""
+
+# Python imports
+import unittest
+import mock
+import os
+import logging
+
+# Third party imports
+import pandas
+
+# Project imports
+import app_identity
+import bq_utils
+import gcs_utils
+import utils.participant_summary_requests as psr
+import tests.integration_tests.data_steward.retraction.retract_deactivated_pids_test as rdpt
+from sandbox import get_sandbox_dataset_id
+from constants.cdr_cleaner import clean_cdr as clean_consts
+from utils import bq
+from tests import test_util
+
+
+class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = app_identity.get_application_id()
+        self.dataset_id = bq_utils.get_dataset_id()
+        self.sandbox_id = get_sandbox_dataset_id(self.dataset_id)
+        self.tablename = '_deactivated_participants'
+        self.ticket_number = 'DC12345'
+
+        self.deactivated_participants = [(1, 'NO_CONTACT', '2018-12-07T08:21:14'),
+                                         (2, 'NO_CONTACT', '2019-12-07T08:21:14'),
+                                         (3, 'NO_CONTACT', '2017-12-07T08:21:14')]
+        self.columns = ['participantId', 'suspensionStatus', 'suspensionTime']
+        self.deactivated_participants_data = {
+            'person_id': [1, 2],
+            'suspension_status': ['NO_CONTACT', 'NO_CONTACT'],
+            'suspension_time': ['2018-12-07T08:21:14', '2019-12-07T08:21:14']
+        }
+        self.deactivated_participants_df = pandas.DataFrame(
+            columns=self.columns, data=self.deactivated_participants_data)
+
+        self.json_response_entry = {
+            'entry': [{
+                'fullUrl':
+                    'https//foo_project.appspot.com/rdr/v1/Participant/1/Summary',
+                'resource': {
+                    'participantId': '1',
+                    'suspensionStatus': 'NO_CONTACT',
+                    'suspensionTime': '2018-12-07T08:21:14'
+                }
+            }, {
+                'fullUrl':
+                    'https//foo_project.appspot.com/rdr/v1/Participant/2/Summary',
+                'resource': {
+                    'participantId': '2',
+                    'suspensionStatus': 'NO_CONTACT',
+                    'suspensionTime': '2019-12-07T08:21:14'
+                }
+            }, {
+                'fullUrl':
+                    'https//foo_project.appspot.com/rdr/v1/Participant/3/Summary',
+                'resource': {
+                    'participantId': '3',
+                    'suspensionStatus': 'NO_CONTACT',
+                    'suspensionTime': '2017-12-07T08:21:14'
+                }
+            }]
+        }
+
+        self.client = bq.get_client(self.project_id)
+
+    @mock.patch('utils.participant_summary_requests.requests.get')
+    @mock.patch(
+        'retraction.retract_deactivated_pids.get_date_info_for_pids_tables')
+    def test_remove_ehr_data_past_deactivation_date(self, mock_retraction_info, mock_get):
+        # pre conditions for participant summary API module
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = self.json_response_entry
+
+        # Ensure deactivated participants table is created and or updated
+        psr.get_deactivated_participants(self.project_id, self.dataset_id,
+                                         self.tablename, self.columns)
+
+        # pre conditions for retraction module
+        d = {
+            'project_id': [
+                self.project_id, self.project_id, self.project_id,
+                self.project_id, self.project_id, self.project_id
+            ],
+            'dataset_id': [
+                self.dataset_id, self.dataset_id, self.dataset_id,
+                self.dataset_id, self.dataset_id, self.dataset_id
+            ],
+            'table': [
+                'fake_condition_occurrence', 'fake_drug_exposure',
+                'fake_measurement', 'fake_observation',
+                'fake_procedure_occurrence', 'fake_visit_occurrence'
+            ],
+            'date_column': [
+                None, None, 'measurement_date', 'observation_date',
+                'procedure_date', None
+            ],
+            'start_date_column': [
+                'condition_start_date', 'drug_exposure_start_date', None, None,
+                None, 'visit_start_date'
+            ],
+            'end_date_column': [
+                'condition_end_date', 'drug_exposure_end_date', None, None,
+                None, 'visit_end_date'
+            ]
+        }
+        retraction_info = pandas.DataFrame(data=d)
+        mock_retraction_info.return_value = retraction_info
+
+        job_ids = []
+        dropped_row_count_queries = []
+        kept_row_count_queries = []
+        hpo_table_list = []
+
+        # Load the cdm files into dataset
+        for cdm_file in test_util.NYC_FIVE_PERSONS_FILES:
+            cdm_file_name = os.path.basename(cdm_file)
+            cdm_table = cdm_file_name.split('.')[0]
+            hpo_table = bq_utils.get_table_id(self.project_id, cdm_table)
+            # Do not process if person table
+            if hpo_table == 'fake_person':
+                continue
+            hpo_table_list.append(hpo_table)
+            logging.info(
+                f'Preparing to load table {self.dataset_id}.{hpo_table}')
+            with open(cdm_file, 'rb') as f:
+                gcs_utils.upload_object(gcs_utils.get_hpo_bucket(self.project_id),
+                                        cdm_file_name, f)
+            result = bq_utils.load_cdm_csv(self.project_id,
+                                           cdm_table,
+                                           dataset_id=self.dataset_id)
+            logging.info(f'Loading table {self.dataset_id}.{hpo_table}')
+            job_id = result['jobReference']['jobId']
+            job_ids.append(job_id)
+
+        incomplete_jobs = bq_utils.wait_on_jobs(job_ids)
+        self.assertEqual(len(incomplete_jobs), 0,
+                         'NYC five person load job did not complete')
+        logging.info('All tables loaded successfully')
+
+        # Store query for checking number of rows to delete
+        for ehr in self.deactivated_participants:
+            pid = ehr[0]
+            for row in retraction_info.itertuples(index=False):
+                if row.date_column is None:
+                    dropped_query = rdpt.EXPECTED_DROPPED_ROWS_QUERY_END_DATE.format(
+                        dataset_id=self.dataset_id,
+                        table_id=row.table,
+                        pid_table_id=self.tablename,
+                        pid=pid,
+                        start_date_column=row.start_date_column,
+                        end_date_column=row.end_date_column)
+                    kept_query = rdpt.EXPECTED_KEPT_ROWS_QUERY_END_DATE.format(
+                        dataset_id=self.dataset_id,
+                        table_id=row.table,
+                        pid_table_id=self.tablename,
+                        pid=pid,
+                        start_date_column=row.start_date_column,
+                        end_date_column=row.end_date_column)
+                else:
+                    dropped_query = rdpt.EXPECTED_DROPPED_ROWS_QUERY.format(
+                        dataset_id=self.dataset_id,
+                        table_id=row.table,
+                        pid_table_id=self.tablename,
+                        pid=pid,
+                        date_column=row.date_column)
+                    kept_query = rdpt.EXPECTED_KEPT_ROWS_QUERY.format(
+                        dataset_id=self.dataset_id,
+                        table_id=row.table,
+                        pid_table_id=self.tablename,
+                        pid=pid,
+                        date_column=row.date_column)
+                dropped_row_count_queries.append({
+                    clean_consts.QUERY: dropped_query,
+                    clean_consts.DESTINATION_DATASET: self.dataset_id,
+                    clean_consts.DESTINATION_TABLE: row.table
+                })
+                kept_row_count_queries.append({
+                    clean_consts.QUERY: kept_query,
+                    clean_consts.DESTINATION_DATASET: self.dataset_id,
+                    clean_consts.DESTINATION_TABLE: row.table
+                })
+
+        # Use query results to count number of expected dropped row deletions
+        expected_dropped_row_count = {}
+        for query_dict in dropped_row_count_queries:
+            response = self.client.query(query_dict['query'])
+            result = response.result()
+            if query_dict['destination_table_id'] in expected_dropped_row_count:
+                expected_dropped_row_count[
+                    query_dict['destination_table_id']] += result.total_rows
+            else:
+                expected_dropped_row_count[
+                    query_dict['destination_table_id']] = result.total_rows
+
+        # Separate check to find number of actual deleted rows
+        q = rdpt.TABLE_ROWS_QUERY.format(dataset_id=self.dataset_id)
+        q_result = self.client.query(q)
+        row_count_before_retraction = {}
+        for row in q_result:
+            row_count_before_retraction[row['table_id']] = row['row_count']
+
+        # Use query results to count number of expected dropped row deletions
+        expected_kept_row_count = {}
+        for query_dict in kept_row_count_queries:
+            response = self.client.query(query_dict['query'])
+            result = response.result()
+            if query_dict['destination_table_id'] in expected_kept_row_count:
+                expected_kept_row_count[query_dict['destination_table_id']] -= (
+                    (row_count_before_retraction[
+                         query_dict['destination_table_id']] -
+                     result.total_rows))
+            else:
+                expected_kept_row_count[query_dict['destination_table_id']] = (
+                        row_count_before_retraction[
+                            query_dict['destination_table_id']] -
+                        (row_count_before_retraction[
+                             query_dict['destination_table_id']] -
+                         result.total_rows))
+
+        # Perform retraction
+        query_list = retract_deactivated_pids.create_queries(
+            self.project_id, self.ticket_number, self.project_id,
+            self.bq_dataset_id, self.pid_table_id)
+        retract_deactivated_pids.run_queries(query_list, self.client)
+
+        # Find actual deleted rows
+        q_result = self.client.query(q)
+        results = q_result.result()
+        row_count_after_retraction = {}
+        for row in results:
+            row_count_after_retraction[row['table_id']] = row['row_count']
+
+        for table in expected_dropped_row_count:
+            self.assertEqual(
+                expected_dropped_row_count[table],
+                row_count_before_retraction[table] -
+                row_count_after_retraction[table])
+
+        for table in expected_kept_row_count:
+            self.assertEqual(expected_kept_row_count[table],
+                             row_count_after_retraction[table])
+
+    def tearDown(self):
+        test_util.delete_all_tables(self.dataset_id)
+        test_util.delete_all_tables(self.sandbox_id)
+        self.client.delete_dataset(self.sandbox_id)
+

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -24,7 +24,7 @@ import utils.participant_summary_requests as psr
 import retraction.retract_deactivated_pids as rdp
 import tests.integration_tests.data_steward.retraction.retract_deactivated_pids_test as rdpt
 import cdr_cleaner.cleaning_rules.remove_ehr_data_past_deactivation_date as red
-from sandbox import get_sandbox_dataset_id
+from sandbox import get_sandbox_dataset_id, check_and_create_sandbox_dataset
 from constants.cdr_cleaner import clean_cdr as clean_consts
 from utils import bq
 from tests import test_util
@@ -42,7 +42,7 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
         self.hpo_id = 'fake'
         self.project_id = app_identity.get_application_id()
         self.dataset_id = bq_utils.get_dataset_id()
-        self.sandbox_id = get_sandbox_dataset_id(self.dataset_id)
+        self.sandbox_id = check_and_create_sandbox_dataset(self.project_id, self.dataset_id)
         self.tablename = '_deactivated_participants'
         self.ticket_number = 'DC12345'
 
@@ -191,7 +191,7 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
                     sandbox_query = rdp.SANDBOX_QUERY_END_DATE.render(
                         project=self.project_id,
                         dataset=self.dataset_id,
-                        table=self.sandbox_id,
+                        table=row.table,
                         pid=pid,
                         end_date_column=row.end_date_column,
                         deactivated_pids_project=self.project_id,
@@ -231,7 +231,7 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
                 })
                 sandbox_row_count_queries.append({
                     clean_consts.QUERY: sandbox_query,
-                    clean_consts.DESTINATION_DATASET: self.dataset_id,
+                    clean_consts.DESTINATION_DATASET: self.sandbox_id,
                     clean_consts.DESTINATION_TABLE: self.tablename
                 })
 

--- a/tests/integration_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/integration_tests/data_steward/utils/participant_summary_requests_test.py
@@ -15,6 +15,7 @@ The intent of this module is to check that GCR access token is generated properl
 # Python imports
 import mock
 import os
+import time
 
 # Third party imports
 import pandas
@@ -167,3 +168,10 @@ class ParticipantSummaryRequests(BaseTest.BigQueryTestBase):
         self.assertTableValuesMatch(
             '.'.join([self.project_id, self.destination_table]),
             self.bq_columns, values)
+
+    def tearDown(self):
+        """
+        Add a one second delay to teardown to make it less likely to fail due to rate limits.
+        """
+        time.sleep(1)
+        super().tearDown()

--- a/tests/integration_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/integration_tests/data_steward/utils/participant_summary_requests_test.py
@@ -19,14 +19,12 @@ import os
 # Third party imports
 import pandas
 import pandas.testing
-import google.auth.transport.requests as req
-from google.auth import default
+import datetime
 from dateutil import parser
 
 # Project imports
 import utils.participant_summary_requests as psr
 from app_identity import PROJECT_ID
-from utils import auth
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
 
@@ -55,10 +53,8 @@ class ParticipantSummaryRequests(BaseTest.BigQueryTestBase):
         self.columns = ['participantId', 'suspensionStatus', 'suspensionTime']
         self.bq_columns = ['person_id', 'suspension_status', 'deactivated_date']
         self.deactivated_participants = [[
-            111, 'NO_CONTACT',
-            pandas.Timestamp('2018-12-07T08:21:14')
-        ], [222, 'NO_CONTACT',
-            pandas.Timestamp('2018-12-07T08:21:14')]]
+            111, 'NO_CONTACT', datetime.date(2018, 12, 7)
+        ], [222, 'NO_CONTACT', datetime.date(2018, 12, 7)]]
 
         self.fake_dataframe = pandas.DataFrame(self.deactivated_participants,
                                                columns=self.bq_columns)
@@ -150,8 +146,8 @@ class ParticipantSummaryRequests(BaseTest.BigQueryTestBase):
                                          self.tablename, self.columns)
 
         # Post conditions
-        values = [(111, 'NO_CONTACT', parser.parse('2018-12-07T08:21:14 UTC')),
-                  (222, 'NO_CONTACT', parser.parse('2018-12-07T08:21:14 UTC'))]
+        values = [(111, 'NO_CONTACT', datetime.date(2018, 12, 7)),
+                  (222, 'NO_CONTACT', datetime.date(2018, 12, 7))]
         self.assertTableValuesMatch(
             '.'.join([self.project_id, self.destination_table]),
             self.bq_columns, values)
@@ -166,8 +162,8 @@ class ParticipantSummaryRequests(BaseTest.BigQueryTestBase):
                                    self.destination_table)
 
         # Post conditions
-        values = [(111, 'NO_CONTACT', parser.parse('2018-12-07T08:21:14 UTC')),
-                  (222, 'NO_CONTACT', parser.parse('2018-12-07T08:21:14 UTC'))]
+        values = [(111, 'NO_CONTACT', datetime.date(2018, 12, 7)),
+                  (222, 'NO_CONTACT', datetime.date(2018, 12, 7))]
         self.assertTableValuesMatch(
             '.'.join([self.project_id, self.destination_table]),
             self.bq_columns, values)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -1,0 +1,199 @@
+"""
+Unit test for the remove_ehr_data_past_deactivation_date module
+
+Original Issue: DC-686
+
+The intent is to sandbox and drop records dated after the date of deactivation for participants
+who have deactivated from the Program.
+"""
+
+# Python imports
+import unittest
+import mock
+
+# Third Party imports
+import pandas
+import pandas.testing
+
+# Project imports
+from constants import bq_utils as bq_consts
+from constants.cdr_cleaner import clean_cdr as clean_consts
+import retraction.retract_deactivated_pids as rdp
+import cdr_cleaner.cleaning_rules.remove_ehr_data_past_deactivation_date as red
+
+
+class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        # Input parameters expected by the class
+        self.project_id = 'foo_project'
+        self.pids_project_id = 'foo_pid_project_id'
+        self.pids_dataset_id = 'foo_pid_dataset_id'
+        self.tablename = 'foo_table'
+        self.ticket_number = 'DC12345'
+        self.columns = ['participantId', 'suspensionStatus', 'suspensionTime']
+
+        mock_bq_client_patcher = mock.patch(
+            'retraction.retract_deactivated_pids.get_client')
+        self.mock_bq_client = mock_bq_client_patcher.start()
+        self.addCleanup(mock_bq_client_patcher.stop)
+
+        self.deactivated_participants_data = {
+            'person_id': [1, 2],
+            'suspension_status': ['NO_CONTACT', 'NO_CONTACT'],
+            'suspension_time': ['2018-12-07T08:21:14', '2019-12-07T08:21:14']
+        }
+
+    @mock.patch(
+        'retraction.retract_deactivated_pids.get_date_info_for_pids_tables')
+    @mock.patch(
+        'retraction.retract_deactivated_pids.check_and_create_sandbox_dataset')
+    @mock.patch('retraction.retract_deactivated_pids.get_client')
+    @mock.patch('retraction.retract_deactivated_pids.check_pid_exist')
+    @mock.patch(
+        'utils.participant_summary_requests.get_deactivated_participants')
+    def test_remove_ehr_data_past_deactivation_date(
+        self, mock_get_deactivated_participants, mock_pid_exist, mock_client,
+            mock_check_sandbox, mock_date_info):
+        # Preconditions for participant summary module mocks
+        deactivated_participants_df = pandas.DataFrame(
+            columns=self.columns, data=self.deactivated_participants_data)
+        mock_get_deactivated_participants.return_value = deactivated_participants_df
+
+        # Preconditions for retraction module mocks
+        d = {
+            'project_id': [
+                self.project_id, self.project_id, self.project_id,
+                self.project_id, self.project_id, self.project_id
+            ],
+            'dataset_id': [
+                self.pids_dataset_id, self.pids_dataset_id,
+                self.pids_dataset_id, self.pids_dataset_id,
+                self.pids_dataset_id, self.pids_dataset_id
+            ],
+            'table': [
+                'fake_condition_occurrence', 'fake_drug_exposure',
+                'fake_measurement', 'fake_observation',
+                'fake_procedure_occurrence', 'fake_visit_occurrence'
+            ],
+            'date_column': [
+                None, None, 'measurement_date', 'observation_date',
+                'procedure_date', None
+            ],
+            'start_date_column': [
+                'condition_start_date', 'drug_exposure_start_date', None, None,
+                None, 'visit_start_date'
+            ],
+            'end_date_column': [
+                'condition_end_date', 'drug_exposure_end_date', None, None,
+                None, 'visit_end_date'
+            ]
+        }
+        retraction_info = pandas.DataFrame(data=d)
+        mock_date_info.return_value = retraction_info
+
+        client = mock_client.return_value = self.mock_bq_client
+        client.query.return_value.to_dataframe.return_value = deactivated_participants_df
+
+        mock_pid_exist.return_value = 1
+        sandbox = mock_check_sandbox.return_value = 'foo_pid_dataset_id_sandbox'
+
+        # test
+        returned_queries = red.remove_ehr_data(self.project_id,
+                                               self.ticket_number,
+                                               self.pids_project_id,
+                                               self.pids_dataset_id,
+                                               self.tablename)
+
+        # post conditions
+        expected_queries = []
+
+        for ehr_row in deactivated_participants_df.itertuples(index=False):
+            for retraction_row in retraction_info.itertuples(index=False):
+                sandbox_dataset = sandbox
+                pid = ehr_row.person_id
+
+                if pandas.isnull(retraction_row.date_column):
+                    sandbox_query = rdp.SANDBOX_QUERY_END_DATE.render(
+                        project=retraction_row.project_id,
+                        sandbox_dataset=sandbox_dataset,
+                        intermediary_table=self.ticket_number + '_' +
+                        retraction_row.table,
+                        dataset=retraction_row.dataset_id,
+                        table=retraction_row.table,
+                        pid=pid,
+                        deactivated_pids_project=self.pids_project_id,
+                        deactivated_pids_dataset=self.pids_dataset_id,
+                        deactivated_pids_table=self.tablename,
+                        end_date_column=retraction_row.end_date_column,
+                        start_date_column=retraction_row.start_date_column)
+                    clean_query = rdp.CLEAN_QUERY_END_DATE.render(
+                        project=retraction_row.project_id,
+                        dataset=retraction_row.dataset_id,
+                        table=retraction_row.table,
+                        pid=pid,
+                        deactivated_pids_project=self.pids_project_id,
+                        deactivated_pids_dataset=self.pids_dataset_id,
+                        deactivated_pids_table=self.tablename,
+                        end_date_column=retraction_row.end_date_column,
+                        start_date_column=retraction_row.start_date_column)
+                else:
+                    sandbox_query = rdp.SANDBOX_QUERY_DATE.render(
+                        project=retraction_row.project_id,
+                        sandbox_dataset=sandbox_dataset,
+                        intermediary_table=self.ticket_number + '_' +
+                        retraction_row.table,
+                        dataset=retraction_row.dataset_id,
+                        table=retraction_row.table,
+                        pid=pid,
+                        deactivated_pids_project=self.pids_project_id,
+                        deactivated_pids_dataset=self.pids_dataset_id,
+                        deactivated_pids_table=self.tablename,
+                        date_column=retraction_row.date_column)
+                    clean_query = rdp.CLEAN_QUERY_DATE.render(
+                        project=retraction_row.project_id,
+                        dataset=retraction_row.dataset_id,
+                        table=retraction_row.table,
+                        pid=pid,
+                        deactivated_pids_project=self.pids_project_id,
+                        deactivated_pids_dataset=self.pids_dataset_id,
+                        deactivated_pids_table=self.tablename,
+                        date_column=retraction_row.date_column)
+                expected_queries.append({
+                    clean_consts.QUERY:
+                        sandbox_query,
+                    clean_consts.DESTINATION:
+                        retraction_row.project_id + '.' + sandbox_dataset +
+                        '.' + (self.ticket_number + '_' + retraction_row.table),
+                    clean_consts.DESTINATION_DATASET:
+                        retraction_row.dataset_id,
+                    clean_consts.DESTINATION_TABLE:
+                        retraction_row.table,
+                    clean_consts.DISPOSITION:
+                        bq_consts.WRITE_APPEND,
+                    'type':
+                        'sandbox'
+                })
+                expected_queries.append({
+                    clean_consts.QUERY:
+                        clean_query,
+                    clean_consts.DESTINATION:
+                        retraction_row.project_id + '.' +
+                        retraction_row.dataset_id + '.' + retraction_row.table,
+                    clean_consts.DESTINATION_DATASET:
+                        retraction_row.dataset_id,
+                    clean_consts.DESTINATION_TABLE:
+                        retraction_row.table,
+                    clean_consts.DISPOSITION:
+                        bq_consts.WRITE_TRUNCATE,
+                    'type':
+                        'retraction'
+                })
+
+        self.assertEqual(returned_queries, expected_queries)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -60,7 +60,7 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
         'utils.participant_summary_requests.get_deactivated_participants')
     def test_remove_ehr_data_past_deactivation_date(
         self, mock_get_deactivated_participants, mock_pid_exist, mock_client,
-            mock_check_sandbox, mock_date_info):
+        mock_check_sandbox, mock_date_info):
         # Preconditions for participant summary module mocks
         deactivated_participants_df = pandas.DataFrame(
             columns=self.columns, data=self.deactivated_participants_data)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_ehr_data_past_deactivation_date_test.py
@@ -105,11 +105,11 @@ class RemoveEhrDataPastDeactivationDateTest(unittest.TestCase):
         sandbox = mock_check_sandbox.return_value = 'foo_pid_dataset_id_sandbox'
 
         # test
-        returned_queries = red.remove_ehr_data(self.project_id,
-                                               self.ticket_number,
-                                               self.pids_project_id,
-                                               self.pids_dataset_id,
-                                               self.tablename)
+        returned_queries = red.remove_ehr_data_queries(self.project_id,
+                                                       self.ticket_number,
+                                                       self.pids_project_id,
+                                                       self.pids_dataset_id,
+                                                       self.tablename)
 
         # post conditions
         expected_queries = []

--- a/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
@@ -24,7 +24,7 @@ import pandas.testing
 import utils.participant_summary_requests as psr
 
 
-class ParticipantSummaryRequests(unittest.TestCase):
+class ParticipantSummaryRequestsTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
-  Created `remove_ehr_data_past_deactivation_date.py` module to utilize `retract_deactivated_pids.py` and `participant_summary_requests.py` modules to remove EHR data of deactivated participants past the date of deactivation

- Created unit and integration test modules to properly test `remove_ehr_data_past_deactivation_date`

- Modified `participant_summary_request.py` module to convert the `suspensionTime` (`deactivation_date`) field to be of type `DATE` instead of `TIMESTAMP`