### PR TITLE
[DC-1177] Logging error causes union jobs to fail

### DIFF
--- a/data_steward/validation/ehr_union.py
+++ b/data_steward/validation/ehr_union.py
@@ -227,6 +227,7 @@ def query(q, dst_table_id, dst_dataset_id, write_disposition='WRITE_APPEND'):
                                       destination_dataset_id=dst_dataset_id,
                                       write_disposition=write_disposition)
     query_job_id = query_job_result['jobReference']['jobId']
+    logging.info(f'Job {query_job_id} started for table {dst_table_id}')
     job_status = query_job_result['status']
     error_result = job_status.get('errorResult')
     if error_result is not None:
@@ -501,8 +502,11 @@ def load(cdm_table, hpo_ids, input_dataset_id, output_dataset_id):
     else:
         q = table_union_query(cdm_table, hpo_ids, input_dataset_id,
                               output_dataset_id)
-    logging.info(f'Query for union of {cdm_table} tables from {hpo_ids} is {q}')
     query_result = query(q, output_table, output_dataset_id)
+    query_job_id = query_result['jobReference']['jobId']
+    logging.info(
+        f'Job {query_job_id} completed for union of {cdm_table} tables from {hpo_ids}'
+    )
     return query_result
 
 


### PR DESCRIPTION
* [DC-1177] Remove long queries from log messages and use job_id

[DC-1177]: https://precisionmedicineinitiative.atlassian.net/browse/DC-1177