### PR TITLE
[DC-1329] create sandbox utility options function

### DIFF
--- a/data_steward/utils/sandbox.py
+++ b/data_steward/utils/sandbox.py
@@ -141,7 +141,7 @@ def get_sandbox_table_description_string(description):
 
     if not description or description.isspace():
         raise ValueError(
-            f"Description must be a non-empty string. Received teh value '{description}'."
+            f"Description must be a non-empty string. Received the value '{description}'."
         )
 
     return TABLE_DESCRIPTION_STRING.render(description=description)

--- a/data_steward/utils/sandbox.py
+++ b/data_steward/utils/sandbox.py
@@ -138,6 +138,12 @@ def get_sandbox_table_description_string(description):
     :return: A formatted table description
     :rtype: str
     """
+
+    if not description or description.isspace():
+        raise ValueError(
+            f"Description must be a non-empty string. Received teh value '{description}'."
+        )
+
     return TABLE_DESCRIPTION_STRING.render(description=description)
 
 

--- a/data_steward/utils/sandbox.py
+++ b/data_steward/utils/sandbox.py
@@ -128,6 +128,9 @@ def get_sandbox_labels_string(src_dataset_name,
                 f"Label '{label}' requires a boolean value of True or False. Received the value '{value}'."
             )
 
+        #Convert bools to lowered strings for BQ
+        labels[label] = str(value).lower()
+
     return TABLE_LABELS_STRING.render(labels=labels)
 
 

--- a/data_steward/utils/sandbox.py
+++ b/data_steward/utils/sandbox.py
@@ -106,21 +106,21 @@ def get_sandbox_labels_string(src_dataset_name,
     :return: A formatted string of the arguments concatenated as labels
     :rtype: str
     """
-    STRING_LABELS = ['src_dataset', 'class_name', 'table_tag']
-    BOOL_LABELS = ['shared_lookup']
+    string_labels = ['src_dataset', 'class_name', 'table_tag']
+    bool_labels = ['shared_lookup']
 
     labels = OrderedDict([('src_dataset', src_dataset_name),
                           ('class_name', class_name), ('table_tag', table_tag),
                           ('shared_lookup', shared_lookup)])
 
-    for label in STRING_LABELS:
+    for label in string_labels:
         value = labels[label]
         if not value or value.isspace():
             raise ValueError(
                 f"Label '{label}' requires a non-empty string. Received the value '{value}'."
             )
 
-    for label in BOOL_LABELS:
+    for label in bool_labels:
         value = labels[label]
 
         if type(value) != bool:
