### PR TITLE
[DC-1350] Remove registered tier questionnaire_response_id remapping logic

### DIFF
--- a/data_steward/deid/config/ids/config.json
+++ b/data_steward/deid/config/ids/config.json
@@ -202,22 +202,6 @@
         "datetime": "TIMESTAMP_SUB( CAST(:FIELD AS TIMESTAMP), INTERVAL (:SHIFT) DAY) AS :FIELD"
     },
     {
-        "_id": "compute",
-        "id": ["(SELECT research_id FROM :idataset._deid_map WHERE _deid_map.person_id = :value_field) as :FIELD"],
-        "response_id": [
-            "(SELECT ",
-            "CASE WHEN :value_field IS NULL THEN NULL ",
-            "ELSE (",
-                "SELECT dqrm.research_response_id ",
-                "FROM :idataset._deid_questionnaire_response_map AS dqrm ",
-                "WHERE dqrm.questionnaire_response_id = :value_field) ",
-            "END ) AS :FIELD"
-        ],
-        "month": ["EXTRACT (MONTH FROM :value_field) AS :FIELD"],
-        "day": ["EXTRACT (DAY FROM :value_field) AS :FIELD"],
-        "year": ["EXTRACT (YEAR FROM :value_field) AS :FIELD"]
-    },
-    {
         "_id": "dml_statements",
         "comment": [
             "A place to define Data Manipulation Statments to execute after creating ",

--- a/data_steward/deid/config/ids/tables/observation.json
+++ b/data_steward/deid/config/ids/tables/observation.json
@@ -96,15 +96,6 @@
             "copy_to": ["value_as_concept_id"]
          }
     ],
-    "compute": [
-        {
-            "rules": "@compute.response_id",
-            "fields": ["questionnaire_response_id"],
-            "table": ":idataset.deid_questionnaire_response_map as map_response",
-            "key_field": "map_user.questionnaire_response_id",
-            "value_field": "observation.questionnaire_response_id"
-        }
-    ],
     "shift": [
         {"rules": "@shift.date",
          "fields": ["observation_date"]},


### PR DESCRIPTION
Removed original `questionnaire_response_id` remapping rule logic by
* Removing `create_questionnaire_mapping_table` and `map_questionnaire_response_ids` functions from `aou.py`
* Removing any calls to those functions above in `aou.py`
* Removing compute rules in `observation.json` and `config.json`