### PR TITLE
[DC-1122] export VOCABULARY_DATASET variable for combined stage

### DIFF
--- a/data_steward/tools/generate_combined_dataset.sh
+++ b/data_steward/tools/generate_combined_dataset.sh
@@ -102,6 +102,8 @@ export RDR_DATASET_ID="${rdr_dataset}"
 export UNIONED_DATASET_ID="${unioned_ehr_dataset}"
 export COMBINED_DATASET_ID="${combined_backup}"
 export BIGQUERY_DATASET_ID="${unioned_ehr_dataset}"
+# required by populate_route_ids cleaning rule
+export VOCABULARY_DATASET="${vocab_dataset}"
 # set env variable for cleaning rule remove_non_matching_participant.py
 export VALIDATION_RESULTS_DATASET_ID="${validation_dataset}"
 


### PR DESCRIPTION
export VOCABULARY_DATASET variable for combined stage cleaning rule

* the populate_route_ids cleaning rule requires this environment variable to be set