### PR TITLE
[DC-1354] Confirm removal of free standing generate_ext_tables python script

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/README.md
+++ b/data_steward/cdr_cleaner/cleaning_rules/README.md
@@ -33,7 +33,7 @@ clean_cdr.py --data_stage FITBIT
              --dataset_id fitbit
              --sandbox_dataset_id fitbit_sandbox
 
-MissingParameterError: the parameter 'mapping_dataset_id' required by generate_ext_tables, RemoveFitbitDataIfMaxAgeExceeded, PIDtoRID FitbitDateShift was not supplied. No cleaning rules have been applied.
+MissingParameterError: the parameter 'mapping_dataset_id' required by RemoveFitbitDataIfMaxAgeExceeded, PIDtoRID FitbitDateShift was not supplied. No cleaning rules have been applied.
 ```
 
 ## Configuration dependencies
@@ -67,16 +67,14 @@ Depending on the rule(s) being applied, additional configuration parameters may 
 | [tablename](#)[^2] | |
 [^2]: these parameters defined in remove_ehr_data_past_deactivation_date will probably be refactored
 ### mapping_dataset_id
- - generate_ext_tables [^3] : creates and loads `_site_mappings` table in this dataset
  - RemoveFitbitDataIfMaxAgeExceeded
  - PIDtoRID
- - FitbitDateShift 
-[^3]: The cleaning rule `generate_ext_tables` does not conform to many conventions and we eventually intend to refactor it
+ - FitbitDateShift
 ### mapping_table_id
  - PIDtoRID
  - FitbitDateShift
 ### combined_dataset_id
- - generate_ext_tables: creates `{domain_table}_ext` using `_mapping{_domain_table}`  and `_site_mappings`
+
 ### ehr_dataset_id
  - remove_non_matching_participant (optional)
 ### validation_dataset_id

--- a/data_steward/cdr_cleaner/cleaning_rules/README.md
+++ b/data_steward/cdr_cleaner/cleaning_rules/README.md
@@ -33,7 +33,7 @@ clean_cdr.py --data_stage FITBIT
              --dataset_id fitbit
              --sandbox_dataset_id fitbit_sandbox
 
-MissingParameterError: the parameter 'mapping_dataset_id' required by RemoveFitbitDataIfMaxAgeExceeded, PIDtoRID FitbitDateShift was not supplied. No cleaning rules have been applied.
+MissingParameterError: the parameter 'mapping_dataset_id' required by GenerateSiteMappingsAndExtTables, RemoveFitbitDataIfMaxAgeExceeded, PIDtoRID FitbitDateShift was not supplied. No cleaning rules have been applied.
 ```
 
 ## Configuration dependencies
@@ -73,8 +73,6 @@ Depending on the rule(s) being applied, additional configuration parameters may 
 ### mapping_table_id
  - PIDtoRID
  - FitbitDateShift
-### combined_dataset_id
-
 ### ehr_dataset_id
  - remove_non_matching_participant (optional)
 ### validation_dataset_id

--- a/data_steward/tools/deid_runner.sh
+++ b/data_steward/tools/deid_runner.sh
@@ -104,9 +104,6 @@ python "${TOOLS_DIR}/run_deid.py" --idataset "${cdr_id}" --private_key "${key_fi
 # create empty sandbox dataset for the deid
 bq mk --dataset --description "${version} sandbox dataset to apply cleaning rules on ${registered_cdr_deid}" --label "phase:sandbox" --label "release_tag:${dataset_release_tag}" --label "de_identified:true" "${APP_ID}":"${registered_cdr_deid_sandbox}"
 
-# generate ext tables in deid dataset
-python "${TOOLS_DIR}/generate_ext_tables.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --mapping_dataset_id "${cdr_id}" -s 2>&1 | tee generate_ext_tables.txt
-
 # update the observation_ext table with survey_version info.  should become a formal cleaning rule in the future.
 python "${CLEANER_DIR}/manual_cleaning_rules/survey_version_info.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --mapping_dataset "${cdr_id}" --cope_survey_dataset "${cope_survey_dataset}" --cope_survey_table "${cope_survey_table_name}" -s 2>&1 | tee survey_versioning.txt
 


### PR DESCRIPTION
* removed bash script invocation in `deid_runner`
* Updated `cleaning_rules/README.md` and removed mentions of `generate_ext_tables.py`