### PR TITLE
[DC-1349] Update registered tier to use questionnaire_response_id remapping cleaning rule.

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -73,6 +73,7 @@ from cdr_cleaner.cleaning_rules.deid.questionnaire_response_id_map import QRIDto
 from cdr_cleaner.cleaning_rules.null_person_birthdate import NullPersonBirthdate
 from cdr_cleaner.cleaning_rules.race_ethnicity_record_suppression import RaceEthnicityRecordSuppression
 from cdr_cleaner.cleaning_rules.table_suppression import TableSuppression
+from cdr_cleaner.cleaning_rules.deid.questionnaire_response_id_map import QRIDtoRID
 from constants.cdr_cleaner import clean_cdr_engine as ce_consts
 from constants.cdr_cleaner.clean_cdr import DataStage
 
@@ -208,6 +209,10 @@ CONTROLLED_TIER_DEID_BASE_CLEANING_CLASSES = []
 
 CONTROLLED_TIER_DEID_CLEAN_CLEANING_CLASSES = []
 
+REGISTERED_TIER_DEID_CLEANING_CLASSES = [
+    (QRIDtoRID,)  # Should run before any row suppression rules
+]
+
 DATA_STAGE_RULES_MAPPING = {
     DataStage.EHR.value:
         EHR_CLEANING_CLASSES,
@@ -229,6 +234,8 @@ DATA_STAGE_RULES_MAPPING = {
         CONTROLLED_TIER_DEID_BASE_CLEANING_CLASSES,
     DataStage.CONTROLLED_TIER_DEID_CLEAN.value:
         CONTROLLED_TIER_DEID_CLEAN_CLEANING_CLASSES,
+    DataStage.REGISTERED_TIER_DEID.value:
+        REGISTERED_TIER_DEID_CLEANING_CLASSES
 }
 
 

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
@@ -71,7 +71,7 @@ class QRIDtoRID(BaseCleaningRule):
                          description=desc,
                          affected_datasets=[
                              cdr_consts.CONTROLLED_TIER_DEID,
-                             cdr_consts.COMBINED
+                             cdr_consts.REGISTERED_TIER_DEID
                          ],
                          affected_tables=OBSERVATION,
                          project_id=project_id,

--- a/data_steward/constants/cdr_cleaner/clean_cdr.py
+++ b/data_steward/constants/cdr_cleaner/clean_cdr.py
@@ -7,9 +7,12 @@ COMBINED = 'combined'
 DEID_BASE = 'deid_base'
 DEID_CLEAN = 'deid_clean'
 FITBIT = 'fitbit'
+
 CONTROLLED_TIER_DEID = 'controlled_tier_deid'
 CONTROLLED_TIER_DEID_BASE = 'controlled_tier_deid_base'
 CONTROLLED_TIER_DEID_CLEAN = 'controlled_tier_deid_clean'
+
+REGISTERED_TIER_DEID = 'registered_tier_died'
 
 BACKUP = 'backup'
 STAGING = 'staging'
@@ -55,6 +58,7 @@ class DataStage(Enum):
     CONTROLLED_TIER_DEID = CONTROLLED_TIER_DEID
     CONTROLLED_TIER_DEID_BASE = CONTROLLED_TIER_DEID_BASE
     CONTROLLED_TIER_DEID_CLEAN = CONTROLLED_TIER_DEID_CLEAN
+    REGISTERED_TIER_DEID = REGISTERED_TIER_DEID
 
     def __str__(self):
         return self.value

--- a/data_steward/tools/deid_runner.sh
+++ b/data_steward/tools/deid_runner.sh
@@ -77,6 +77,7 @@ TOOLS_DIR="${DATA_STEWARD_DIR}/tools"
 DEID_DIR="${DATA_STEWARD_DIR}/deid"
 CLEANER_DIR="${DATA_STEWARD_DIR}/cdr_cleaner"
 HANDOFF_DATE="$(date -v +1d +'%Y-%m-%d')"
+data_stage="deid"
 
 export BIGQUERY_DATASET_ID="${registered_cdr_deid}"
 export PYTHONPATH="${PYTHONPATH}:${DEID_DIR}:${DATA_STEWARD_DIR}"

--- a/data_steward/tools/deid_runner.sh
+++ b/data_steward/tools/deid_runner.sh
@@ -94,7 +94,10 @@ python "${DATA_STEWARD_DIR}/cdm.py" "${registered_cdr_deid}"
 python "${DATA_STEWARD_DIR}/cdm.py" --component vocabulary "${registered_cdr_deid}"
 "${TOOLS_DIR}"/table_copy.sh --source_app_id "${APP_ID}" --target_app_id "${APP_ID}" --source_dataset "${vocab_dataset}" --target_dataset "${registered_cdr_deid}"
 
-# apply deidentification on combined dataset
+# run cleaning_rules on registered tier dataset
+python "${CLEANER_DIR}/clean_cdr.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --data_stage ${data_stage} -s 2>&1 | tee registered_tier_cleaning_log.txt
+
+# apply deidentification on registered tier dataset
 python "${TOOLS_DIR}/run_deid.py" --idataset "${cdr_id}" --private_key "${key_file}" --action submit --interactive --console-log --age_limit "${deid_max_age}" --odataset "${registered_cdr_deid}" 2>&1 | tee deid_run.txt
 
 # create empty sandbox dataset for the deid

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
@@ -50,8 +50,9 @@ class QRIDtoRIDTest(unittest.TestCase):
 
     def test_get_query_spec(self):
         # Pre conditions
-        self.assertEqual(self.rule_instance.affected_datasets,
-                         [cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.REGISTERED_TIER_DEID])
+        self.assertEqual(
+            self.rule_instance.affected_datasets,
+            [cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.REGISTERED_TIER_DEID])
 
         # Test
         result_list = self.rule_instance.get_query_specs()

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
@@ -51,7 +51,7 @@ class QRIDtoRIDTest(unittest.TestCase):
     def test_get_query_spec(self):
         # Pre conditions
         self.assertEqual(self.rule_instance.affected_datasets,
-                         [cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.COMBINED])
+                         [cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.REGISTERED_TIER_DEID])
 
         # Test
         result_list = self.rule_instance.get_query_specs()


### PR DESCRIPTION
* Added a `REGISTERED_TIER_DEID_CLEANING_CLASSES` list
* Added `QRIDtoRID` cleaning rule to the
  `REGISTERED_TIER_DEID_CLEANING_CLASSES` list
* Added the registered tier `DataStage` element
* Added the registered tier rules to the `DATA_STAGE_RULES_MAPPING`
  dictionary
* Added the `REGISTERED_TIER_DEID` constant
* Updated to run registered tier cleaning rules before running deid