@@ -151,7 +151,7 @@ def get_sandbox_options(dataset_name,
     :param str dataset_name: A dataset name
     :param str class_name: A class name
     :param str table_tag: A table tag
-    :param str description: A table description
+    :param str desc: A table description
     :param bool shared_lookup: A boolean that indicates if a table is a shared lookup, defaults to False
     :return: A BigQuery table options clause 
     :rtype: str

--- a/data_steward/utils/sandbox.py
+++ b/data_steward/utils/sandbox.py
@@ -21,9 +21,11 @@ TABLE_DESCRIPTION_STRING = JINJA_ENV.from_string("""
 """)
 
 TABLE_OPTIONS_CLAUSE = JINJA_ENV.from_string("""
+{%- block options %}
 OPTIONS(
 {{ contents }}
 )
+{%- endblock %}
 """)
 
 
@@ -91,10 +93,26 @@ def get_sandbox_labels_string(src_dataset_name,
                               table_tag,
                               shared_lookup=False):
     STRING_LABELS = ['src_dataset', 'class_name', 'table_tag']
+    BOOL_LABELS = ['shared_lookup']
 
     labels = OrderedDict([('src_dataset', src_dataset_name),
                           ('class_name', class_name), ('table_tag', table_tag),
                           ('shared_lookup', shared_lookup)])
+
+    for label in STRING_LABELS:
+        value = labels[label]
+        if not value or value.isspace():
+            raise ValueError(
+                f"Label '{label}' requires a non-empty string. Received the value '{value}'."
+            )
+
+    for label in BOOL_LABELS:
+        value = labels[label]
+
+        if type(value) != bool:
+            raise ValueError(
+                f"Label '{label}' requires a boolean value of True or False. Received the value '{value}'."
+            )
 
     return TABLE_LABELS_STRING.render(labels=labels)
 
@@ -113,5 +131,4 @@ def get_sandbox_options(dataset_name,
     description_text = get_sandbox_table_description_string(desc)
 
     contents = ',\n'.join([description_text, labels_text])
-
     return TABLE_OPTIONS_CLAUSE.render(contents=contents)

--- a/data_steward/utils/sandbox.py
+++ b/data_steward/utils/sandbox.py
@@ -92,6 +92,17 @@ def get_sandbox_labels_string(src_dataset_name,
                               class_name,
                               table_tag,
                               shared_lookup=False):
+    """A helper function that formats a set of labels for BigQuery
+
+    :param str src_dataset_name: A dataset name
+    :param str class_name: A class name
+    :param str table_tag: A table tag
+    :param bool shared_lookup: A boolean that indicates if a table is a shared lookup, defaults to False
+    :raises ValueError: Raises if one of first three arguments is whitespace or None
+    :raises ValueError: Raises if the `shared_lookup` is not a boolean
+    :return: A formatted string of the arguments concatenated as labels
+    :rtype: str
+    """
     STRING_LABELS = ['src_dataset', 'class_name', 'table_tag']
     BOOL_LABELS = ['shared_lookup']
 
@@ -118,6 +129,12 @@ def get_sandbox_labels_string(src_dataset_name,
 
 
 def get_sandbox_table_description_string(description):
+    """A helper function that returns a formatted description for BigQuery
+
+    :param str description: A table description
+    :return: A formatted table description
+    :rtype: str
+    """
     return TABLE_DESCRIPTION_STRING.render(description=description)
 
 
@@ -126,6 +143,16 @@ def get_sandbox_options(dataset_name,
                         table_tag,
                         desc,
                         shared_lookup=False):
+    """A function that assembles a BigQuery table options clause from labels and descriptions
+
+    :param str dataset_name: A dataset name
+    :param str class_name: A class name
+    :param str table_tag: A table tag
+    :param str description: A table description
+    :param bool shared_lookup: A boolean that indicates if a table is a shared lookup, defaults to False
+    :return: A BigQuery table options clause 
+    :rtype: str
+    """
     labels_text = get_sandbox_labels_string(dataset_name, class_name, table_tag,
                                             shared_lookup)
     description_text = get_sandbox_table_description_string(desc)

--- a/tests/unit_tests/data_steward/utils/sandbox_test.py
+++ b/tests/unit_tests/data_steward/utils/sandbox_test.py
@@ -45,7 +45,7 @@ class SandboxTest(unittest.TestCase):
         self.assertIn(f'("src_dataset", "{dataset_name}")', actual)
         self.assertIn(f'("class_name", "{class_name}")', actual)
         self.assertIn(f'("table_tag", "{table_tag}")', actual)
-        self.assertIn(f'("shared_lookup", "{shared_lookup}")', actual)
+        self.assertIn(f'("shared_lookup", "true")', actual)
 
         #Test that an empty string argument will throw an error
         empty_class_name = ""
@@ -94,7 +94,7 @@ class SandboxTest(unittest.TestCase):
                 ("src_dataset", "{dataset_name}"),
                 ("class_name", "{class_name}"),
                 ("table_tag", "{table_tag}"),
-                ("shared_lookup", "{shared_lookup}")
+                ("shared_lookup", "true")
             ]
         """
 

--- a/tests/unit_tests/data_steward/utils/sandbox_test.py
+++ b/tests/unit_tests/data_steward/utils/sandbox_test.py
@@ -70,6 +70,11 @@ class SandboxTest(unittest.TestCase):
         actual = sandbox.get_sandbox_table_description_string(description)
         self.assertIn(f'description="{description}"', actual)
 
+        #Test description empty
+        description = "    "
+        with self.assertRaises(ValueError):
+            sandbox.get_sandbox_table_description_string(description)
+
     @patch('utils.sandbox.get_sandbox_labels_string')
     @patch('utils.sandbox.get_sandbox_table_description_string')
     def test_get_sandbox_options(self,

--- a/tests/unit_tests/data_steward/utils/sandbox_test.py
+++ b/tests/unit_tests/data_steward/utils/sandbox_test.py
@@ -19,3 +19,42 @@ class SandboxTest(unittest.TestCase):
         expected = f'{self.table_namer}_{base_name}'
         actual = sandbox.get_sandbox_table_name(self.table_namer, base_name)
         self.assertEqual(expected, actual)
+
+    def test_get_sandbox_labels_string(self):
+        dataset_name = "my_dataset_name"
+        class_name = "my_class_name"
+        table_tag = "my_table_tag"
+        shared_lookup = True
+
+        #Test that standard arguments run without error
+        actual = sandbox.get_sandbox_labels_string(dataset_name,
+                                                   class_name,
+                                                   table_tag,
+                                                   shared_lookup=shared_lookup)
+        self.assertIn(f'("src_dataset", "{dataset_name}")', actual)
+        self.assertIn(f'("class_name", "{class_name}")', actual)
+        self.assertIn(f'("table_tag", "{table_tag}")', actual)
+        self.assertIn(f'("shared_lookup", "{shared_lookup}")', actual)
+
+        #Test that an empty string argument will throw an error
+        empty_class_name = ""
+        with self.assertRaises(ValueError):
+            sandbox.get_sandbox_labels_string(dataset_name,
+                                              empty_class_name,
+                                              table_tag,
+                                              shared_lookup=shared_lookup)
+
+        #Test that a non-boolean shared_lookup argument will throw an error
+        non_bool_shared_lookup = "Yes"
+        with self.assertRaises(ValueError):
+            sandbox.get_sandbox_labels_string(
+                dataset_name,
+                empty_class_name,
+                table_tag,
+                shared_lookup=non_bool_shared_lookup)
+
+    def test_get_sandbox_table_description_string(self):
+        description = "This is a helpful description."
+
+        actual = sandbox.get_sandbox_table_description_string(description)
+        self.assertIn(f'description="{description}"', actual)

--- a/tests/unit_tests/data_steward/utils/sandbox_test.py
+++ b/tests/unit_tests/data_steward/utils/sandbox_test.py
@@ -28,8 +28,7 @@ class SandboxTest(unittest.TestCase):
         self.assertEqual(base_name,
                          sandbox.get_sandbox_table_name('\t', base_name))
         self.assertEqual(base_name,
-                         sandbox.get_sandbox_table_name('\n', base_name))    
-
+                         sandbox.get_sandbox_table_name('\n', base_name))
 
     def test_get_sandbox_labels_string(self):
         dataset_name = "my_dataset_name"


### PR DESCRIPTION
Creates an options clause for defining BigQuery table descriptions and labels.