### PR TITLE
[DC-822] Update Death Date Validation CR to New Base Class & Correct Pipeline Step

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -28,7 +28,6 @@ import cdr_cleaner.cleaning_rules.remove_non_matching_participant as validate_mi
 import cdr_cleaner.cleaning_rules.remove_records_with_wrong_date as remove_records_with_wrong_date
 import cdr_cleaner.cleaning_rules.round_ppi_values_to_nearest_integer as round_ppi_values
 import cdr_cleaner.cleaning_rules.update_family_history_qa_codes as update_family_history
-import cdr_cleaner.cleaning_rules.valid_death_dates as valid_death_dates
 import cdr_cleaner.manual_cleaning_rules.clean_smoking_ppi as smoking
 import cdr_cleaner.manual_cleaning_rules.negative_ppi as negative_ppi
 import cdr_cleaner.manual_cleaning_rules.remove_operational_pii_fields as operational_pii_fields
@@ -68,6 +67,7 @@ from cdr_cleaner.cleaning_rules.truncate_rdr_using_date import TruncateRdrData
 from cdr_cleaner.cleaning_rules.unit_normalization import UnitNormalization
 from cdr_cleaner.cleaning_rules.update_fields_numbers_as_strings import UpdateFieldsNumbersAsStrings
 from cdr_cleaner.cleaning_rules.temporal_consistency import TemporalConsistency
+from cdr_cleaner.cleaning_rules.valid_death_dates import ValidDeathDates
 from constants.cdr_cleaner import clean_cdr_engine as ce_consts
 from constants.cdr_cleaner.clean_cdr import DataStage
 
