### PR TITLE
[DC-1213] Use the Participant Summary API to retrieve fields of interest for participant validation

### DIFF
--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -26,13 +26,15 @@ from google.auth import default
 from utils import auth
 from resources import fields_for
 
-# These fields are coming in from RDR with their naming convention and will be converted
-# to the Curation naming convention in the `get_site_participant_information` function
 FIELDS_OF_INTEREST_FOR_VALIDATION = [
     'participantId', 'firstName', 'middleName', 'lastName', 'streetAddress',
     'streetAddress2', 'city', 'state', 'zipCode', 'phoneNumber', 'email',
     'dateOfBirth', 'sex'
 ]
+"""
+These fields are coming in from RDR with their naming convention and will be converted
+to the Curation naming convention in the `get_site_participant_information` function
+"""
 
 
 def get_access_token():

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -16,7 +16,6 @@ The intent of the get_participant_information function is to retrieve the inform
 
 # Third party imports
 import re
-import signal
 import pandas
 import requests
 import pandas_gbq
@@ -82,7 +81,6 @@ def get_participant_data(url, headers):
                 link_url = link_obj[0].get('url')
                 next_url = original_url + '&' + link_url[link_url.find('_token'
                                                                       ):]
-                print(next_url)
             else:
                 done = True
 
@@ -278,10 +276,3 @@ def store_participant_data(df, project_id, destination_table):
                              project_id,
                              if_exists="replace",
                              table_schema=table_schema)
