### PR TITLE
[DC-1293] Create required intermediate and final datasets

### DIFF
--- a/data_steward/constants/cdr_cleaner/clean_cdr.py
+++ b/data_steward/constants/cdr_cleaner/clean_cdr.py
@@ -11,6 +11,10 @@ CONTROLLED_TIER_DEID = 'controlled_tier_deid'
 CONTROLLED_TIER_DEID_BASE = 'controlled_tier_deid_base'
 CONTROLLED_TIER_DEID_CLEAN = 'controlled_tier_deid_clean'
 
+BACKUP = 'backup'
+STAGING = 'staging'
+SANDBOX = 'sandbox'
+
 PERSON_TABLE_NAME = 'person'
 
 # Query dictionary keys

--- a/data_steward/constants/cdr_cleaner/clean_cdr.py
+++ b/data_steward/constants/cdr_cleaner/clean_cdr.py
@@ -14,6 +14,7 @@ CONTROLLED_TIER_DEID_CLEAN = 'controlled_tier_deid_clean'
 BACKUP = 'backup'
 STAGING = 'staging'
 SANDBOX = 'sandbox'
+CLEAN = 'clean'
 
 PERSON_TABLE_NAME = 'person'
 

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -103,6 +103,16 @@ def create_dataset(client, name, input_dataset, tier, release_tag, deid_stage):
             "Please specify the base name of the datasets to be created")
     if not input_dataset:
         raise RuntimeError("Please specify the name of the input dataset")
+    if not tier:
+        raise RuntimeError(
+            "Please specify the tier intended for the output datasets")
+    if not release_tag:
+        raise RuntimeError(
+            "Please specify the release tag for the dataset in the format of YYYY#q#r"
+        )
+    if not deid_stage:
+        raise RuntimeError(
+            "Please specify the deid stage (deid, base, or clean)")
 
     # Construct names of datasets need as part of the deid process
     final_dataset_id = name
@@ -118,19 +128,11 @@ def create_dataset(client, name, input_dataset, tier, release_tag, deid_stage):
     }
 
     # Dataset descriptions
