### PR TITLE
[DC-1431] parameterizing rdr cleaning rule truncation date

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
@@ -82,7 +82,7 @@ class TruncateRdrData(BaseCleaningRule):
                          sandbox_dataset_id=sandbox_dataset_id)
         try:
             self.cutoff_date = validate_date_string(truncation_date)
-        except ValueError:
+        except (TypeError, ValueError):
             self.cutoff_date = str(datetime.now().date())
 
     def get_query_specs(self):

--- a/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
@@ -72,7 +72,16 @@ class TruncateRdrData(BaseCleaningRule):
         :params: truncation_date: the last date that should be included in the
             dataset
         """
-        desc = 'All rows of data in the August RDR export with dates after 08/01/2020 will be truncated.'
+        try:
+            # set to provided date string if the date string is valid
+            self.cutoff_date = validate_date_string(truncation_date)
+        except (TypeError, ValueError):
+            # otherwise, default to using todays date as the date string
+            self.cutoff_date = str(datetime.now().date())
+
+        desc = (f'All rows of data in the RDR export with dates after '
+                f'{self.cutoff_date} will be truncated.')
+
         super().__init__(issue_numbers=['DC1009'],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],
@@ -80,10 +89,6 @@ class TruncateRdrData(BaseCleaningRule):
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id)
-        try:
-            self.cutoff_date = validate_date_string(truncation_date)
-        except (TypeError, ValueError):
-            self.cutoff_date = str(datetime.now().date())
 
     def get_query_specs(self):
         """
@@ -156,7 +161,11 @@ def validate_date_string(date_string):
     """
     Validates the date string is a valid date in the YYYY-MM-DD format.
 
+    If the string is valid, it returns the string.  Otherwise, it raises either
+    a ValueError or TypeError.
+
     :param date_string: The string to validate
+
     :return:  a valid date string
     :raises:  A ValueError if the date string is not a valid date or
         doesn't conform to the specified format.

--- a/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
@@ -9,6 +9,7 @@ All rows of data in the August RDR export with dates after 08/01/2020 should be 
 """
 
 # Python imports
+from datetime import datetime
 import logging
 
 # Project imports
@@ -29,8 +30,6 @@ TABLES_DATES_FIELDS = {
     common.MEASUREMENT: 'measurement_date',
     common.PROCEDURE_OCCURRENCE: 'procedure_date'
 }
