### PR TITLE
[DC-1288] Allow calling clean_cdr stage from another python module

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -327,7 +327,7 @@ def get_missing_custom_params(rules, **kwargs):
 def validate_custom_params(rules, **kwargs):
     """
     Raises error if required custom parameters are missing for any CR in list of CRs
-    
+
     :param rules: list of cleaning rule classes/functions
     :param kwargs: dictionary of provided arguments
     :return: None
@@ -340,8 +340,12 @@ def validate_custom_params(rules, **kwargs):
             f'Missing required custom parameter(s): {missing_param_rules}')
 
 
-if __name__ == '__main__':
-    args, kwargs = fetch_args_kwargs()
+def clean_cdr(args=None):
+    """
+    :param args: list of all the arguments to apply the cleaning rules
+    :return:
+    """
+    args, kwargs = fetch_args_kwargs(args)
 
     rules = DATA_STAGE_RULES_MAPPING[args.data_stage.value]
     validate_custom_params(rules, **kwargs)
@@ -363,3 +367,7 @@ if __name__ == '__main__':
                                    sandbox_dataset_id=args.sandbox_dataset_id,
                                    rules=rules,
                                    **kwargs)
+
+
+if __name__ == '__main__':
+    clean_cdr()

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -340,7 +340,7 @@ def validate_custom_params(rules, **kwargs):
             f'Missing required custom parameter(s): {missing_param_rules}')
 
 
-def clean_cdr(args=None):
+def main(args=None):
     """
     :param args: list of all the arguments to apply the cleaning rules
     :return:
@@ -370,4 +370,4 @@ def clean_cdr(args=None):
 
 
 if __name__ == '__main__':
-    clean_cdr()
+    main()

--- a/tests/unit_tests/data_steward/cdr_cleaner/clean_cdr_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/clean_cdr_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+from mock import patch
+
 import cdr_cleaner.clean_cdr as cc
 from constants.cdr_cleaner.clean_cdr import DataStage
 from tests.test_util import FakeRuleClass, fake_rule_func
@@ -248,3 +250,71 @@ class CleanCDRTest(unittest.TestCase):
         actual = cc.get_missing_custom_params([(Fake1,), (fake_1,), (fake_2,)])
         expected = {'required_param_1': ['fake_1']}
         self.assertDictEqual(expected, actual)
+
+    @patch('cdr_cleaner.clean_cdr.clean_engine.clean_dataset')
+    @patch('cdr_cleaner.clean_cdr.clean_engine.get_query_list')
+    @patch('cdr_cleaner.clean_cdr.validate_custom_params')
+    @patch('cdr_cleaner.clean_cdr.fetch_args_kwargs')
+    def test_clean_cdr(self, mock_fetch_args, mock_validate_args,
+                       mock_get_query_list, mock_clean_dataset):
+
+        from argparse import Namespace
+
+        # Test clean_dataset() function call
+        args = [
+            '-p', self.project_id, '-d', self.dataset_id, '-b',
+            self.sandbox_dataset_id, '--data_stage', 'ehr'
+        ]
+        # creates argparse namespace return value
+        expected_args = Namespace(
+            **{
+                'project_id': self.project_id,
+                'dataset_id': self.dataset_id,
+                'sandbox_dataset_id': self.sandbox_dataset_id,
+                'data_stage': DataStage.EHR,
+                'console_log': False,
+                'list_queries': False
+            })
+
+        expected_kargs = {}
+        mock_fetch_args.return_value = expected_args, expected_kargs
+
+        rules = cc.DATA_STAGE_RULES_MAPPING['ehr']
+
+        cc.main(args)
+
+        mock_validate_args.assert_called_once_with(rules, **expected_kargs)
+
+        mock_clean_dataset.assert_called_once_with(
+            project_id=self.project_id,
+            dataset_id=self.dataset_id,
+            sandbox_dataset_id=self.sandbox_dataset_id,
+            rules=rules)
+
+        # Test get_queries() function call
+        args = [
+            '-p', self.project_id, '-d', self.dataset_id, '-b',
+            self.sandbox_dataset_id, '--data_stage', 'ehr', '--list_queries',
+            True
+        ]
+
+        expected_args = Namespace(
+            **{
+                'project_id': self.project_id,
+                'dataset_id': self.dataset_id,
+                'sandbox_dataset_id': self.sandbox_dataset_id,
+                'data_stage': DataStage.EHR,
+                'console_log': False,
+                'list_queries': True
+            })
+
+        expected_kargs = {}
+        mock_fetch_args.return_value = expected_args, expected_kargs
+
+        cc.main(args)
+
+        mock_get_query_list.assert_called_once_with(
+            project_id=self.project_id,
+            dataset_id=self.dataset_id,
+            sandbox_dataset_id=self.sandbox_dataset_id,
+            rules=rules)


### PR DESCRIPTION
Make clean_cdr() callable from other python modules.
Signed-off-by: Krishna Kalluri <krishnasaikalluri@gmail.com>