-    backup_dataset_desc = {
-        f'Backup dataset of {input_dataset}. No deid cleaning rules applied'
-    }
-    staging_dataset_desc = {
-        f'Staging dataset of {input_dataset}. Deid cleaning rules have been applied'
-    }
-    sandbox_dataset_desc = {
-        f'Sandbox dataset of {input_dataset}. '
-        f'Contains rows dropped or altered by deid cleaning rules'
-    }
-    final_dataset_desc = {
-        f'Final version of {input_dataset}. All deid cleaning rules have been applied'
-    }
+    backup_dataset_desc = f'Backup dataset of {input_dataset}. No deid cleaning rules applied'
+    staging_dataset_desc = f'Staging dataset of {input_dataset}. Deid cleaning rules have been applied'
+    sandbox_dataset_desc = f'Sandbox dataset of {input_dataset}. '\
+                           f'Contains rows dropped or altered by deid cleaning rules'
+    final_dataset_desc = f'Final version of {input_dataset}. All deid cleaning rules have been applied'
 
     # Creation of dataset objects
     backup_dataset_object = bq.define_dataset(client.project, backup_dataset_id,

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -156,14 +156,10 @@ def create_datasets(client, name, input_dataset, tier, release_tag, deid_stage):
     # Copy input dataset tables to backup and staging datasets
     tables = client.list_tables(input_dataset)
     for table in tables:
-        input_tables = f'{input_dataset}.{table.table_id}'
-        backup_tables = f'{backup_dataset_id}.{table.table_id}'
-        client.copy_table(input_tables, backup_tables)
-
-    for table in tables:
-        input_tables = f'{input_dataset}.{table.table_id}'
-        staging_tables = f'{staging_dataset_id}.{table.table_id}'
-        client.copy_table(input_tables, staging_tables)
+        backup_table = f'{backup_dataset_id}.{table.table_id}'
+        staging_table = f'{staging_dataset_id}.{table.table_id}'
+        client.copy_table(table, backup_tables)
+        client.copy_table(table, staging_tables)
 
     return final_dataset_id, backup_dataset_id, staging_dataset_id, sandbox_dataset_id
 

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -8,6 +8,7 @@ import re
 # Project imports
 from utils import pipeline_logging
 from utils import bq
+from constants.cdr_cleaner import clean_cdr as consts
 
 LOGGER = logging.getLogger(__name__)
 
@@ -116,9 +117,9 @@ def create_datasets(client, name, input_dataset, tier, release_tag, deid_stage):
 
     # Construct names of datasets need as part of the deid process
     final_dataset_id = name
-    backup_dataset_id = f'backup_{name}'
-    staging_dataset_id = f'staging_{name}'
-    sandbox_dataset_id = f'sandbox_{name}'
+    backup_dataset_id = f'{name}_{consts.BACKUP}'
+    staging_dataset_id = f'{name}_{consts.STAGING}'
+    sandbox_dataset_id = f'{name}_{consts.SANDBOX}'
 
     dataset_ids = [
         final_dataset_id, backup_dataset_id, staging_dataset_id,
@@ -132,7 +133,7 @@ def create_datasets(client, name, input_dataset, tier, release_tag, deid_stage):
         'data_tier': tier
     }
 
-    description = f'Dataset created for {release_tag} {tier} CDR run'
+    description = f'Dataset created for {tier}{release_tag} CDR run'
 
     # Creation of dataset objects
     dataset_objects = []
@@ -161,7 +162,14 @@ def create_datasets(client, name, input_dataset, tier, release_tag, deid_stage):
         client.copy_table(table, backup_table)
         client.copy_table(table, staging_table)
 
-    return final_dataset_id, backup_dataset_id, staging_dataset_id, sandbox_dataset_id
+    datasets = {
+        name: final_dataset_id,
+        consts.BACKUP: backup_dataset_id,
+        consts.STAGING: staging_dataset_id,
+        consts.SANDBOX: sandbox_dataset_id
+    }
+
+    return datasets
 
 
 def create_tier(credentials_filepath, project_id, tier, input_dataset,

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -158,8 +158,8 @@ def create_datasets(client, name, input_dataset, tier, release_tag, deid_stage):
     for table in tables:
         backup_table = f'{backup_dataset_id}.{table.table_id}'
         staging_table = f'{staging_dataset_id}.{table.table_id}'
-        client.copy_table(table, backup_tables)
-        client.copy_table(table, staging_tables)
+        client.copy_table(table, backup_table)
+        client.copy_table(table, staging_table)
 
     return final_dataset_id, backup_dataset_id, staging_dataset_id, sandbox_dataset_id
 

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -413,6 +413,8 @@ def update_labels_and_tags(dataset_id,
                                f'without overwriting keys {overwrite_keys}')
         return {**existing_labels_or_tags, **updates}
 
+    return {**existing_labels_or_tags, **updates}
+
 
 def delete_dataset(project_id,
                    dataset_id,

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -42,6 +42,7 @@ class CreateTierTest(unittest.TestCase):
         # Tools for mocking the client
         mock_bq_client_patcher = mock.patch('utils.bq.get_client')
         self.mock_bq_client = mock_bq_client_patcher.start()
+        self.addCleanup(mock_bq_client_patcher.stop)
 
         self.correct_parameter_list = [
             '--credentials_filepath', self.credentials_filepath, '--project_id',

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -36,7 +36,6 @@ class CreateTierTest(unittest.TestCase):
         self.description = f'Dataset created for {self.tier}{self.release_tag} CDR run'
         self.labels_and_tags = {
             'release_tag': self.release_tag,
-            'phase': self.deid_stage,
             'data_tier': self.tier,
         }
 
@@ -220,24 +219,19 @@ class CreateTierTest(unittest.TestCase):
 
         # Tests if incorrect parameters are given
         self.assertRaises(RuntimeError, create_datasets, None, self.name,
-                          self.input_dataset, self.tier, self.release_tag,
-                          self.deid_stage)
+                          self.input_dataset, self.tier, self.release_tag)
         self.assertRaises(RuntimeError, create_datasets, client, None,
-                          self.input_dataset, self.tier, self.release_tag,
-                          self.deid_stage)
+                          self.input_dataset, self.tier, self.release_tag)
         self.assertRaises(RuntimeError, create_datasets, client, self.name,
-                          None, self.tier, self.release_tag, self.deid_stage)
+                          None, self.tier, self.release_tag)
         self.assertRaises(RuntimeError, create_datasets, client, self.name,
-                          self.input_dataset, None, self.release_tag,
-                          self.deid_stage)
+                          self.input_dataset, None, self.release_tag)
         self.assertRaises(RuntimeError, create_datasets, client, self.name,
-                          self.input_dataset, self.tier, None, self.deid_stage)
-        self.assertRaises(RuntimeError, create_datasets, client, self.name,
-                          self.input_dataset, self.tier, self.release_tag, None)
+                          self.input_dataset, self.tier, None)
 
         # Test
         expected = create_datasets(client, self.name, self.input_dataset,
-                                   self.tier, self.release_tag, self.deid_stage)
+                                   self.tier, self.release_tag)
 
         # Post conditions
         client.create_dataset.assert_called()