-
-
-if __name__ == '__main__':
-    # columns = ['participantId', 'suspensionStatus', 'suspensionTime']
-    # tablename = '_deactivated_participants'
-    # get_deactivated_participants('all-of-us-rdr-prod', 'cdr-20201008-20201201', tablename, columns)
-    get_site_participant_information('all-of-us-rdr-prod', 'PITT')

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -10,7 +10,7 @@ The intent of the get_participant_information function is to retrieve the inform
     validation for a single site based on the site name (hpo_id). The information necessary for this request as defined
     in the ticket (DC-1213) as well as the Participant Summary Field List
     (https://all-of-us-raw-data-repository.readthedocs.io/en/latest/api_workflows/field_reference/participant_summary_field_list.html)
-    are `participant_id`, `firstName`, `middleName`, `lastName`, `streetAddress`, `streetAddress2`, `city`, `state`,
+    are `participantId`, `firstName`, `middleName`, `lastName`, `streetAddress`, `streetAddress2`, `city`, `state`,
     `zipCode`, `phoneNumber`, `email`, `dateOfBirth`, `sex`
 """
 
@@ -176,7 +176,7 @@ def get_site_participant_information(project_id, hpo_id):
     """
     Fetches the necessary participant information for a particular site.
 
-    :param project_id: The RDR project that contains participant summary data
+    :param project_id: The RDR project hosting the API
     :param hpo_id: awardee name of the site
 
     :return: returns dataframe of participant information
@@ -201,8 +201,13 @@ def get_site_participant_information(project_id, hpo_id):
     #   regardless if there is EHR data uploaded for that participant
     # suspensionStatus=NOT_SUSPENDED and withdrawalStatus=NOT_WITHDRAWN -- ensures only active participants returned
     #   via the API
-    url = 'https://{0}.appspot.com/rdr/v1/ParticipantSummary?awardee={1}&suspensionStatus={2}&consentForElectronicHealthRecords={3}&withdrawalStatus={4}&_sort=participantId&_count=1000'.format(
-        project_id, hpo_id, 'NOT_SUSPENDED', 'SUBMITTED', 'NOT_WITHDRAWN')
+    url = (f'https://{project_id}.appspot.com/rdr/v1/ParticipantSummary'
+           f'?awardee={hpo_id}'
+           f'&suspensionStatus=NOT_SUSPENDED'
+           f'&consentForElectronicHealthRecords=SUBMITTED'
+           f'&withdrawalStatus=NOT_WITHDRAWN'
+           f'&_sort=participantId'
+           f'&_count=1000')
 
     participant_data = get_participant_data(url, headers)
 
@@ -211,7 +216,8 @@ def get_site_participant_information(project_id, hpo_id):
 
     participant_information = []
 
-    # Loop over participant summary records, insert participant data in the same order as participant_information_cols
+    # Loop over participant summary records, insert participant data in
+    # the same order as participant_information_cols
     for entry in participant_data:
         item = []
         for col in participant_information_cols:

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -178,14 +178,14 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
 
 def get_site_participant_information(project_id, hpo_id):
     """
-    Fetches the necessary participant information for a particular site. RuntimeErrors will occur
-        if parameter are not supplied or are incorrect and a Google TimeoutError will occur if the
-        API call takes longer than 10 minutes to return all the participants from the single site.
+    Fetches the necessary participant information for a particular site.
 
     :param project_id: The RDR project hosting the API
     :param hpo_id: awardee name of the site
 
-    :return: returns dataframe of participant information
+    :return: a dataframe of participant information
+    :raises: RuntimeError if the project_id and hpo_id are not strings
+    :raises: TimeoutError if response takes longer than 10 minutes
     """
     # Parameter checks
     if not isinstance(project_id, str):

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -26,6 +26,8 @@ from google.auth import default
 from utils import auth
 from resources import fields_for
 
+# These fields are coming in from RDR with their naming convention and will be converted
+# to the Curation naming convention in the `get_site_participant_information` function
 FIELDS_OF_INTEREST_FOR_VALIDATION = [
     'participantId', 'firstName', 'middleName', 'lastName', 'streetAddress',
     'streetAddress2', 'city', 'state', 'zipCode', 'phoneNumber', 'email',
@@ -174,7 +176,9 @@ def get_deactivated_participants(project_id, dataset_id, tablename, columns):
 
 def get_site_participant_information(project_id, hpo_id):
     """
-    Fetches the necessary participant information for a particular site.
+    Fetches the necessary participant information for a particular site. RuntimeErrors will occur
+        if parameter are not supplied or are incorrect and a Google TimeoutError will occur if the
+        API call takes longer than 10 minutes to return all the participants from the single site.
 
     :param project_id: The RDR project hosting the API
     :param hpo_id: awardee name of the site

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -27,7 +27,6 @@ from google.auth import default
 from utils import auth
 from resources import fields_for
 
-
 FIELDS_OF_INTEREST_FOR_VALIDATION = [
     'participantId', 'firstName', 'middleName', 'lastName', 'streetAddress',
     'streetAddress2', 'city', 'state', 'zipCode', 'phoneNumber', 'email',
@@ -219,7 +218,8 @@ def get_site_participant_information(project_id, hpo_id):
                     item.append(val)
         participant_information.append(item)
 
-    df = pandas.DataFrame(participant_information, columns=participant_information_cols)
+    df = pandas.DataFrame(participant_information,
+                          columns=participant_information_cols)
 
     # Transforms participantId to an integer string
     df['participantId'] = df['participantId'].apply(participant_id_to_int)
@@ -285,5 +285,3 @@ if __name__ == '__main__':
     # tablename = '_deactivated_participants'
     # get_deactivated_participants('all-of-us-rdr-prod', 'cdr-20201008-20201201', tablename, columns)
     get_site_participant_information('all-of-us-rdr-prod', 'PITT')
-
-

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -56,7 +56,7 @@ def get_access_token():
 
 def get_participant_data(url, headers):
     """
-    Fetches participant data via ParticipantSummary API with a retrieval limit of 3 minutes
+    Fetches participant data via ParticipantSummary API
 
     :param url: the /ParticipantSummary endpoint to fetch information about the participant
     :param headers: the metadata associated with the API request and response
@@ -192,13 +192,17 @@ def get_site_participant_information(project_id, hpo_id):
 
     headers = {
         'content-type': 'application/json',
-        'Authorization': 'Bearer {0}'.format(token)
+        'Authorization': f'Bearer {token}'
     }
 
     # Make request to get API version. This is the current RDR version for reference see
     # see https://github.com/all-of-us/raw-data-repository/blob/master/opsdataAPI.md for documentation of this API.
-    url = 'https://{0}.appspot.com/rdr/v1/ParticipantSummary?awardee={1}&_sort=participantId&_count=1000'.format(
-        project_id, hpo_id)
+    # consentForElectronicHealthRecords=SUBMITTED -- ensures only consenting participants are returned via the API
+    #   regardless if there is EHR data uploaded for that participant
+    # suspensionStatus=NOT_SUSPENDED and withdrawalStatus=NOT_WITHDRAWN -- ensures only active participants returned
+    #   via the API
+    url = 'https://{0}.appspot.com/rdr/v1/ParticipantSummary?awardee={1}&suspensionStatus={2}&consentForElectronicHealthRecords={3}&withdrawalStatus={4}&_sort=participantId&_count=1000'.format(
+        project_id, hpo_id, 'NOT_SUSPENDED', 'SUBMITTED', 'NOT_WITHDRAWN')
 
     participant_data = get_participant_data(url, headers)
 

--- a/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
@@ -58,8 +58,8 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
 
         self.updated_site_participant_info = [[
             333, 'foo_first', 'foo_middle', 'foo_last', 'foo_street_address',
-            'foo_street_address_2', 'foo_city', 'foo_state', '12345', '1112223333', 'foo_email',
-            '1900-01-01', 'SexAtBirth_Male'
+            'foo_street_address_2', 'foo_city', 'foo_state', '12345',
+            '1112223333', 'foo_email', '1900-01-01', 'SexAtBirth_Male'
         ], [444, 'foo_first', 'foo_last', 'UNSET']]
 
         self.fake_dataframe = pandas.DataFrame(
@@ -186,13 +186,13 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
         dataframe_response = psr.get_site_participant_information(
             self.project_id, self.fake_hpo)
 
-        dataset_response = psr.store_participant_data(
-            dataframe_response, self.project_id,
-            self.destination_table)
+        dataset_response = psr.store_participant_data(dataframe_response,
+                                                      self.project_id,
+                                                      self.destination_table)
 
-        expected_response = mock_store_participant_data(
-            dataframe_response, self.project_id,
-            self.destination_table)
+        expected_response = mock_store_participant_data(dataframe_response,
+                                                        self.project_id,
+                                                        self.destination_table)
 
         # Post conditions
         pandas.testing.assert_frame_equal(

--- a/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
@@ -5,7 +5,7 @@ Ensures that get_token function fetches the access token properly, get_deactivat
     fetches all deactivated participants information, and store_participant_data properly stores all
     the fetched deactivated participant data
 
-Original Issues: DC-797, DC-971 (sub-task), DC-972 (sub-task)
+Original Issues: DC-797, DC-971 (sub-task), DC-972 (sub-task), DC-1213
 
 The intent of this module is to check that GCR access token is generated properly, the list of
     deactivated participants returned contains `participantID`, `suspensionStatus`, and `suspensionTime`,

--- a/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
@@ -68,7 +68,7 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
 
         self.participant_data = [{
             'fullUrl':
-                'https//foo_project.appspot.com/rdr/v1/Participant/P111/Summary',
+                f'https//{self.project_id}.appspot.com/rdr/v1/Participant/P111/Summary',
             'resource': {
                 'participantId': 'P111',
                 'suspensionStatus': 'NO_CONTACT',
@@ -76,7 +76,7 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
             }
         }, {
             'fullUrl':
-                'https//foo_project.appspot.com/rdr/v1/Participant/P222/Summary',
+                f'https//{self.project_id}.appspot.com/rdr/v1/Participant/P222/Summary',
             'resource': {
                 'participantId': 'P222',
                 'suspensionStatus': 'NO_CONTACT',
@@ -86,7 +86,7 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
 
         self.site_participant_info_data = [{
             'fullUrl':
-                'https//foo_project.appspot.com/rdr/v1/Participant/P333/Summary',
+                f'https//{self.project_id}.appspot.com/rdr/v1/Participant/P333/Summary',
             'resource': {
                 'participantId': 'P333',
                 'firstName': 'foo_first',
@@ -104,7 +104,7 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
             },
         }, {
             'fullUrl':
-                'https//foo_project.appspot.com/rdr/v1/Participant/P444/Summary',
+                f'https//{self.project_id}.appspot.com/rdr/v1/Participant/P444/Summary',
             'resource': {
                 'participantId': 'P444',
                 'firstName': 'bar_first',
@@ -115,7 +115,7 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
         self.json_response_entry = {
             'entry': [{
                 'fullUrl':
-                    'https//foo_project.appspot.com/rdr/v1/Participant/P111/Summary',
+                    f'https//{self.project_id}.appspot.com/rdr/v1/Participant/P111/Summary',
                 'resource': {
                     'participantId': 'P111',
                     'suspensionStatus': 'NO_CONTACT',
@@ -123,7 +123,7 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
                 }
             }, {
                 'fullUrl':
-                    'https//foo_project.appspot.com/rdr/v1/Participant/P222/Summary',
+                    f'https//{self.project_id}.appspot.com/rdr/v1/Participant/P222/Summary',
                 'resource': {
                     'participantId': 'P222',
                     'suspensionStatus': 'NO_CONTACT',

--- a/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
@@ -196,25 +196,28 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
 
         self.assertEqual(expected_response, dataset_response)
 
-    def test_get_site_participant_information(self):
+    @mock.patch('utils.participant_summary_requests.get_participant_data')
+    def test_get_site_participant_information(self, mock_get_participant_data):
 
         # Pre conditions
-        actual_site_participant_information = []
+        mock_get_participant_data.return_value = self.site_participant_info_data
+        site_participant_information = []
 
-        for entry in self.site_participant_info_data:
+        for entry in mock_get_participant_data.return_value:
             item = []
             for col in psr.FIELDS_OF_INTEREST_FOR_VALIDATION:
                 for key, val in entry.get('resource', {}).items():
                     if col == key:
                         item.append(val)
-            actual_site_participant_information.append(item)
+            site_participant_information.append(item)
 
         # Tests
-        expected_list = self.site_participant_information
-        actual_list = actual_site_participant_information
-
+        expected_dataframe = pandas.DataFrame(site_participant_information,
+                                              columns=psr.FIELDS_OF_INTEREST_FOR_VALIDATION)
+        actual_dataframe = pandas.DataFrame(self.site_participant_information,
+                                            columns=psr.FIELDS_OF_INTEREST_FOR_VALIDATION)
         # Post conditions
-        self.assertEqual(expected_list, actual_list)
+        pandas.testing.assert_frame_equal(expected_dataframe, actual_dataframe)
 
     def test_participant_id_to_int(self):
         # pre conditions

--- a/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
+++ b/tests/unit_tests/data_steward/utils/participant_summary_requests_test.py
@@ -212,10 +212,13 @@ class ParticipantSummaryRequestsTest(unittest.TestCase):
             site_participant_information.append(item)
 
         # Tests
-        expected_dataframe = pandas.DataFrame(site_participant_information,
-                                              columns=psr.FIELDS_OF_INTEREST_FOR_VALIDATION)
-        actual_dataframe = pandas.DataFrame(self.site_participant_information,
-                                            columns=psr.FIELDS_OF_INTEREST_FOR_VALIDATION)
+        expected_dataframe = pandas.DataFrame(
+            site_participant_information,
+            columns=psr.FIELDS_OF_INTEREST_FOR_VALIDATION)
+        actual_dataframe = pandas.DataFrame(
+            self.site_participant_information,
+            columns=psr.FIELDS_OF_INTEREST_FOR_VALIDATION)
+
         # Post conditions
         pandas.testing.assert_frame_equal(expected_dataframe, actual_dataframe)
 


### PR DESCRIPTION
* Created function `get_site_participant_information` which retrieves all the participants information using the columns listed in `FIELDS_OF_INTEREST_FOR_VALIDATION` 
** uses pagination and count to significantly speed up the time it takes to return records. Extremely helpful when using to get results from sites with a lot of participants as this no longer takes upwards of 10 minutes. Takes about 2 to retrieve 30k+ records.
* Created test function `test_get_site_participant_information`