@@ -148,7 +148,7 @@ COMBINED_CLEANING_CLASSES = [
     (clean_years.get_year_of_birth_queries,),
     (neg_ages.get_negative_ages_queries,),
     (NoDataAfterDeath,),
-    (valid_death_dates.get_valid_death_date_queries,),
+    (ValidDeathDates,),
     (drug_refills_supply.get_days_supply_refills_queries,),
     # trying to load a table while creating query strings,
     # won't work with mocked strings.  should use base class
@@ -177,7 +177,6 @@ FITBIT_CLEANING_CLASSES = [
 
 DEID_BASE_CLEANING_CLASSES = [
     (neg_ages.get_negative_ages_queries,),
-    (valid_death_dates.get_valid_death_date_queries,),
     (FillSourceValueTextFields,),
     (RepopulatePersonPostDeid,),
     (DateShiftCopeResponses,),

--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -37,7 +37,7 @@ SANDBOX_INVALID_DEATH_DATE_ROWS = common.JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}` AS (
 SELECT *
 FROM `{{project_id}}.{{dataset_id}}.{{table}}`
-WHERE {{table}}_date < '{{program_start_date}}' AND {{table}}_date > {{current_date}})
+WHERE {{table}}_date < '{{program_start_date}}' OR {{table}}_date > {{current_date}})
 """)
 
 

--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -1,13 +1,21 @@
 """
-A death date is considered "valid" if it is after the program start date and before the current date.
-Allowing for more flexibility, we choose Jan 1, 2017 as the program start date.
+Removes data containing death_dates which fall outside of the AoU program dates or after the current date
+
+Original Issues: DC-431, DC-822
+
+The intent is to ensure there are no death dates that occur before the start of the AoU program or after the current
+date. A death date is considered "valid" if it is after the program start date and before the current date. Allowing for more flexibility,
+we chose Jan 1, 2017 as the program start date.
 """
+
+# Python imports
 import logging
 
 # Project imports
-from constants import bq_utils as bq_consts
-from constants.cdr_cleaner import clean_cdr as cdr_consts
 import common
+from constants.bq_utils import WRITE_TRUNCATE
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,39 +23,120 @@ death = common.DEATH
 program_start_date = '2017-01-01'
 current_date = 'CURRENT_DATE()'
 
-KEEP_VALID_DEATH_TABLE_ROWS = (
-    "SELECT * "
-    "FROM `{project_id}.{dataset_id}.{table}` "
-    "WHERE {table}_date > '{program_start_date}' AND {table}_date < {current_date} "
-)
+# Keeps any rows where the death_date is after the AoU program start or before the current date by comparing person_ids
+# of the death table and sandbox tables. If the person_id is not in the sandbox table the row is kept, else, dropped.
+KEEP_VALID_DEATH_DATE_ROWS = common.JINJA_ENV.from_string("""
+SELECT * FROM `{{project_id}}.{{dataset_id}}.{{table}}` 
+WHERE person_id NOT IN (
+SELECT person_id FROM `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}`
+""")
+
+# Selects all the invalid rows. Invalid means the death_date occurs before the AoU program start
+# or after the current date.
+SANDBOX_INVALID_DEATH_DATE_ROWS = common.JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}` AS (
+SELECT *
+FROM `{{project_id}}.{{dataset_id}}.{{table}}`
+WHERE {{table}}_date < '{{program_start_date}}' AND {{table}}_date > {{current_date}})
+""")
 
 
-def get_valid_death_date_queries(project_id,
-                                 dataset_id,
-                                 sandbox_dataset_id=None):
+class ValidDeathDates(BaseCleaningRule):
     """
-    This function gets the queries required to keep table records
-    associated with a person whose death date is "valid" described above
-
-    :param project_id: Project name
-    :param dataset_id: Name of the dataset where a rule should be applied
-    :param sandbox_dataset_id: Identifies the sandbox dataset to store rows 
-    #TODO use sandbox_dataset_id for CR
-    :return a list of queries.
+    Any row with a death_date that occurs before the start of the AoU program (Jan 1, 2017 for simplicity) or after
+    the current date should be sandboxed and dropped from the death table.
     """
-    queries = []
-    query = dict()
-    query[cdr_consts.QUERY] = KEEP_VALID_DEATH_TABLE_ROWS.format(
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table=death,
-        program_start_date=program_start_date,
-        current_date=current_date)
-    query[cdr_consts.DESTINATION_TABLE] = death
-    query[cdr_consts.DISPOSITION] = bq_consts.WRITE_TRUNCATE
-    query[cdr_consts.DESTINATION_DATASET] = dataset_id
-    queries.append(query)
-    return queries
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper information.
+
+        Set the issue numbers, description and affected datasets. As other tickets may affect
+        this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = 'All rows in the death table that contain a death_date which occurs before the start of the AoU program' \
+               '(Jan 1, 2017) or after the current date will be sandboxed and dropped'
+        super().__init__(issue_numbers=['DC822'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.COMBINED],
+                         affected_tables=death,
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self, *args, **keyword_args):
+        """
+        Return a list of dictionary query specifications.
+
+        :return:  A list of dictionaries. Each dictionary contains a single query
+            and a specification for how to execute that query. The specifications
+            are optional but the query is required.
+        """
+        keep_valid_death_dates = {
+            cdr_consts.QUERY:
+                KEEP_VALID_DEATH_DATE_ROWS.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    table=death,
+                    sandbox_id=self.sandbox_dataset_id,
+                    sandbox_table=self.get_sandbox_table_for(death)),
+            cdr_consts.DESTINATION_TABLE:
+                death,
+            cdr_consts.DESTINATION_DATASET:
+                self.dataset_id,
+            cdr_consts.DISPOSITION:
+                WRITE_TRUNCATE
+        }
+
+        sandbox_invalid_death_dates = {
+            cdr_consts.QUERY:
+                SANDBOX_INVALID_DEATH_DATE_ROWS.render(
+                    project_id=self.project_id,
+                    sandbox_id=self.sandbox_dataset_id,
+                    sandbox_table=self.get_sandbox_table_for(death),
+                    dataset_id=self.dataset_id,
+                    table=death,
+                    program_start_date=program_start_date,
+                    current_date=current_date)
+        }
+
+        return [keep_valid_death_dates, sandbox_invalid_death_dates]
+
+    def setup_rule(self, client, *args, **keyword_args):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def get_sandbox_tablenames(self):
+        """
+        Get the sandbox dataset id for this class instance
+        """
+        return [
+            self.get_sandbox_table_for(affected_table)
+            for affected_table in self.affected_tables
+        ]
+
+    def get_sandbox_table_for(self, affected_table):
+        """
+        A helper function to retrieve the sandbox table name for the affected_table
+        :param affected_table: tables that is affected by running this cleaning rule
+        :return: formatted string name of the sandbox
+        """
+        return f'{self.issue_numbers[0].lower()}_{affected_table}'
+
+    def setup_validation(self, client, *args, **keyword_args):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client, *args, **keyword_args):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
 
 
 if __name__ == '__main__':
@@ -58,13 +147,14 @@ if __name__ == '__main__':
 
     if ARGS.list_queries:
         clean_engine.add_console_logging()
-        query_list = clean_engine.get_query_list(
-            ARGS.project_id, ARGS.dataset_id, ARGS.sandbox_dataset_id,
-            [(get_valid_death_date_queries,)])
+        query_list = clean_engine.get_query_list(ARGS.project_id,
+                                                 ARGS.dataset_id,
+                                                 ARGS.sandbox_dataset_id,
+                                                 [(ValidDeathDates,)])
         for query in query_list:
             LOGGER.info(query)
     else:
         clean_engine.add_console_logging(ARGS.console_log)
         clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
                                    ARGS.sandbox_dataset_id,
-                                   [(get_valid_death_date_queries,)])
+                                   [(ValidDeathDates,)])

--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -4,8 +4,8 @@ Removes data containing death_dates which fall outside of the AoU program dates 
 Original Issues: DC-431, DC-822
 
 The intent is to ensure there are no death dates that occur before the start of the AoU program or after the current
-date. A death date is considered "valid" if it is after the program start date and before the current date. Allowing for more flexibility,
-we chose Jan 1, 2017 as the program start date.
+date. A death date is considered "valid" if it is after the program start date and before the current date. Allowing for
+ more flexibility, we chose Jan 1, 2017 as the program start date.
 """
 
 # Python imports
@@ -55,8 +55,8 @@ class ValidDeathDates(BaseCleaningRule):
         this SQL, append them to the list of Jira Issues.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
-        desc = 'All rows in the death table that contain a death_date which occurs before the start of the AoU program' \
-               '(Jan 1, 2017) or after the current date will be sandboxed and dropped'
+        desc = 'All rows in the death table that contain a death_date which occurs before the start of the AoU ' \
+               'program (Jan 1, 2017) or after the current date will be sandboxed and dropped'
         super().__init__(issue_numbers=['DC822'],
                          description=desc,
                          affected_datasets=[cdr_consts.COMBINED],
@@ -80,7 +80,7 @@ class ValidDeathDates(BaseCleaningRule):
                     dataset_id=self.dataset_id,
                     table=death,
                     sandbox_id=self.sandbox_dataset_id,
-                    sandbox_table=self.get_sandbox_table_for(death)),
+                    sandbox_table=self.sandbox_table_for(death)),
             cdr_consts.DESTINATION_TABLE:
                 death,
             cdr_consts.DESTINATION_DATASET:
@@ -94,7 +94,7 @@ class ValidDeathDates(BaseCleaningRule):
                 SANDBOX_INVALID_DEATH_DATE_ROWS.render(
                     project_id=self.project_id,
                     sandbox_id=self.sandbox_dataset_id,
-                    sandbox_table=self.get_sandbox_table_for(death),
+                    sandbox_table=self.sandbox_table_for(death),
                     dataset_id=self.dataset_id,
                     table=death,
                     program_start_date=program_start_date,
@@ -110,21 +110,19 @@ class ValidDeathDates(BaseCleaningRule):
         pass
 
     def get_sandbox_tablenames(self):
-        """
-        Get the sandbox dataset id for this class instance
-        """
-        return [
-            self.get_sandbox_table_for(affected_table)
-            for affected_table in self.affected_tables
-        ]
+        pass
 
-    def get_sandbox_table_for(self, affected_table):
+    def sandbox_table_for(self, affected_table):
         """
         A helper function to retrieve the sandbox table name for the affected_table
-        :param affected_table: tables that is affected by running this cleaning rule
-        :return: formatted string name of the sandbox
+        :param affected_table:
+        :return:
         """
-        return f'{self.issue_numbers[0].lower()}_{affected_table}'
+        if affected_table not in self.affected_tables:
+            raise LookupError(
+                f'{affected_table} is not define as an affected table in {self.affected_tables}'
+            )
+        return f'{"_".join(self.issue_numbers).lower()}_{affected_table}'
 
     def setup_validation(self, client, *args, **keyword_args):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -112,18 +112,6 @@ class ValidDeathDates(BaseCleaningRule):
     def get_sandbox_tablenames(self):
         pass
 
-    def sandbox_table_for(self, affected_table):
-        """
-        A helper function to retrieve the sandbox table name for the affected_table
-        :param affected_table:
-        :return:
-        """
-        if affected_table not in self.affected_tables:
-            raise LookupError(
-                f'{affected_table} is not define as an affected table in {self.affected_tables}'
-            )
-        return f'{"_".join(self.issue_numbers).lower()}_{affected_table}'
-
     def setup_validation(self, client, *args, **keyword_args):
         """
         Run required steps for validation setup

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -1,0 +1,88 @@
+"""
+Unit test for valid_death_dates.py
+
+Removes data containing death_dates which fall outside of the AoU program dates or after the current date
+
+
+Original Issues: DC-431, DC-822
+
+The intent is to ensure there are no death dates that occur before the start of the AoU program or after the current
+date. A death date is considered "valid" if it is after the program start date and before the current date. Allowing for more flexibility,
+we chose Jan 1, 2017 as the program start date.
+"""
+
+# Python imports
+import unittest
+
+# Project imports
+import common
+from constants.bq_utils import WRITE_TRUNCATE
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.valid_death_dates import ValidDeathDates, KEEP_VALID_DEATH_DATE_ROWS,\
+    SANDBOX_INVALID_DEATH_DATE_ROWS, program_start_date, current_date
+
+
+class ValidDeathDatesTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'foo_project'
+        self.dataset_id = 'foo_dataset'
+        self.sandbox_dataset_id = 'foo_sandbox'
+        self.client = None
+
+        self.rule_instance = ValidDeathDates(self.project_id, self.dataset_id,
+                                             self.sandbox_dataset_id)
+
+        self.assertEqual(self.rule_instance.project_id, self.project_id)
+        self.assertEqual(self.rule_instance.dataset_id, self.dataset_id)
+        self.assertEqual(self.rule_instance.sandbox_dataset_id,
+                         self.sandbox_dataset_id)
+
+    def test_setup_rule(self):
+        # Test
+        self.rule_instance.setup_rule(self.client)
+
+    def test_get_query_spec(self):
+        # Pre conditions
+        self.assertEqual(self.rule_instance.affected_datasets,
+                         [cdr_consts.COMBINED])
+
+        # Test
+        result_list = self.rule_instance.get_query_specs()
+
+        # Post conditions
+        expected_list = [{
+            cdr_consts.QUERY:
+                KEEP_VALID_DEATH_DATE_ROWS.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    table=common.DEATH,
+                    sandbox_id=self.sandbox_dataset_id,
+                    sandbox_table=self.rule_instance.get_sandbox_table_for(
+                        common.DEATH)),
+            cdr_consts.DESTINATION_TABLE:
+                common.DEATH,
+            cdr_consts.DESTINATION_DATASET:
+                self.dataset_id,
+            cdr_consts.DISPOSITION:
+                WRITE_TRUNCATE
+        }, {
+            cdr_consts.QUERY:
+                SANDBOX_INVALID_DEATH_DATE_ROWS.render(
+                    project_id=self.project_id,
+                    sandbox_id=self.sandbox_dataset_id,
+                    sandbox_table=self.rule_instance.get_sandbox_table_for(
+                        common.DEATH),
+                    dataset_id=self.dataset_id,
+                    table=common.DEATH,
+                    program_start_date=program_start_date,
+                    current_date=current_date)
+        }]
+
+        self.assertEqual(result_list, expected_list)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -64,7 +64,7 @@ class ValidDeathDatesTest(unittest.TestCase):
                     dataset_id=self.dataset_id,
                     table=common.DEATH,
                     sandbox_id=self.sandbox_dataset_id,
-                    sandbox_table=self.rule_instance.get_sandbox_table_for(
+                    sandbox_table=self.rule_instance.sandbox_table_for(
                         common.DEATH)),
             cdr_consts.DESTINATION_TABLE:
                 common.DEATH,
@@ -77,7 +77,7 @@ class ValidDeathDatesTest(unittest.TestCase):
                 SANDBOX_INVALID_DEATH_DATE_ROWS.render(
                     project_id=self.project_id,
                     sandbox_id=self.sandbox_dataset_id,
-                    sandbox_table=self.rule_instance.get_sandbox_table_for(
+                    sandbox_table=self.rule_instance.sandbox_table_for(
                         common.DEATH),
                     dataset_id=self.dataset_id,
                     table=common.DEATH,


### PR DESCRIPTION
* modified `valid_death_dates.py`:
1. module inherits from `BaseCleaningRule`
2. created a sandbox query `SANDBOX_INVALID_DEATH_DATE_ROWS` to sandbox death date rows that occur before the start of the program or after the current date
* modified `cdr_cleaner.py` to use new class in import statement. Removed from all cleaning class lists except for `COMBINED_CLEANING_CLASSES`
* created `valid_death_dates_test.py` to test that the queries are created properly populated with the correct information 