### PR TITLE
[DC-1146] Drop duplicate COPE response rows

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -34,7 +34,6 @@ import cdr_cleaner.manual_cleaning_rules.negative_ppi as negative_ppi
 import cdr_cleaner.manual_cleaning_rules.remove_operational_pii_fields as operational_pii_fields
 import \
     cdr_cleaner.manual_cleaning_rules.update_questiona_answers_not_mapped_to_omop as map_questions_answers_to_omop
-from cdr_cleaner.cleaning_rules.id_deduplicate import DeduplicateIdColumn
 from cdr_cleaner.cleaning_rules.clean_height_weight import CleanHeightAndWeight
 from cdr_cleaner.cleaning_rules.clean_mapping import CleanMappingExtTables
 from cdr_cleaner.cleaning_rules.clean_ppi_numeric_fields_using_parameters import \
@@ -45,6 +44,7 @@ from cdr_cleaner.cleaning_rules.deid.fitbit_dateshift import FitbitDateShiftRule
 from cdr_cleaner.cleaning_rules.deid.pid_rid_map import PIDtoRID
 from cdr_cleaner.cleaning_rules.deid.remove_fitbit_data_if_max_age_exceeded import \
     RemoveFitbitDataIfMaxAgeExceeded
+from cdr_cleaner.cleaning_rules.drop_cope_duplicate_responses import DropCopeDuplicateResponses
 from cdr_cleaner.cleaning_rules.drop_duplicate_ppi_questions_and_answers import \
     DropDuplicatePpiQuestionsAndAnswers
 from cdr_cleaner.cleaning_rules.drop_ppi_duplicate_responses import DropPpiDuplicateResponses
@@ -53,6 +53,7 @@ from cdr_cleaner.cleaning_rules.ensure_date_datetime_consistency import \
     EnsureDateDatetimeConsistency
 from cdr_cleaner.cleaning_rules.fill_source_value_text_fields import FillSourceValueTextFields
 from cdr_cleaner.cleaning_rules.fix_unmapped_survey_answers import FixUnmappedSurveyAnswers
+from cdr_cleaner.cleaning_rules.id_deduplicate import DeduplicateIdColumn
 from cdr_cleaner.cleaning_rules.measurement_table_suppression import MeasurementRecordsSuppression
 from cdr_cleaner.cleaning_rules.no_data_30_days_after_death import NoDataAfterDeath
 from cdr_cleaner.cleaning_rules.null_concept_ids_for_numeric_ppi import NullConceptIDForNumericPPI