@@ -259,13 +253,19 @@ class CreateTierTest(unittest.TestCase):
         ])
 
         # Ensures datasets are updated with the proper labels and tags (if dataset is de-identified or not)
-        self.assertEqual(mock_update_labels_tags.call_count, 3)
+        self.assertEqual(mock_update_labels_tags.call_count, 4)
 
         mock_update_labels_tags.assert_has_calls([
-            mock.call(datasets[consts.BACKUP], self.labels_and_tags,
-                      {'de-identified': 'false'}),
-            mock.call(datasets[consts.STAGING], self.labels_and_tags,
-                      {'de-identified': 'true'}),
+            mock.call(datasets[consts.SANDBOX], self.labels_and_tags,
+                      {'phase': {consts.SANDBOX}}),
+            mock.call(datasets[consts.BACKUP], self.labels_and_tags, {
+                'de-identified': 'false',
+                'phase': {consts.BACKUP}
+            }),
+            mock.call(datasets[consts.STAGING], self.labels_and_tags, {
+                'de-identified': 'true',
+                'phase': {consts.STAGING}
+            }),
             mock.call(datasets[self.name], self.labels_and_tags,
                       {'de-identified': 'true'})
         ])

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -33,7 +33,7 @@ class CreateTierTest(unittest.TestCase):
         self.deid_stage = 'deid'
         self.name = 'foo_name'
 
