### PR TITLE
[DC-1394] Too much survey data being suppressed/cleaned

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -78,7 +78,9 @@ from constants.cdr_cleaner.clean_cdr import DataStage
 
 LOGGER = logging.getLogger(__name__)
 
-EHR_CLEANING_CLASSES = [(CleanMappingExtTables,)]
+EHR_CLEANING_CLASSES = [
+    (CleanMappingExtTables,),  # should be one of the last cleaning rules run
+]
 
 UNIONED_EHR_CLEANING_CLASSES = [
     (DeduplicateIdColumn,),
@@ -93,7 +95,7 @@ UNIONED_EHR_CLEANING_CLASSES = [
     (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
     ),
     (invalid_procedure_source.get_remove_invalid_procedure_source_queries,),
-    (CleanMappingExtTables,),
+    (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
 RDR_CLEANING_CLASSES = [
@@ -104,10 +106,10 @@ RDR_CLEANING_CLASSES = [
     (
         FixUnmappedSurveyAnswers,),
     (ObservationSourceConceptIDRowSuppression,),
+    (UpdateFieldsNumbersAsStrings,),
     (maps_to_value_vocab_update.get_maps_to_value_ppi_vocab_update_queries,),
     (back_fill_pmi_skip.get_run_pmi_fix_queries,),
     (CleanPPINumericFieldsUsingParameters,),
-    (NullConceptIDForNumericPPI,),
     (RemoveMultipleRaceEthnicityAnswersQueries,),
     (negative_ppi.get_update_ppi_queries,),
     # trying to load a table while creating query strings,
@@ -130,10 +132,10 @@ RDR_CLEANING_CLASSES = [
         get_update_questions_answers_not_mapped_to_omop,),
     (round_ppi_values.get_round_ppi_values_queries,),
     (update_family_history.get_update_family_history_qa_queries,),
+    (NullConceptIDForNumericPPI,),
     (DropDuplicatePpiQuestionsAndAnswers,),
     (extreme_measurements.get_drop_extreme_measurement_queries,),
     (drop_mult_meas.get_drop_multiple_measurement_queries,),
-    (UpdateFieldsNumbersAsStrings,),
 ]
 
 COMBINED_CLEANING_CLASSES = [
@@ -168,8 +170,8 @@ COMBINED_CLEANING_CLASSES = [
     (remove_aian_participants.get_queries,),
     (validate_missing_participants.delete_records_for_non_matching_participants,
     ),
-    (CleanMappingExtTables,),
-    (TemporalConsistency,)
+    (TemporalConsistency,),
+    (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
 FITBIT_CLEANING_CLASSES = [
@@ -183,7 +185,7 @@ DEID_BASE_CLEANING_CLASSES = [
     (RepopulatePersonPostDeid,),
     (DateShiftCopeResponses,),
     (CreatePersonExtTable,),
-    (CleanMappingExtTables,),
+    (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
 DEID_CLEAN_CLEANING_CLASSES = [
@@ -191,7 +193,7 @@ DEID_CLEAN_CLEANING_CLASSES = [
     (CleanHeightAndWeight,),  # dependent on MeasurementRecordsSuppression
     (UnitNormalization,),  # dependent on CleanHeightAndWeight
     (DropZeroConceptIDs,),
-    (CleanMappingExtTables,)
+    (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
 CONTROLLED_TIER_DEID_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/manual_cleaning_rules/negative_ppi.py
+++ b/data_steward/cdr_cleaner/manual_cleaning_rules/negative_ppi.py
@@ -58,29 +58,11 @@ def get_update_ppi_queries(project_id, dataset_id, sandbox_dataset_id):
     return queries
 
 
-def parse_args():
-    """
-    This function expands the default argument list defined in cdr_cleaner.args_parser
-    :return: an expanded argument list object
-    """
-    import cdr_cleaner.args_parser as parser
-
-    additional_argument = {
-        parser.SHORT_ARGUMENT: '-n',
-        parser.LONG_ARGUMENT: '--sandbox_dataset_id',
-        parser.ACTION: 'store',
-        parser.DEST: 'sandbox_dataset_id',
-        parser.HELP: 'Specify the sandbox_dataset_id',
-        parser.REQUIRED: True
-    }
-    args = parser.default_parse_args([additional_argument])
-    return args
-
-
 if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
     import cdr_cleaner.clean_cdr_engine as clean_engine
 
-    ARGS = parse_args()
+    ARGS = parser.get_argument_parser().parse_args()
 
     if ARGS.list_queries:
         clean_engine.add_console_logging()


### PR DESCRIPTION
This changes the run order of several cleaning rules in the RDR data
stage.  This will fix the issue that caused the smoking data to be
suppressed.

It adds comments to help identify some common expected rule running orders.

It removes some useless code from the manual cleaning rules that prevented
the rules from being run as standalone rules.  They ran fine as part of the
RDR list.