### PR TITLE
[DC-1387] Free Text survey response record suppression

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -81,6 +81,7 @@ from cdr_cleaner.cleaning_rules.race_ethnicity_record_suppression import RaceEth
 from cdr_cleaner.cleaning_rules.table_suppression import TableSuppression
 from cdr_cleaner.cleaning_rules.deid.questionnaire_response_id_map import QRIDtoRID
 from cdr_cleaner.cleaning_rules.generalize_zip_codes import GeneralizeZipCodes
+from cdr_cleaner.cleaning_rules.free_text_survey_response_suppression import FreeTextSurveyResponseSuppression
 from cdr_cleaner.cleaning_rules.cancer_concept_suppression import CancerConceptSuppression
 from constants.cdr_cleaner import clean_cdr_engine as ce_consts
 from constants.cdr_cleaner.clean_cdr import DataStage
@@ -214,7 +215,9 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (TableSuppression,),
     (GeneralizeZipCodes,),  # Should run after any data remapping rules
     (RaceEthnicityRecordSuppression,
-    ),  # Should run after any data remapping rules,
+    ),  # Should run after any data remapping rules
+    (FreeTextSurveyResponseSuppression,
+    ),  # Should run after any data remapping rules
     (MotorVehicleAccidentSuppression,),
     (ExplicitIdentifierSuppression,),
     (BirthInformationSuppression,),

--- a/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
@@ -70,7 +70,7 @@ class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression
         query_job = client.query(concept_suppression_lookup_query)
         result = query_job.result()
 
-        if hasattr(result, 'errors') and result.errors:
+        if query_job.errors or query_job.error_result:
             LOGGER.error(f"Error running job {result.job_id}: {result.errors}")
             raise GoogleCloudError(
                 f"Error running job {result.job_id}: {result.errors}")

--- a/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
@@ -42,7 +42,8 @@ class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression
         this SQL, append them to the list of Jira Issues.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
-        desc = 'Sandbox and record suppress any records containing concepts related to free text responses'
+        desc = (f'Sandbox and record suppress any records containing '
+                f'concepts related to free text responses')
         super().__init__(
             issue_numbers=['DC1387'],
             description=desc,

--- a/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
@@ -1,0 +1,108 @@
+"""
+To ensure participant privacy, remove any records containing concepts related to free text responses
+
+Original Issue: DC-1387
+"""
+
+# Python imports
+import logging
+from abc import ABC
+
+from google.cloud.exceptions import GoogleCloudError
+
+# Project imports
+from utils import pipeline_logging
+from common import JINJA_ENV, OBSERVATION
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.deid.concept_suppression import AbstractBqLookupTableConceptSuppression
+
+LOGGER = logging.getLogger(__name__)
+
+SUPPRESSION_RULE_CONCEPT_TABLE = 'free_text_suppression_concept'
+
+FREE_TEXT_CONCEPT_QUERY = JINJA_ENV.from_string("""
+-- This query generates a lookup table that contains all the suppressed concepts relating to  --
+-- free text generated using REGEX --
+CREATE OR REPLACE TABLE `{{project_id}}.{{dataset_id}}.{{concept_suppression_table}}` AS
+(SELECT * FROM `{{project_id}}.{{dataset_id}}.concept`
+WHERE REGEXP_CONTAINS(concept_code, r'(FreeText)|(TextBox)') OR concept_code = 'notes')
+""")
+
+
+class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression):
+    """
+    Any record in the observation table with a free text concept should be sandboxed and suppressed
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper information.
+
+        Set the issue numbers, description and affected datasets. As other tickets may affect
+        this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = 'Sandbox and record suppress any records containing concepts related to free text responses'
+        super().__init__(issue_numbers=['DC1387'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID],
+                         affected_tables=OBSERVATION,
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         concept_suppression_lookup_table=SUPPRESSION_RULE_CONCEPT_TABLE)
+
+    def create_suppression_lookup_table(self, client):
+        """
+
+        :param client:
+        :return:
+
+        raises google.cloud.exceptions.GoogleCloudError if a QueryJob fails
+        """
+        concept_suppression_lookup_query = FREE_TEXT_CONCEPT_QUERY.render(
+            project_id=self.project_id,
+            dataset_id=self.dataset_id,
+            sandbox_dataset=self.sandbox_dataset_id,
+            concept_suppression_table=self.concept_suppression_lookup_table)
+        query_job = client.query(concept_suppression_lookup_query)
+        result = query_job.result()
+
+        if hasattr(result, 'errors') and result.errors:
+            LOGGER.error(f"Error running job {result.job_id}: {result.errors}")
+            raise GoogleCloudError(
+                f"Error running job {result.job_id}: {result.errors}")
+
+    def setup_validation(self, client, *args, **keyword_args):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client, *args, **keyword_args):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.parse_args()
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(
+            ARGS.project_id, ARGS.dataset_id, ARGS.sandbox_dataset_id,
+            [(FreeTextSurveyResponseSuppression,)])
+
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(FreeTextSurveyResponseSuppression,)])

--- a/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
@@ -6,7 +6,6 @@ Original Issue: DC-1387
 
 # Python imports
 import logging
-from abc import ABC
 
 from google.cloud.exceptions import GoogleCloudError
 
@@ -23,13 +22,14 @@ SUPPRESSION_RULE_CONCEPT_TABLE = 'free_text_suppression_concept'
 FREE_TEXT_CONCEPT_QUERY = JINJA_ENV.from_string("""
 -- This query generates a lookup table that contains all the suppressed concepts relating to  --
 -- free text generated using REGEX --
