### PR TITLE
[DC-1169] Integration Test for Invalid Foreign Keys CR

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys.py
@@ -216,12 +216,6 @@ class NullInvalidForeignKeys(BaseCleaningRule):
                             dataset_id=self.dataset_id,
                             table_name=table,
                             sandbox_expr=sandbox_expression),
-                    cdr_consts.DESTINATION_DATASET:
-                        self.dataset_id,
-                    cdr_consts.DESTINATION_TABLE:
-                        table,
-                    cdr_consts.DISPOSITION:
-                        bq_consts.WRITE_TRUNCATE
                 }
 
                 sandbox_queries_list.append(sandbox_query)

--- a/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys.py
@@ -68,7 +68,7 @@ class NullInvalidForeignKeys(BaseCleaningRule):
         desc = (
             'Ensures that invalid foreign keys are null while the remainder of the rows persist'
         )
-        super().__init__(issue_numbers=['DC-388', 'DC-807'],
+        super().__init__(issue_numbers=['DC388', 'DC807'],
                          description=desc,
                          affected_datasets=[cdr_consts.COMBINED],
                          project_id=project_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys.py
@@ -261,7 +261,7 @@ class NullInvalidForeignKeys(BaseCleaningRule):
         :param affected_table: tables that is affected by running this cleaning rule
         :return: formatted string name of the sandbox
         """
-        return f'{"_".join(self.issue_numbers).lower()}_{affected_table}'
+        return f'{self.issue_numbers[0].lower()}_{affected_table}'
 
     def setup_validation(self, client):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
@@ -49,13 +49,15 @@ class NullInvalidForeignKeysTest(BaseTest.CleaningRulesTestBase):
 
         selected_table_names = [
             '_mapping_provider', '_mapping_visit_occurrence',
-            '_mapping_location', '_mapping_care_site',
-            'procedure_occurrence', 'person'
+            '_mapping_location', '_mapping_care_site', 'procedure_occurrence',
+            'person'
         ]
 
         for table_name in sandbox_table_names:
-            sandbox_table_name = cls.rule_instance.get_sandbox_table_for(table_name)
-            cls.fq_sandbox_table_names.append(f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
+            sandbox_table_name = cls.rule_instance.get_sandbox_table_for(
+                table_name)
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
 
         cls.fq_table_names = [
             f'{project_id}.{cls.dataset_id}.{table_name}'

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
@@ -1,0 +1,198 @@
+"""
+Integration test for cleaning_rules.null_invalid_foreign_keys.py module
+
+Original Issue - DC-1169
+
+The intent of this unit test is to ensure that any invalid foreign keys are nulled out while
+the remaining rows of the table are unchanged. A valid foreign key means that an existing
+foreign key already exists in the table it references. An invalid foreign key means that there
+is NOT an existing foreign key in the table it references
+"""
+
+# Python imports
+import os
+from mock import patch
+
+# Third party imports
+from dateutil import parser
+
+# Project imports
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.null_invalid_foreign_keys import NullInvalidForeignKeys
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+sandbox_table_names = ['procedure_occurrence', 'person']
+
+
+class NullInvalidForeignKeysTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # set the expected test datasets
+        dataset_id = os.environ.get('UNIONED_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        cls.rule_instance = NullInvalidForeignKeys(project_id, dataset_id,
+                                                   sandbox_id)
+
+        selected_table_names = [
+            '_mapping_provider', '_mapping_visit_occurrence',
+            '_mapping_location', '_mapping_care_site',
+            'procedure_occurrence', 'person'
+        ]
+
+        for table_name in sandbox_table_names:
+            sandbox_table_name = cls.rule_instance.get_sandbox_table_for(table_name)
+            cls.fq_sandbox_table_names.append(f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
+
+        cls.fq_table_names = [
+            f'{project_id}.{cls.dataset_id}.{table_name}'
+            for table_name in selected_table_names
+        ]
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and
+        a common fully qualified dataset name string used to load
+        the data.
+        """
+
+        self.date = parser.parse('2020-03-06').date()
+        self.datetime = parser.parse('2020-03-06 11:00:00 UTC')
+
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+        super().setUp()
+
+    @patch.object(NullInvalidForeignKeys, 'get_affected_tables')
+    def test_get_query_specs(self, mock_get_affected_tables):
+        """
+        Tests that the specifications for the SANDBOX_QUERY and INVALID_FOREIGN_KEY_QUERY
+        perform as designed.
+
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+        # mocks the return value of get_affected_tables as we only want to loop through the
+        # procedure_occurrence and person tables, not all of the CDM tables
+        mock_get_affected_tables.return_value = sandbox_table_names
+
+        # load statements for the mapping tables
+        mapping_procedure = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}._mapping_provider` (provider_id)
+        VALUES (1)""").render(fq_dataset_name=self.fq_dataset_name)
+
+        mapping_visit_occurrence = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}._mapping_visit_occurrence` (visit_occurrence_id)
+        VALUES (2)""").render(fq_dataset_name=self.fq_dataset_name)
+
+        mapping_location = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}._mapping_location` (location_id)
+        VALUES (3)""").render(fq_dataset_name=self.fq_dataset_name)
+
+        mapping_care_site = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}._mapping_care_site` (care_site_id)
+        VALUES (4)""").render(fq_dataset_name=self.fq_dataset_name)
+
+        # load statements for tables to be cleaned through cleaning rule (procedure_occurrence, person)
+        procedure_occurrence = self.jinja_env.from_string(
+            """
+        INSERT INTO `{{fq_dataset_name}}.procedure_occurrence`
+            (procedure_occurrence_id, person_id, procedure_concept_id, procedure_date, procedure_datetime, 
+            procedure_type_concept_id, provider_id, visit_occurrence_id)
+        VALUES
+            -- invalid person_id foreign key. will be sandboxed and nulled --
+            (111, 0, 101, date('2020-03-06'), timestamp('2020-03-06 11:00:00'), 101, 1, 2),
+            
+            -- invalid provider_id foreign key. will be sandboxed and nulled --
+            (222, 555, 101, date('2020-03-06'), timestamp('2020-03-06 11:00:00'), 101, 0, 2),
+            
+            -- invalid visit_occurrence_id foreign key, will be sandboxed and nulled --
+            (333, 666, 101, date('2020-03-06'), timestamp('2020-03-06 11:00:00'), 101, 1, 0),
+            
+            -- all foreign keys valid. nothing will be sandboxed or nulled --
+            (444, 777, 101, date('2020-03-06'), timestamp('2020-03-06 11:00:00'), 101, 1, 2)"""
+        ).render(fq_dataset_name=self.fq_dataset_name)
+
+        person = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}.person`
+            (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id, location_id, 
+            provider_id, care_site_id)
+        VALUES
+            -- invalid location_id foreign key. will be sandboxed and nulled --
+            (555, 101, 1985, 101, 101, 0, 1, 4),
+            
+            -- invalid care_site_id foreign key. will be sandboxed and nulled --
+            (666, 101, 1989, 101, 101, 3, 1, 0),
+            
+            -- all foreign keys valid. nothing will be sandboxed or nulled --
+            (777, 101, 1995, 101, 101, 3, 1, 4)""").render(
+            fq_dataset_name=self.fq_dataset_name)
+
+        self.load_test_data([
+            mapping_procedure, mapping_visit_occurrence, mapping_location,
+            mapping_care_site, procedure_occurrence, person
+        ])
+
+        tables_and_counts = [
+            {
+                'fq_table_name':
+                    '.'.join([self.fq_dataset_name, 'procedure_occurrence']),
+                'fields': [
+                    'procedure_occurrence_id', 'person_id',
+                    'procedure_concept_id', 'procedure_date',
+                    'procedure_datetime', 'procedure_type_concept_id',
+                    'provider_id', 'visit_occurrence_id'
+                ],
+                'loaded_ids': [111, 222, 333, 444],
+                'sandboxed_ids': [111, 222, 333],
+                'cleaned_values': [
+                    # cleaned invalid test values
+                    (111, None, 101, self.date, self.datetime, 101, 1, 2),
+                    (222, 555, 101, self.date, self.datetime, 101, None, 2),
+                    (333, 666, 101, self.date, self.datetime, 101, 1, None),
+                    # valid test values, no changes
+                    (444, 777, 101, self.date, self.datetime, 101, 1, 2)
+                ]
+            },
+            {
+                'fq_table_name':
+                    '.'.join([self.fq_dataset_name, 'person']),
+                'fields': [
+                    'person_id', 'gender_concept_id', 'year_of_birth',
+                    'race_concept_id', 'ethnicity_concept_id', 'location_id',
+                    'provider_id', 'care_site_id'
+                ],
+                'loaded_ids': [555, 666, 777],
+                'sandboxed_ids': [555, 666],
+                'cleaned_values': [
+                    # cleaned invalid test values
+                    (555, 101, 1985, 101, 101, None, 1, 4),
+                    (666, 101, 1989, 101, 101, 3, 1, None),
+                    # valid test values, no changes
+                    (777, 101, 1995, 101, 101, 3, 1, 4)
+                ]
+            }
+        ]
+
+        self.default_test(tables_and_counts)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
@@ -178,13 +178,12 @@ class NullInvalidForeignKeys(unittest.TestCase):
 
         sandbox_query = {
             cdr_consts.QUERY:
-                nifk.SANDBOX_QUERY.render(
-                    project_id=self.project_id,
-                    sandbox_dataset_id=self.sandbox_id,
-                    intermediary_table='dc388_person',
-                    dataset_id=self.dataset_id,
-                    table_name=table,
-                    sandbox_expr=self.sandbox_expression),
+                nifk.SANDBOX_QUERY.render(project_id=self.project_id,
+                                          sandbox_dataset_id=self.sandbox_id,
+                                          intermediary_table='dc388_person',
+                                          dataset_id=self.dataset_id,
+                                          table_name=table,
+                                          sandbox_expr=self.sandbox_expression),
         }
 
         invalid_foreign_key_query = {

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
@@ -179,7 +179,7 @@ class NullInvalidForeignKeys(unittest.TestCase):
                 nifk.SANDBOX_QUERY.render(
                     project_id=self.project_id,
                     sandbox_dataset_id=self.sandbox_id,
-                    intermediary_table='dc-388_dc-807_person',
+                    intermediary_table='dc388_dc807_person',
                     dataset_id=self.dataset_id,
                     table_name=table,
                     sandbox_expr=self.sandbox_expression),

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
@@ -183,12 +183,6 @@ class NullInvalidForeignKeys(unittest.TestCase):
                     dataset_id=self.dataset_id,
                     table_name=table,
                     sandbox_expr=self.sandbox_expression),
-            cdr_consts.DESTINATION_DATASET:
-                self.dataset_id,
-            cdr_consts.DESTINATION_TABLE:
-                table,
-            cdr_consts.DISPOSITION:
-                bq_consts.WRITE_TRUNCATE
         }
 
         invalid_foreign_key_query = {

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/null_invalid_foreign_keys_test.py
@@ -1,6 +1,8 @@
 """
 Unit test for cleaning_rules.null_invalid_foreign_keys.py module
 
+Original Issues: DC-807, DC-388
+
 The intent of this unit test is to ensure that any invalid foreign keys are nulled out while
 the remaining rows of the table are unchanged. A valid foreign key means that an existing
 foreign key already exists in the table it references. An invalid foreign key means that there
@@ -179,7 +181,7 @@ class NullInvalidForeignKeys(unittest.TestCase):
                 nifk.SANDBOX_QUERY.render(
                     project_id=self.project_id,
                     sandbox_dataset_id=self.sandbox_id,
-                    intermediary_table='dc388_dc807_person',
+                    intermediary_table='dc388_person',
                     dataset_id=self.dataset_id,
                     table_name=table,
                     sandbox_expr=self.sandbox_expression),


### PR DESCRIPTION
* modified main module and unit test because cannot set python code destination object when running the `CREATE OR REPLACE` statement in the `SANDBOX_QUERY` queries
* created integration test to test functionality of main module
* in the integration test only the `person` and `procedure_occurrence` tables are cleaned as between those two all foreign key columns will be tested
* only the mapping tables used in the `INVALID_FOREIGN_KEY_QUERY` for `person` and `procedure_occurrence` are created and supplied with data
* the `get_affected_tables` function from main module is mocked as we do not need all the CDM tables to be iterate through for cleaning, only `person` and `procedure_occurrence`
