### PR TITLE
[DC-1232] Assess Safety of Removing EHR Site Validation File Writer Endpoint

### DIFF
--- a/data_steward/constants/validation/main.py
+++ b/data_steward/constants/validation/main.py
@@ -190,7 +190,6 @@ PREFIX = '/data_steward/v1/'
 # Cron URLs
 PARTICIPANT_VALIDATION = 'ParticipantValidation/'
 WRITE_DRC_VALIDATION_FILE = PARTICIPANT_VALIDATION + 'DRCFile'
-WRITE_SITE_VALIDATION_FILES = PARTICIPANT_VALIDATION + 'SiteFiles'
 
 # Return Values
 VALIDATION_SUCCESS = 'participant-validation-done'

--- a/data_steward/constants/validation/main.py
+++ b/data_steward/constants/validation/main.py
@@ -194,7 +194,6 @@ WRITE_DRC_VALIDATION_FILE = PARTICIPANT_VALIDATION + 'DRCFile'
 # Return Values
 VALIDATION_SUCCESS = 'participant-validation-done'
 DRC_VALIDATION_REPORT_SUCCESS = 'drc-participant-validation-report-written'
-SITES_VALIDATION_REPORT_SUCCESS = 'sites-participant-validation-reports-written'
 
 CONTENT_TYPE = 'content-type'
 APPLICATION_JSON = 'application/json'

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -1048,11 +1048,6 @@ app.add_url_rule(consts.PREFIX + consts.WRITE_DRC_VALIDATION_FILE,
                  view_func=write_drc_pii_validation_file,
                  methods=['GET'])
 
-app.add_url_rule(consts.PREFIX + consts.WRITE_SITE_VALIDATION_FILES,
-                 endpoint='write_sites_pii_validation_files',
-                 view_func=write_sites_pii_validation_files,
-                 methods=['GET'])
-
 app.add_url_rule(consts.PREFIX + consts.PARTICIPANT_VALIDATION,
                  endpoint='validate_pii',
                  view_func=validate_pii,

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -1001,17 +1001,6 @@ def write_drc_pii_validation_file():
     return consts.DRC_VALIDATION_REPORT_SUCCESS
 
 
-@api_util.auth_required_cron
-@log_traceback
-def write_sites_pii_validation_files():
-    project = bq_utils.app_identity.get_application_id()
-    validation_dataset = bq_utils.get_validation_results_dataset_id()
-    logging.info(f"Calling write_results_to_site_buckets")
-    matching.write_results_to_site_buckets(project, validation_dataset)
-
-    return consts.SITES_VALIDATION_REPORT_SUCCESS
-
-
 @app.before_first_request
 def set_up_logging():
     initialize_logging()


### PR DESCRIPTION
* removed code creating /ParticipantValidation/SiteFiles endpoint handling in `/validation/main.py`
* removed `WRITE_SITE_VALIDATION_FILES` constant from `constants/validation/main.py`
* removed `write_sites-pii_validation_files()` function from `/validation/main.py`