-        self.description = f'Dataset created for {self.tier}{self.release_tag} CDR run'
+        self.description = f'dataset created from {self.input_dataset} for {self.tier}{self.release_tag} CDR run'
         self.labels_and_tags = {
             'release_tag': self.release_tag,
             'data_tier': self.tier,
@@ -211,7 +211,7 @@ class CreateTierTest(unittest.TestCase):
         client.side_effects = create_datasets
 
         datasets = {
-            self.name: self.name,
+            consts.CLEAN: self.name,
             consts.BACKUP: f'{self.name}_{consts.BACKUP}',
             consts.SANDBOX: f'{self.name}_{consts.SANDBOX}',
             consts.STAGING: f'{self.name}_{consts.STAGING}'
@@ -242,7 +242,7 @@ class CreateTierTest(unittest.TestCase):
         self.assertEqual(mock_define_dataset.call_count, 4)
 
         mock_define_dataset.assert_has_calls([
-            mock.call(client.project, datasets[self.name], self.description,
+            mock.call(client.project, datasets[consts.CLEAN], self.description,
                       self.labels_and_tags),
             mock.call(client.project, datasets[consts.BACKUP], self.description,
                       self.labels_and_tags),
@@ -256,16 +256,18 @@ class CreateTierTest(unittest.TestCase):
         self.assertEqual(mock_update_labels_tags.call_count, 4)
 
         mock_update_labels_tags.assert_has_calls([
-            mock.call(datasets[consts.SANDBOX], self.labels_and_tags,
-                      {'phase': {consts.SANDBOX}}),
+            mock.call(datasets[consts.CLEAN], self.labels_and_tags, {
+                'de-identified': 'true',
+                'phase': consts.CLEAN
+            }),
             mock.call(datasets[consts.BACKUP], self.labels_and_tags, {
                 'de-identified': 'false',
-                'phase': {consts.BACKUP}
+                'phase': consts.BACKUP
             }),
             mock.call(datasets[consts.STAGING], self.labels_and_tags, {
                 'de-identified': 'true',
-                'phase': {consts.STAGING}
+                'phase': consts.STAGING
             }),
-            mock.call(datasets[self.name], self.labels_and_tags,
-                      {'de-identified': 'true'})
+            mock.call(datasets[consts.SANDBOX], self.labels_and_tags,
+                      {'phase': consts.SANDBOX}),
         ])

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -10,7 +10,7 @@ import mock
 # Third party imports
 
 # Project imports
-from utils import bq
+from constants.cdr_cleaner import clean_cdr as consts
 from tools.create_tier import parse_deid_args, validate_deid_stage_param, validate_tier_param, \
     validate_release_tag_param, create_datasets, get_dataset_name
 
@@ -33,7 +33,7 @@ class CreateTierTest(unittest.TestCase):
         self.deid_stage = 'deid'
         self.name = 'foo_name'
 
-        self.description = f'Dataset created for {self.release_tag} {self.tier} CDR run'
+        self.description = f'Dataset created for {self.tier}{self.release_tag} CDR run'
         self.labels_and_tags = {
             'release_tag': self.release_tag,
             'phase': self.deid_stage,
@@ -211,6 +211,13 @@ class CreateTierTest(unittest.TestCase):
         client = mock_client.return_value = self.mock_bq_client
         client.side_effects = create_datasets
 
+        datasets = {
+            self.name: self.name,
+            consts.BACKUP: f'{self.name}_{consts.BACKUP}',
+            consts.SANDBOX: f'{self.name}_{consts.SANDBOX}',
+            consts.STAGING: f'{self.name}_{consts.STAGING}'
+        }
+
         # Tests if incorrect parameters are given
         self.assertRaises(RuntimeError, create_datasets, None, self.name,
                           self.input_dataset, self.tier, self.release_tag,
@@ -235,31 +242,30 @@ class CreateTierTest(unittest.TestCase):
         # Post conditions
         client.create_dataset.assert_called()
 
-        self.assertEqual(expected, ('foo_name', 'backup_foo_name',
-                                    'staging_foo_name', 'sandbox_foo_name'))
+        self.assertEqual(expected, datasets)
 
         # Ensures datasets are created with the proper name, descriptions, and labels and tags
         self.assertEqual(mock_define_dataset.call_count, 4)
 
         mock_define_dataset.assert_has_calls([
-            mock.call(client.project, 'foo_name', self.description,
+            mock.call(client.project, datasets[self.name], self.description,
                       self.labels_and_tags),
-            mock.call(client.project, 'backup_foo_name', self.description,
+            mock.call(client.project, datasets[consts.BACKUP], self.description,
                       self.labels_and_tags),
-            mock.call(client.project, 'staging_foo_name', self.description,
-                      self.labels_and_tags),
-            mock.call(client.project, 'sandbox_foo_name', self.description,
-                      self.labels_and_tags)
+            mock.call(client.project, datasets[consts.STAGING],
+                      self.description, self.labels_and_tags),
+            mock.call(client.project, datasets[consts.SANDBOX],
+                      self.description, self.labels_and_tags)
         ])
 
         # Ensures datasets are updated with the proper labels and tags (if dataset is de-identified or not)
         self.assertEqual(mock_update_labels_tags.call_count, 3)
 
         mock_update_labels_tags.assert_has_calls([
-            mock.call('backup_foo_name', self.labels_and_tags,
+            mock.call(datasets[consts.BACKUP], self.labels_and_tags,
                       {'de-identified': 'false'}),
-            mock.call('staging_foo_name', self.labels_and_tags,
+            mock.call(datasets[consts.STAGING], self.labels_and_tags,
                       {'de-identified': 'true'}),
-            mock.call('foo_name', self.labels_and_tags,
+            mock.call(datasets[self.name], self.labels_and_tags,
                       {'de-identified': 'true'})
         ])

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -268,6 +268,8 @@ class CreateTierTest(unittest.TestCase):
                 'de-identified': 'true',
                 'phase': consts.STAGING
             }),
-            mock.call(datasets[consts.SANDBOX], self.labels_and_tags,
-                      {'phase': consts.SANDBOX}),
+            mock.call(datasets[consts.SANDBOX], self.labels_and_tags, {
+                'de-identified': 'false',
+                'phase': consts.SANDBOX
+            }),
         ])


### PR DESCRIPTION
* created `create_datasets` function in `create_tier.py` which does the following:
1. Verifies that the proper information is given (`client`, `name`, `input_dataset`, `tier`, `release_tag`, `deid_stage`) by throwing `RuntimeError`s if not
2. Constructs the names of the datasets from the given `name` parameter
3. Creates the dataset objects from the list of `dataset_ids`
4. Creates the dataset from the list of `dataset_objects`
5. Updates the labels/tags of the`backup_dataset_id`, `staging_dataset_id`, and `final_dataset_id` datasets to identify whether or not the particular dataset has been de-identified
6. Copies the tables from the `input_dataset` to the `backup_dataset_id`, and `staging_dataset_id` datasets

* created `test_create_datasets` function in `create_tier_test.py` which does the following:
1. Creates a mocked client object
2. Tests that all the correct parameters by correctly raising `RuntimeError`s 
3. Ensuring that the `bq.create_dataset` function is called at least once
4. Ensures that the `bq.define_dataset` function is called exactly 4 times (for each of the created datasets)
5. Ensures that the `bq.define_dataset` function is called with the proper information
6. Ensures that the `bq.update_labels_and_tags` function is called exactly 3 times (for the `backup_dataset_id`, `staging_dataset_id`, and `final_dataset_id` datasets
7. Ensures that the `bq.update_labels_and_tags` function is called with the proper information