@@ -114,6 +115,7 @@ RDR_CLEANING_CLASSES = [
     (
         smoking.get_queries_clean_smoking,),
     (DropPpiDuplicateResponses,),
+    (DropCopeDuplicateResponses,),
     # trying to load a table while creating query strings,
     # won't work with mocked strings.  should use base class
     # setup_query_execution function to load dependencies before query execution

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses.py
@@ -1,0 +1,212 @@
+"""
+Removes the duplicate sets of COPE responses to the same questions in the same survey version.
+
+In PPI(COPE) surveys, the purpose of questionnaire_response_id is to group all responses from the same survey together.
+Some COPE questions allowed participants to provide multiple answers, which be will connected via the same
+questionnaire_response_id. However, a participant may submit the responses multiple times for the same questions,
+therefore creating duplicates. for the COPE surveys there are multiple versions of the survey where the questions can be
+reused in multiple versions. we need to keep the same question answer pairs from different versions.
+We need to use the combination of person_id, observation_source_concept_id,
+observation_source_value, and questionnaire_response_id and cope_month to identify multiple sets of responses.
+We only want to keep the most recent set of responses and remove previous sets of responses per each cope_month version.
+cope_survey_semantic_version_map in the rdr dataset can be used to get the cope_month version.
+
+In short the query should achieve
+Step 1:
+ Identify most recent questionnaire_response_id for same person, question, answer, cope_month combination.
+Step 2:
+ Prioritize responses with same person, question, cope_month combination with the most recent questionnaire_response_id.
+Step 3:
+ Keep only records associated with most questionnaire_response_id, person, question, answer per each cope_month version.
+"""
+import logging
+
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+# Project imports
+from common import JINJA_ENV
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from utils import pipeline_logging
+
+LOGGER = logging.getLogger(__name__)
+
+COPE_SURVEY_VERSION_MAP_TABLE = 'cope_survey_semantic_version_map'
+
+SANDBOX_DUPLICATE_COPE_RESPONSES_TEMPLATE = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE
+    `{{project}}.{{sandbox_dataset}}.{{intermediary_table}}` AS 
+SELECT
+  *
+FROM
+  `{{project}}.{{dataset}}.observation`
+WHERE
+  observation_id IN 
+""")
+
+REMOVE_DUPLICATE_COPE_RESPONSES_TEMPLATE = JINJA_ENV.from_string("""
+DELETE
+FROM
+  `{{project}}.{{dataset}}.observation`
+WHERE
+  observation_id IN 
+""")
+
+IDENTIFY_DUPLICATE_COPE_RESPONSES_TEMPLATE = JINJA_ENV.from_string("""
+    (
+  SELECT
+  observation_id
+FROM (
+  SELECT
+    *,
+    DENSE_RANK() OVER(PARTITION BY person_id,
+     observation_source_concept_id,
+     observation_source_value,
+     cope_month
+     ORDER BY is_pmi_skip ASC,
+     max_observation_datetime DESC,
+     questionnaire_response_id DESC,
+     observation_id DESC
+     ) AS rank_order
+  FROM (
+    SELECT
+      observation_id,
+      person_id,
+      observation_source_concept_id,
+      observation_source_value,
+      obs.questionnaire_response_id,
+    IF
+      (value_source_value = 'PMI_Skip',
+        1,
+        0) AS is_pmi_skip,
+      MAX(observation_datetime) OVER(PARTITION BY person_id,
+       observation_source_concept_id,
+        observation_source_value,
+        cope.cope_month,
+         obs.questionnaire_response_id
+          ) AS max_observation_datetime,
+      cope.cope_month /* will handle case if obs table has valid cope_month or not */
+    FROM
+      `{{project}}.{{dataset}}.observation` obs
+    INNER JOIN
+      `{{project}}.{{dataset}}.{{cope_survey_version_table}}` cope
+    ON
+      obs.questionnaire_response_id = cope.questionnaire_response_id
+         )
+        ) o
+WHERE
+  o.rank_order != 1 )
+""")
+
+
+class DropCopeDuplicateResponses(BaseCleaningRule):
+    """
+    Removes the duplicate sets of responses to the same questions excluding COPE survey.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper information.
+
+        Set the issue numbers, description and affected datasets. As other tickets may affect
+        this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = 'Removes the duplicate sets of COPE responses to the same questions from the same survey version.'
+        super().__init__(issue_numbers=['DC1146', 'DC1135'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         affected_tables=['observation'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_sandbox_statement(self, project_id, dataset_id, sandbox_dataset_id,
+                              sandbox_table, survey_version_table):
+        duplicate_id_query = IDENTIFY_DUPLICATE_COPE_RESPONSES_TEMPLATE.render(
+            project=project_id,
+            dataset=dataset_id,
+            cope_survey_version_table=survey_version_table)
+
+        select_duplicates_query = SANDBOX_DUPLICATE_COPE_RESPONSES_TEMPLATE.render(
+            project=project_id,
+            dataset=dataset_id,
+            sandbox_dataset=sandbox_dataset_id,
+            intermediary_table=sandbox_table)
+        return select_duplicates_query + duplicate_id_query
+
+    def get_delete_statement(self, project_id, dataset_id,
+                             survey_version_table):
+        duplicate_id_query = IDENTIFY_DUPLICATE_COPE_RESPONSES_TEMPLATE.render(
+            project=project_id,
+            dataset=dataset_id,
+            cope_survey_version_table=survey_version_table)
+        delete_duplicates_template = REMOVE_DUPLICATE_COPE_RESPONSES_TEMPLATE.render(
+            project=project_id, dataset=dataset_id)
+        return delete_duplicates_template + duplicate_id_query
+
+    def get_query_specs(self):
+        """
+        Return a list of dictionary query specifications.
+
+        :return:  A list of dictionaries. Each dictionary contains a single query
+            and a specification for how to execute that query. The specifications
+            are optional but the query is required.
+        """
+
+        sandbox_duplicate_rows = {
+            cdr_consts.QUERY:
+                self.get_sandbox_statement(self.project_id, self.dataset_id,
+                                           self.sandbox_dataset_id,
+                                           self.get_sandbox_tablenames()[0],
+                                           COPE_SURVEY_VERSION_MAP_TABLE)
+        }
+
+        delete_duplicate_rows = {
+            cdr_consts.QUERY:
+                self.get_delete_statement(self.project_id, self.dataset_id,
+                                          COPE_SURVEY_VERSION_MAP_TABLE)
+        }
+
+        return [sandbox_duplicate_rows, delete_duplicate_rows]
+
+    def setup_rule(self, client):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def setup_validation(self, client):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def get_sandbox_tablenames(self):
+        sandbox_table = f'{self._issue_numbers[0].lower()}_{self.affected_tables[0]}'
+        return [sandbox_table]
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    pipeline_logging.configure()
+    ARGS = parser.parse_args()
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(
+            ARGS.project_id, ARGS.dataset_id, ARGS.sandbox_dataset_id,
+            [(DropCopeDuplicateResponses,)])
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(DropCopeDuplicateResponses,)])

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
@@ -1,0 +1,160 @@
+"""
+Integration test for drop_cope_duplicate_responses module
+
+Removes the duplicate sets of COPE responses to the same questions in the same survey version.
+
+In PPI(COPE) surveys, the purpose of questionnaire_response_id is to group all responses from the same survey together.
+Some COPE questions allowed participants to provide multiple answers, which be will connected via the same
+questionnaire_response_id. However, a participant may submit the responses multiple times for the same questions,
+therefore creating duplicates. for the COPE surveys there are multiple versions of the survey where the questions can be
+reused in multiple versions. we need to keep the same question answer pairs from different versions.
+We need to use the combination of person_id, observation_source_concept_id,
+observation_source_value, and questionnaire_response_id and cope_month to identify multiple sets of responses.
+We only want to keep the most recent set of responses and remove previous sets of responses per each cope_month version.
+cope_survey_semantic_version_map in the rdr dataset can be used to get the cope_month version.
+
+In short the query should achieve
+Step 1:
+ Identify most recent questionnaire_response_id for same person, question, answer, cope_month combination.
+Step 2:
+ Prioritize responses with same person, question, cope_month combination with the most recent questionnaire_response_id.
+Step 3:
+ Keep only records associated with most questionnaire_response_id, person, question, answer per each cope_month version.
+"""
+
+# Python Imports
+import os
+
+# Project Imports
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.drop_cope_duplicate_responses import DropCopeDuplicateResponses
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+
+class DropCopeDuplicateResponsesTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # Set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # Set the expected test datasets
+        dataset_id = os.environ.get('RDR_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        cls.rule_instance = DropCopeDuplicateResponses(project_id, dataset_id,
+                                                       sandbox_id)
+
+        sb_table_names = cls.rule_instance.get_sandbox_tablenames()
+        for table_name in sb_table_names:
+            cls.fq_sandbox_table_names.append(
+                f'{project_id}.{sandbox_id}.{table_name}')
+
+        cls.fq_table_names = [f'{project_id}.{dataset_id}.observation']
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and a common
+        fully qualified (fq) dataset name string to load the data.
+        """
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+        super().setUp()
+
+    def test_field_cleaning(self):
+        """
+        Tests that the specifications for the SANDBOX_QUERY and CLEAN_PPI_NUMERIC_FIELDS_QUERY
+        perform as designed.
+
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+
+        tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{fq_dataset_name}}.observation` (observation_id,
+    person_id,
+    observation_concept_id,
+    observation_date,
+    observation_datetime,
+    observation_type_concept_id,
+    observation_source_concept_id,
+    observation_source_value,
+    value_source_value,
+    questionnaire_response_id)
+VALUES
+  (123, 1111111, 1384662, DATE('2015-09-15'), TIMESTAMP('2015-09-15'), 45905771, 1384662,
+   'InfectiousDiseases_InfectiousDiseaseCondition', 'InfectiousDiseaseCondition_Chickenpox', 111111111),
+  (234, 1111111, 1384662, DATE('2015-07-15'), TIMESTAMP('2015-07-15'),45905771, 1384662,
+   'InfectiousDiseases_InfectiousDiseaseCondition', 'InfectiousDiseaseCondition_NoInfectiousDisease', 222222222),
+  (345, 2222222, 3044964, DATE('2020-07-15'), TIMESTAMP('2020-07-15'), 45905771, 1333276,
+   'phq_9_4', 'COPE_A_75', 333333333),
+  (456, 2222222, 3044098, DATE('2020-08-15'), TIMESTAMP('2020-08-15'), 45905771, 1333276,
+   'phq_9_5', 'COPE_A_161', 444444444),
+   (567, 2222222, 3044964, DATE('2020-07-15'), TIMESTAMP('2020-07-15'), 45905771, 1333276,
+   'phq_9_4', 'COPE_A_75', 555555555),
+  (678, 2222222, 3044098, DATE('2020-12-15'), TIMESTAMP('2020-12-15'), 45905771, 1333276,
+   'phq_9_5', 'COPE_A_161', 666666666)""")
+
+        tmp2 = self.jinja_env.from_string("""
+         DROP TABLE IF EXISTS
+  `{{fq_dataset_name}}.cope_survey_semantic_version_map`;
+CREATE TABLE
+  `{{fq_dataset_name}}.cope_survey_semantic_version_map` AS (
+  WITH
+    w AS (
+    SELECT
+      ARRAY<STRUCT<participant_id INT64,
+      questionnaire_response_id INT64,
+      semantic_version INT64,
+      cope_month STRING>> [(2222222, 333333333, 4, 'jul' ),
+      (2222222, 555555555, 4, 'jul' ),
+      (2222222, 444444444, 6, 'aug' ),
+      (2222222, 666666666, 14,'dec' )] col )
+  SELECT
+    participant_id,
+    questionnaire_response_id,
+    semantic_version,
+    cope_month
+  FROM
+    w,
+    UNNEST(w.col))
+        """)
+
+        query = tmpl.render(fq_dataset_name=self.fq_dataset_name)
+        self.load_test_data([query])
+
+        query = tmp2.render(fq_dataset_name=self.fq_dataset_name)
+        self.load_test_data([query])
+
+        # Expected results list
+        tables_and_counts = [{
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, 'observation']),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
+            'loaded_ids': [123, 234, 345, 456, 567, 678],
+            'sandboxed_ids': [345],
+            'fields': ['observation_id', 'questionnaire_response_id'],
+            'cleaned_values': [(123, 111111111), (234, 222222222),
+                               (456, 444444444), (567, 555555555),
+                               (678, 666666666)]
+        }]
+
+        self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
@@ -15,7 +15,7 @@ cope_survey_semantic_version_map in the rdr dataset can be used to get the cope_
 
 In short the query should achieve
 Step 1:
- Identify most recent questionnaire_response_id for same person, question, answer, cope_month combination.
+ Identify most recent questionnaire_response_id for same person, question, cope_month combination.
 Step 2:
  Prioritize responses with same person, question, cope_month combination with the most recent questionnaire_response_id.
 Step 3:
@@ -78,7 +78,7 @@ class DropCopeDuplicateResponsesTest(BaseTest.CleaningRulesTestBase):
 
         super().setUp()
 
-    def test_field_cleaning(self):
+    def test_drop_duplicate_cope_responses(self):
         """
         Tests that the specifications for the SANDBOX_QUERY and CLEAN_PPI_NUMERIC_FIELDS_QUERY
         perform as designed.
@@ -109,7 +109,11 @@ VALUES
    'phq_9_5', 'COPE_A_161', 444444444),
    (567, 2222222, 3044964, DATE('2020-07-15'), TIMESTAMP('2020-07-15'), 45905771, 1333276,
    'phq_9_4', 'COPE_A_75', 555555555),
-  (678, 2222222, 3044098, DATE('2020-12-15'), TIMESTAMP('2020-12-15'), 45905771, 1333276,
+   (678, 2222222, 3044964, DATE('2020-07-15'), TIMESTAMP('2020-07-15'), 45905771, 1333276,
+   'phq_9_4', 'COPE_A_75', 555555555),
+   (789, 2222222, 3044964, DATE('2020-07-15'), TIMESTAMP('2020-07-15'), 45905771, 1333276,
+   'phq_9_4', 'COPE_A_161', 555555555),
+  (890, 2222222, 3044098, DATE('2020-12-15'), TIMESTAMP('2020-12-15'), 45905771, 1333276,
    'phq_9_5', 'COPE_A_161', 666666666)""")
 
         tmp2 = self.jinja_env.from_string("""
@@ -149,12 +153,12 @@ CREATE TABLE
                 '.'.join([self.fq_dataset_name, 'observation']),
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'loaded_ids': [123, 234, 345, 456, 567, 678],
-            'sandboxed_ids': [345],
+            'loaded_ids': [123, 234, 345, 456, 567, 678, 789, 980],
+            'sandboxed_ids': [345, 678],
             'fields': ['observation_id', 'questionnaire_response_id'],
             'cleaned_values': [(123, 111111111), (234, 222222222),
                                (456, 444444444), (567, 555555555),
-                               (678, 666666666)]
+                               (789, 555555555), (890, 666666666)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for drop_cope_duplicate_responses module
+
+Removes the duplicate sets of COPE responses to the same questions in the same survey version.
+"""
+import unittest
+
+from cdr_cleaner.cleaning_rules.drop_cope_duplicate_responses import (
+    DropCopeDuplicateResponses, COPE_SURVEY_VERSION_MAP_TABLE)
+from constants.cdr_cleaner import clean_cdr as clean_consts
+
+
+class DropCopeDuplicateResponsesTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'foo_project'
+        self.dataset_id = 'foo_dataset'
+        self.sandbox_id = 'foo_sandbox'
+        self.client = None
+
+        self.rule_instance = DropCopeDuplicateResponses(self.project_id,
+                                                        self.dataset_id,
+                                                        self.sandbox_id)
+
+        self.assertEqual(self.rule_instance.project_id, self.project_id)
+        self.assertEqual(self.rule_instance.dataset_id, self.dataset_id)
+        self.assertEqual(self.rule_instance.sandbox_dataset_id, self.sandbox_id)
+
+    def test_get_query_specs(self):
+        # Pre conditions
+        self.assertEqual(self.rule_instance.affected_datasets,
+                         [clean_consts.RDR])
+
+        # Test
+        results_list = self.rule_instance.get_query_specs()
+        # Post conditions
+        sandbox_query = dict()
+        sandbox_query[
+            clean_consts.QUERY] = self.rule_instance.get_sandbox_statement(
+                self.project_id, self.dataset_id, self.sandbox_id,
+                self.rule_instance.get_sandbox_tablenames()[0],
+                COPE_SURVEY_VERSION_MAP_TABLE)
+
+        update_query = dict()
+        update_query[
+            clean_consts.QUERY] = self.rule_instance.get_delete_statement(
+                self.project_id, self.dataset_id, COPE_SURVEY_VERSION_MAP_TABLE)
+
+        expected_list = [sandbox_query, update_query]
+
+        for ex_dict, rs_dict in zip(expected_list, results_list):
+            self.assertDictEqual(ex_dict, rs_dict)
+
+    def test_log_queries(self):
+        # Pre conditions
+        self.assertEqual(self.rule_instance.affected_datasets,
+                         [clean_consts.RDR])
+
+        store_duplicate_rows = self.rule_instance.get_sandbox_statement(
+            self.project_id, self.dataset_id, self.sandbox_id,
+            self.rule_instance.get_sandbox_tablenames()[0],
+            COPE_SURVEY_VERSION_MAP_TABLE)
+
+        delete_duplicate_rows = self.rule_instance.get_delete_statement(
+            self.project_id, self.dataset_id, COPE_SURVEY_VERSION_MAP_TABLE)
+
+        # Test
+        with self.assertLogs(level='INFO') as cm:
+            self.rule_instance.log_queries()
+
+            expected = [
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                + store_duplicate_rows,
+                'INFO:cdr_cleaner.cleaning_rules.base_cleaning_rule:Generated SQL Query:\n'
+                + delete_duplicate_rows
+            ]
+
+            # Post condition
+            self.assertEqual(cm.output, expected)


### PR DESCRIPTION
* Adds Drop duplicate COPE response rows cleaning rule
* Adds Unit tests and integration tests

Signed-off-by: Krishna Kalluri <krishnasaikalluri@gmail.com>