-CREATE OR REPLACE TABLE `{{project_id}}.{{dataset_id}}.{{concept_suppression_table}}` AS
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset}}.{{concept_suppression_table}}` AS
 (SELECT * FROM `{{project_id}}.{{dataset_id}}.concept`
 WHERE REGEXP_CONTAINS(concept_code, r'(FreeText)|(TextBox)') OR concept_code = 'notes')
 """)
 
 
-class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression):
+class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression
+                                       ):
     """
     Any record in the observation table with a free text concept should be sandboxed and suppressed
     """
@@ -43,14 +43,15 @@ class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression)
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
         desc = 'Sandbox and record suppress any records containing concepts related to free text responses'
-        super().__init__(issue_numbers=['DC1387'],
-                         description=desc,
-                         affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID],
-                         affected_tables=OBSERVATION,
-                         project_id=project_id,
-                         dataset_id=dataset_id,
-                         sandbox_dataset_id=sandbox_dataset_id,
-                         concept_suppression_lookup_table=SUPPRESSION_RULE_CONCEPT_TABLE)
+        super().__init__(
+            issue_numbers=['DC1387'],
+            description=desc,
+            affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID],
+            affected_tables=[OBSERVATION],
+            project_id=project_id,
+            dataset_id=dataset_id,
+            sandbox_dataset_id=sandbox_dataset_id,
+            concept_suppression_lookup_table=SUPPRESSION_RULE_CONCEPT_TABLE)
 
     def create_suppression_lookup_table(self, client):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
@@ -75,9 +75,12 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
         fq_dataset_name = self.fq_table_names[0].split('.')
         self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
 
+        fq_sandbox_name = self.fq_sandbox_table_names[0].split('.')
+        self.fq_sandbox_name = '.'.join(fq_sandbox_name[:-1])
+
         super().setUp()
 
-    def test_generalize_zip_codes_cleaning(self):
+    def test_free_text_suppression_cleaning(self):
         """
         Tests that the specifications for FREE_TEXT_RECORD_SUPPRESSION query perform as designed.
 
@@ -188,7 +191,7 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
             'fq_table_name':
                 f'{self.fq_dataset_name}.observation',
             'fq_sandbox_table_name':
-                f'{self.fq_sandbox_table_names}.{self.rule_instance.sandbox_table_for(OBSERVATION)}',
+                f'{self.fq_sandbox_name}.{self.rule_instance.sandbox_table_for(OBSERVATION)}',
             'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9],
             'sandboxed_ids': [1, 2, 3, 4, 5, 6, 7],
             'fields': [

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
@@ -101,7 +101,7 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
                     >>
             [(111, 'Something Text Box', 'Observation', 'SNOWMED', 'Context-dependent', 'WhiteFreeText', 
                     '2016-05-01', '2016-05-02'),
-                (222, 'Something Free Text', 'Observation', 'SNOWMED', 'Context-dependent', 'BlackFreeText', 
+                (222, 'TextBox', 'Observation', 'SNOWMED', 'Context-dependent', 'BlackFreeText', 
                     '2016-05-01', '2016-05-02'),
                 (333, 'None Of These', 'Observation', 'SNOWMED', 'Context-dependent', 'notes', 
                     '2016-05-01', '2016-05-02'),

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
@@ -1,0 +1,207 @@
+"""
+Integration test for the free_text_survey_response_suppression module
+
+Original Issue: DC-1387
+
+Ensures participant privacy by removing any records containing concepts related to free text responses
+"""
+
+# Python imports
+import os
+
+# Third party imports
+from dateutil import parser
+
+# Project imports
+from common import OBSERVATION
+from app_identity import PROJECT_ID
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+from cdr_cleaner.cleaning_rules.free_text_survey_response_suppression import FreeTextSurveyResponseSuppression,\
+    SUPPRESSION_RULE_CONCEPT_TABLE
+
+
+class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # set the expected test datasets
+        dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        cls.rule_instance = FreeTextSurveyResponseSuppression(
+            project_id, dataset_id, sandbox_id)
+
+        cls.fq_table_names = [
+            f'{project_id}.{dataset_id}.{OBSERVATION}',
+        ]
+
+        for table_name in [OBSERVATION]:
+            sandbox_table_name = cls.rule_instance.sandbox_table_for(table_name)
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
+
+        # Add SUPPRESSION_RULE_CONCEPT_TABLE to fq_sandbox_table_names so it gets deleted after
+        # the test
+        cls.fq_sandbox_table_names.append(
+            f'{cls.project_id}.{cls.sandbox_id}.{SUPPRESSION_RULE_CONCEPT_TABLE}'
+        )
+
+        # call super to set up the client, create datasets
+        cls.up_class = super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and a common
+        fully qualified (fq) dataset name string used to load the data.
+        """
+        self.valid_start_date = parser.parse('2016-05-01').date()
+        self.valid_end_date = parser.parse('2016-05-02').date()
+        self.observation_date = parser.parse('2017-05-02').date()
+
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+        super().setUp()
+
+    def test_generalize_zip_codes_cleaning(self):
+        """
+        Tests that the specifications for FREE_TEXT_RECORD_SUPPRESSION query perform as designed.
+
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+
+        concept_table_tmpl = self.jinja_env.from_string("""
+            DROP TABLE IF EXISTS `{{fq_dataset_name}}.concept`;
+            CREATE TABLE `{{fq_dataset_name}}.concept` 
+            AS (
+            WITH w AS (
+                SELECT ARRAY<STRUCT<
+                    concept_id INT64,
+                    concept_name STRING,
+                    domain_id STRING,
+                    vocabulary_id STRING,
+                    concept_class_id STRING,
+                    concept_code STRING,
+                    valid_start_date STRING,
+                    valid_end_date STRING
+                    >>
+            [(111, 'Something Text Box', 'Observation', 'SNOWMED', 'Context-dependent', 'WhiteFreeText', 
+                    '2016-05-01', '2016-05-02'),
+                (222, 'Something Free Text', 'Observation', 'SNOWMED', 'Context-dependent', 'BlackFreeText', 
+                    '2016-05-01', '2016-05-02'),
+                (333, 'None Of These', 'Observation', 'SNOWMED', 'Context-dependent', 'notes', 
+                    '2016-05-01', '2016-05-02'),
+                (444, 'Will Not Be Dropped', 'Observation', 'SNOWMED', 'Context-dependent', '0036T',
+                    '2016-05-01', '2016-05-02'),
+                (555, 'Will Not Be Dropped', 'Observation', 'SNOWMED', 'Context-dependent', '46938', 
+                    '2016-05-01', '2016-05-02')] col
+            )
+            SELECT
+                concept_id,
+                concept_name,
+                domain_id,
+                vocabulary_id,
+                concept_class_id,
+                concept_code,
+                valid_start_date,
+                valid_end_date
+            FROM w, UNNEST(w.col))
+        """)
+
+        observation_table_tmpl = self.jinja_env.from_string("""
+            DROP TABLE IF EXISTS `{{fq_dataset_name}}.observation`;
+            CREATE TABLE `{{fq_dataset_name}}.observation`
+            AS (
+            WITH w AS (
+                SELECT ARRAY<STRUCT<
+                    observation_id INT64,
+                    person_id INT64,
+                    observation_concept_id INT64,
+                    observation_date DATE,
+                    observation_type_concept_id INT64,
+                    value_as_concept_id INT64,
+                    qualifier_concept_id INT64,
+                    unit_concept_id INT64,
+                    observation_source_concept_id INT64,
+                    value_source_concept_id INT64
+                    >>
+                [-- observation_concept_id corresponds to a free text value and record will be dropped --
+                    (1, 2, 111, date('2017-05-02'), 0, 0, 0, 0, 0, 0),
+                -- observation_type_concept_id corresponds to a free text value and record will be dropped --
+                    (2, 3, 0, date('2017-05-02'), 222, 0, 0, 0, 0, 0),
+                -- value_as_concept_id corresponds to a free text value and record will be dropped --
+                    (3, 4, 0, date('2017-05-02'), 0, 333, 0, 0, 0, 0),
+                -- qualifier_concept_id corresponds to a free text value and record will be dropped --
+                    (4, 5, 0, date('2017-05-02'), 0, 0, 111, 0, 0, 0),
+                -- unit_concept_id corresponds to a free text value and record will be dropped --
+                    (5, 6, 0, date('2017-05-02'), 0, 0, 0, 222, 0, 0),
+                -- observation_source_concept_id corresponds to a free text value and record will be dropped --
+                    (6, 7, 0, date('2017-05-02'), 0, 0, 0, 0, 333, 0),
+                -- value_source_concept_id corresponds to a free text value and record will be dropped --
+                    (7, 8, 0, date('2017-05-02'), 0, 0, 0, 0, 0, 111),
+                -- all valid *_concept_id, no records will dropped --
+                    (8, 9, 444, date('2017-05-02'), 444, 444, 444, 444, 444, 444),
+                    (9, 10, 555, date('2017-05-02'), 555, 555, 555, 555, 555, 555)] col
+            )
+            SELECT
+                observation_id,
+                person_id,
+                observation_concept_id,
+                observation_date,
+                observation_type_concept_id,
+                value_as_concept_id,
+                qualifier_concept_id,
+                unit_concept_id,
+                observation_source_concept_id,
+                value_source_concept_id
+            FROM w, UNNEST(w.col))
+        """)
+
+        insert_concept_query = concept_table_tmpl.render(
+            fq_dataset_name=self.fq_dataset_name)
+        insert_observation_query = observation_table_tmpl.render(
+            fq_dataset_name=self.fq_dataset_name)
+
+        # Load test data
+        self.load_test_data([
+            f'''{insert_concept_query};
+                                 {insert_observation_query};'''
+        ])
+
+        # Expected results list
+        tables_and_counts = [{
+            'fq_table_name':
+                f'{self.fq_dataset_name}.observation',
+            'fq_sandbox_table_name':
+                f'{self.fq_sandbox_table_names}.{self.rule_instance.sandbox_table_for(OBSERVATION)}',
+            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            'sandboxed_ids': [1, 2, 3, 4, 5, 6, 7],
+            'fields': [
+                'observation_id', 'person_id', 'observation_concept_id',
+                'observation_date', 'observation_type_concept_id',
+                'value_as_concept_id', 'qualifier_concept_id',
+                'unit_concept_id', 'observation_source_concept_id',
+                'value_source_concept_id'
+            ],
+            'cleaned_values': [(8, 9, 444, self.observation_date, 444, 444, 444,
+                                444, 444, 444),
+                               (9, 10, 555, self.observation_date, 555, 555,
+                                555, 555, 555, 555)]
+        }]
+
+        self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
@@ -68,8 +68,6 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
         Creates common expected parameter types from cleaned tables and a common
         fully qualified (fq) dataset name string used to load the data.
         """
-        self.valid_start_date = parser.parse('2016-05-01').date()
-        self.valid_end_date = parser.parse('2016-05-02').date()
         self.observation_date = parser.parse('2017-05-02').date()
 
         fq_dataset_name = self.fq_table_names[0].split('.')
@@ -82,8 +80,6 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
 
     def test_free_text_suppression_cleaning(self):
         """
-        Tests that the specifications for FREE_TEXT_RECORD_SUPPRESSION query perform as designed.
-
         Validates pre conditions, tests execution, and post conditions based on the load
         statements and the tables_and_counts variable.
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
@@ -101,7 +101,7 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
                     >>
             [(111, 'Something Text Box', 'Observation', 'SNOWMED', 'Context-dependent', 'WhiteFreeText', 
                     '2016-05-01', '2016-05-02'),
-                (222, 'TextBox', 'Observation', 'SNOWMED', 'Context-dependent', 'BlackFreeText', 
+                (222, 'Text Box', 'Observation', 'SNOWMED', 'Context-dependent', 'ATextBox', 
                     '2016-05-01', '2016-05-02'),
                 (333, 'None Of These', 'Observation', 'SNOWMED', 'Context-dependent', 'notes', 
                     '2016-05-01', '2016-05-02'),


### PR DESCRIPTION
* created `free_text_survey_response_suppression.py` to sandbox and record suppress any records with a concept id associated with a free text value by extending the `AbstractBqLookupTableConceptSuppression` class
* added `FreeTextSurveyResponseSuppression` to pipeline
* integration test