-
-CUTOFF_DATE = '2020-08-01'
 
 # Query to create tables in sandbox with the rows that will be removed per cleaning rule
 SANDBOX_QUERY = common.JINJA_ENV.from_string("""
@@ -58,13 +57,20 @@ class TruncateRdrData(BaseCleaningRule):
     sandboxed dataset prior to use of the RDR export to create the CDR
     """
 
-    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 truncation_date=None):
         """
         Initialize the class with proper information.
 
         Set the issue numbers, description and affected datasets. As other tickets may affect
         this SQL, append them to the list of Jira Issues.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+
+        :params: truncation_date: the last date that should be included in the
+            dataset
         """
         desc = 'All rows of data in the August RDR export with dates after 08/01/2020 will be truncated.'
         super().__init__(issue_numbers=['DC1009'],
@@ -74,6 +80,10 @@ class TruncateRdrData(BaseCleaningRule):
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id)
+        try:
+            self.cutoff_date = validate_date_string(truncation_date)
+        except ValueError:
+            self.cutoff_date = str(datetime.now().date())
 
     def get_query_specs(self):
         """
@@ -98,7 +108,7 @@ class TruncateRdrData(BaseCleaningRule):
                         [counter],
                         table_name=table,
                         field_name=TABLES_DATES_FIELDS[table],
-                        cutoff_date=CUTOFF_DATE)
+                        cutoff_date=self.cutoff_date)
             }
 
             sandbox_queries.append(save_changed_rows)
@@ -109,7 +119,7 @@ class TruncateRdrData(BaseCleaningRule):
                                          dataset=self.dataset_id,
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=CUTOFF_DATE),
+                                         cutoff_date=self.cutoff_date),
             }
 
             truncate_queries.append(truncate_query)
@@ -142,22 +152,48 @@ class TruncateRdrData(BaseCleaningRule):
         return sandbox_tables
 
 
+def validate_date_string(date_string):
+    """
+    Validates the date string is a valid date in the YYYY-MM-DD format.
+
+    :param date_string: The string to validate
+    :return:  a valid date string
+    :raises:  A ValueError if the date string is not a valid date or
+        doesn't conform to the specified format.
+    """
+    datetime.strptime(date_string, '%Y-%m-%d')
+    return date_string
+
+
 if __name__ == '__main__':
     import cdr_cleaner.args_parser as parser
     import cdr_cleaner.clean_cdr_engine as clean_engine
 
-    ARGS = parser.parse_args()
+    ext_parser = parser.get_argument_parser()
+    ext_parser.add_argument(
+        '--truncation_date',
+        dest='cutoff_date',
+        action='store',
+        help=('Cutoff date for data based on <table_name>_date fields.  '
+              'Should be in the form YYYY-MM-DD.'),
+        required=True,
+        type=validate_date_string,
+    )
+    ARGS = ext_parser.parse_args()
 
     if ARGS.list_queries:
         clean_engine.add_console_logging()
         query_list = clean_engine.get_query_list(ARGS.project_id,
                                                  ARGS.dataset_id,
                                                  ARGS.sandbox_dataset_id,
-                                                 [(TruncateRdrData,)])
+                                                 [(TruncateRdrData,)],
+                                                 cutoff_date=ARGS.cutoff_date)
         for query in query_list:
             LOGGER.info(query)
     else:
         clean_engine.add_console_logging(ARGS.console_log)
-        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+        clean_engine.clean_dataset(ARGS.project_id,
+                                   ARGS.dataset_id,
                                    ARGS.sandbox_dataset_id,
-                                   [(TruncateRdrData,)])
+                                   ARGS.cutoff_date, [(TruncateRdrData,)],
+                                   cutoff_date=ARGS.cutoff_date)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date_test.py
@@ -1,9 +1,11 @@
 # Python imports
+from datetime import datetime
 import unittest
 
 # Project imports
 from cdr_cleaner.cleaning_rules.truncate_rdr_using_date import (
-    TruncateRdrData, TABLES_DATES_FIELDS, SANDBOX_QUERY, TRUNCATE_ROWS)
+    TruncateRdrData, TABLES_DATES_FIELDS, SANDBOX_QUERY, TRUNCATE_ROWS,
+    validate_date_string)
 from constants.cdr_cleaner import clean_cdr as clean_consts
 
 
@@ -21,6 +23,7 @@ class TruncateRdrDataTest(unittest.TestCase):
         self.sandbox_id = 'baz_sandbox'
 
         self.cutoff_date = '2021-01-01'
+        self.today = str(datetime.now().date())
 
         self.rule_instance = TruncateRdrData(self.project_id, self.dataset_id,
                                              self.sandbox_id)
@@ -51,7 +54,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          get_sandbox_tablenames()[counter],
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=self.cutoff_date)
+                                         cutoff_date=self.today)
             }
 
             sandbox_queries.append(save_changed_rows)
@@ -62,7 +65,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          dataset=self.dataset_id,
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=self.cutoff_date),
+                                         cutoff_date=self.today),
             }
 
             truncate_queries.append(truncate_query)
@@ -71,6 +74,14 @@ class TruncateRdrDataTest(unittest.TestCase):
         expected_list = sandbox_queries + truncate_queries
 
         self.assertEqual(results_list, expected_list)
+
+    def test_validate_date_string(self):
+        self.assertRaises(TypeError, validate_date_string, None)
+        self.assertRaises(TypeError, validate_date_string, 18)
+        self.assertRaises(ValueError, validate_date_string, '01-11-2019')
+
+        self.assertEqual(validate_date_string(self.cutoff_date),
+                         self.cutoff_date)
 
     def test_log_queries(self):
         # Pre conditions
@@ -90,7 +101,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          get_sandbox_tablenames()[counter],
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=self.cutoff_date)
+                                         cutoff_date=self.today)
             }
 
             sandbox_queries.append(
@@ -103,7 +114,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          dataset=self.dataset_id,
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=self.cutoff_date),
+                                         cutoff_date=self.today),
             }
 
             truncate_queries.append(

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date_test.py
@@ -3,8 +3,7 @@ import unittest
 
 # Project imports
 from cdr_cleaner.cleaning_rules.truncate_rdr_using_date import (
-    TruncateRdrData, TABLES_DATES_FIELDS, CUTOFF_DATE, SANDBOX_QUERY,
-    TRUNCATE_ROWS)
+    TruncateRdrData, TABLES_DATES_FIELDS, SANDBOX_QUERY, TRUNCATE_ROWS)
 from constants.cdr_cleaner import clean_cdr as clean_consts
 
 
@@ -20,6 +19,8 @@ class TruncateRdrDataTest(unittest.TestCase):
         self.project_id = 'foo_project'
         self.dataset_id = 'bar_dataset'
         self.sandbox_id = 'baz_sandbox'
+
+        self.cutoff_date = '2021-01-01'
 
         self.rule_instance = TruncateRdrData(self.project_id, self.dataset_id,
                                              self.sandbox_id)
@@ -50,7 +51,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          get_sandbox_tablenames()[counter],
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=CUTOFF_DATE)
+                                         cutoff_date=self.cutoff_date)
             }
 
             sandbox_queries.append(save_changed_rows)
@@ -61,7 +62,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          dataset=self.dataset_id,
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=CUTOFF_DATE),
+                                         cutoff_date=self.cutoff_date),
             }
 
             truncate_queries.append(truncate_query)
@@ -89,7 +90,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          get_sandbox_tablenames()[counter],
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=CUTOFF_DATE)
+                                         cutoff_date=self.cutoff_date)
             }
 
             sandbox_queries.append(
@@ -102,7 +103,7 @@ class TruncateRdrDataTest(unittest.TestCase):
                                          dataset=self.dataset_id,
                                          table_name=table,
                                          field_name=TABLES_DATES_FIELDS[table],
-                                         cutoff_date=CUTOFF_DATE),
+                                         cutoff_date=self.cutoff_date),
             }
 
             truncate_queries.append(


### PR DESCRIPTION
 * updates the cleaning rule to parameterize the cutoff date
 * updates the bash script to accept a truncation date parameter without requiring the parameter.
 * if not provided, the cleaning rule defaults to using today's date as the truncation date
 * default is implemented in the rule to take the business logic out of the bash script
 * will default correctly if None is the argument value
 * adding unit test to validate the date string