### PR TITLE
[DC-1445] Enforce Data cutoff of ehr submissions

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -106,7 +106,8 @@ UNIONED_EHR_CLEANING_CLASSES = [
     # setup_query_execution function to load dependencies before query execution
     (
         populate_routes.get_route_mapping_queries,),
-    (EhrSubmissionDataCutoff,), # should run before EnsureDateDatetimeConsistency
+    (EhrSubmissionDataCutoff,
+    ),  # should run before EnsureDateDatetimeConsistency
     (EnsureDateDatetimeConsistency,),
     (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
     ),

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -68,6 +68,7 @@ from cdr_cleaner.cleaning_rules.deid.birth_information_suppression import \
     BirthInformationSuppression
 from cdr_cleaner.cleaning_rules.replace_standard_id_in_domain_tables import \
     ReplaceWithStandardConceptId
+from cdr_cleaner.cleaning_rules.ehr_submission_data_cutoff import EhrSubmissionDataCutoff
 from cdr_cleaner.cleaning_rules.repopulate_person_post_deid import RepopulatePersonPostDeid
 from cdr_cleaner.cleaning_rules.truncate_rdr_using_date import TruncateRdrData
 from cdr_cleaner.cleaning_rules.unit_normalization import UnitNormalization
@@ -105,6 +106,7 @@ UNIONED_EHR_CLEANING_CLASSES = [
     # setup_query_execution function to load dependencies before query execution
     (
         populate_routes.get_route_mapping_queries,),
+    (EhrSubmissionDataCutoff,), # should run before EnsureDateDatetimeConsistency
     (EnsureDateDatetimeConsistency,),
     (remove_records_with_wrong_date.get_remove_records_with_wrong_date_queries,
     ),

--- a/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
@@ -26,7 +26,7 @@ CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{intermediary_table}}` A
 SELECT * FROM `{{project_id}}.{{dataset_id}}.{{cdm_table}}`
 WHERE 
     (coalesce({{date_fields}}) < DATE("{{cutoff_date}}")) 
-    AND coalesce({{datetime_fields}}) < TIMESTAMP("{{cutoff_date}}")))
+    AND coalesce({{datetime_fields}}) < TIMESTAMP("{{cutoff_date}}"))
 """)
 
 DATE_CUTOFF_QUERY = JINJA_ENV.from_string("""

--- a/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
@@ -53,7 +53,7 @@ class EhrSubmissionDataCutoff(BaseCleaningRule):
         this SQL, append them to the list of Jira Issues.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
 
-        :params: truncation_date: the last date that should be included in the
+        :params: cutoff_date: the last date that should be included in the
             dataset
         """
         try:
@@ -181,7 +181,7 @@ class EhrSubmissionDataCutoff(BaseCleaningRule):
     def get_sandbox_tablenames(self):
         sandbox_tables = []
         for table in self.affected_tables:
-            sandbox_tables.append(f'{self._issue_numbers[0].lower()}_{table}')
+            sandbox_tables.append(self.sandbox_table_for(table))
         return sandbox_tables
 
 

--- a/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
@@ -153,7 +153,8 @@ class EhrSubmissionDataCutoff(BaseCleaningRule):
                     cdr_consts.DESTINATION_DATASET:
                         self.dataset_id,
                     cdr_consts.DISPOSITION:
-                        bq_consts.WRITE_TRUNCATE}
+                        bq_consts.WRITE_TRUNCATE
+                }
 
                 queries_list.append(date_cutoff_query)
 

--- a/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
@@ -1,0 +1,239 @@
+"""
+Enforces a data cutoff date for PPI data.
+
+Original Issue: DC-1445
+
+Intent is to enforce the data cutoff date for PPI data in all CDM tables excluding the person table by sandboxing and
+    removing any records that persist after the data cutoff date.
+"""
+
+# Python imports
+import logging
+from datetime import datetime
+
+# Project imports
+from common import JINJA_ENV
+from utils import pipeline_logging
+from constants import bq_utils as bq_consts
+from resources import fields_for, CDM_TABLES
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+
+LOGGER = logging.getLogger(__name__)
+
+SANDBOX_QUERY = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{intermediary_table}}` AS (
+SELECT * FROM `{{project_id}}.{{dataset_id}}.{{cdm_table}}`
+WHERE 
+    (coalesce({{date_fields}}) < DATE("{{cutoff_date}}")) 
+    AND coalesce({{datetime_fields}}) < TIMESTAMP("{{cutoff_date}}")))
+""")
+
+DATE_CUTOFF_QUERY = JINJA_ENV.from_string("""
+SELECT * FROM `{{project_id}}.{{dataset_id}}.{{cdm_table}}` cdm
+EXCEPT DISTINCT
+SELECT * FROM `{{project_id}}.{{sandbox_id}}.{{intermediary_table}}`
+""")
+
+
+class EhrSubmissionDataCutoff(BaseCleaningRule):
+    """
+    All rows of data in the RDR ETL with dates after the cutoff date should be sandboxed and dropped
+    """
+
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 cutoff_date=None):
+        """
+        Initialize the class with proper information.
+
+        Set the issue numbers, description and affected datasets. As other tickets may affect
+        this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+
+        :params: truncation_date: the last date that should be included in the
+            dataset
+        """
+        try:
+            # set to provided date string if the date string is valid
+            self.cutoff_date = validate_date_string(cutoff_date)
+        except (TypeError, ValueError):
+            # otherwise, default to using today's date as the date string
+            self.cutoff_date = str(datetime.now().date())
+
+        desc = (f'All rows of data in the RDR ETL with dates after '
+                f'{self.cutoff_date} will be sandboxed and dropped.')
+
+        super().__init__(issue_numbers=['DC1445'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.UNIONED],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_affected_tables(self):
+        """
+        This method gets all the tables that are affected by this cleaning rule which are all the CDM tables
+            except for the person table. The birth date field in the person table will be cleaned in another
+            cleaning rule where all participants under the age of 18 will be dropped. Ignoring this table will
+            optimize this cleaning rule's runtime.
+
+        :return: list of affected tables
+        """
+        tables = []
+        for table in CDM_TABLES:
+
+            # skips the person table
+            if table == 'person':
+                continue
+
+            # appends all CDM tables except for the person table
+            else:
+                tables.append(table)
+        return tables
+
+    def get_query_specs(self, *args, **keyword_args):
+        """
+        Return a list of dictionary query specifications.
+
+        :return:  A list of dictionaries. Each dictionary contains a single query
+            and a specification for how to execute that query. The specifications
+            are optional but the query is required.
+        """
+
+        queries_list = []
+        sandbox_queries_list = []
+
+        for table in self.get_affected_tables():
+            # gets all fields from the affected table
+            fields = fields_for(table)
+
+            date_fields = []
+            datetime_fields = []
+
+            for field in fields:
+                # appends only the date columns to the date_fields list
+                if field['type'] in ['date']:
+                    date_fields.append(field['name'])
+
+                # appends only the datetime columns to the datetime_fields list
+                if field['type'] in ['timestamp']:
+                    datetime_fields.append(field['name'])
+
+            # will render the queries only if a CDM table contains a date or datetime field
+            # will ignore the CDM tables that do not have a date or datetime field
+            if date_fields or datetime_fields:
+                sandbox_query = {
+                    cdr_consts.QUERY:
+                        SANDBOX_QUERY.render(
+                            project_id=self.project_id,
+                            sandbox_id=self.sandbox_dataset_id,
+                            intermediary_table=self.sandbox_table_for(table),
+                            dataset_id=self.dataset_id,
+                            cdm_table=table,
+                            date_fields=(", ".join(date_fields)),
+                            datetime_fields=(", ".join(datetime_fields)),
+                            cutoff_date=self.cutoff_date),
+                }
+
+                sandbox_queries_list.append(sandbox_query)
+
+                date_cutoff_query = {
+                    cdr_consts.QUERY:
+                        DATE_CUTOFF_QUERY.render(
+                            project_id=self.project_id,
+                            dataset_id=self.dataset_id,
+                            cdm_table=table,
+                            sandbox_id=self.sandbox_dataset_id,
+                            intermediary_table=self.sandbox_table_for(table)),
+                    cdr_consts.DESTINATION_TABLE:
+                        table,
+                    cdr_consts.DESTINATION_DATASET:
+                        self.dataset_id,
+                    cdr_consts.DISPOSITION:
+                        bq_consts.WRITE_TRUNCATE}
+
+                queries_list.append(date_cutoff_query)
+
+        return sandbox_queries_list + queries_list
+
+    def setup_rule(self, client):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def setup_validation(self, client):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def get_sandbox_tablenames(self):
+        sandbox_tables = []
+        for table in self.affected_tables:
+            sandbox_tables.append(f'{self._issue_numbers[0].lower()}_{table}')
+        return sandbox_tables
+
+
+def validate_date_string(date_string):
+    """
+    Validates the date string is a valid date in the YYYY-MM-DD format.
+
+    If the string is valid, it returns the string.  Otherwise, it raises either
+    a ValueError or TypeError.
+
+    :param date_string: The string to validate
+
+    :return:  a valid date string
+    :raises:  A ValueError if the date string is not a valid date or
+        doesn't conform to the specified format.
+    """
+    datetime.strptime(date_string, '%Y-%m-%d')
+    return date_string
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ext_parser = parser.get_argument_parser()
+    ext_parser.add_argument(
+        '--cutoff_date',
+        dest='cutoff_date',
+        action='store',
+        help=
+        ('Cutoff date for data based on <table_name>_date and <table_name>_datetime fields.  '
+         'Should be in the form YYYY-MM-DD.'),
+        required=True,
+        type=validate_date_string,
+    )
+
+    ARGS = ext_parser.parse_args()
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(ARGS.project_id,
+                                                 ARGS.dataset_id,
+                                                 ARGS.sandbox_dataset_id,
+                                                 [(EhrSubmissionDataCutoff,)],
+                                                 cutoff_date=ARGS.cutoff_date)
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id,
+                                   ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   ARGS.cutoff_date,
+                                   [(EhrSubmissionDataCutoff,)],
+                                   cutoff_date=ARGS.cutoff_date)

--- a/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff.py
@@ -25,8 +25,9 @@ SANDBOX_QUERY = JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{intermediary_table}}` AS (
 SELECT * FROM `{{project_id}}.{{dataset_id}}.{{cdm_table}}`
 WHERE 
-    (coalesce({{date_fields}}) < DATE("{{cutoff_date}}")) 
-    AND coalesce({{datetime_fields}}) < TIMESTAMP("{{cutoff_date}}"))
+    ((GREATEST({{date_fields}}) IS NOT NULL) AND (GREATEST({{date_fields}}) < DATE("{{cutoff_date}}"))) AND
+    ((GREATEST({{datetime_fields}}) IS NOT NULL) AND (GREATEST({{datetime_fields}}) < TIMESTAMP("{{cutoff_date}}")))
+)
 """)
 
 DATE_CUTOFF_QUERY = JINJA_ENV.from_string("""

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -1,0 +1,163 @@
+"""
+Integration test for the cleaning_rules.ehr_submission_data_cutoff.py module
+
+Original Issue: DC-1445
+
+Intent of this integration test is to ensure that the data cutoff for the PPI data in all CDM tables is enforced by
+ sandboxing and removing any records that persist after the data cutoff date.
+"""
+
+# Python imports
+import os
+from dateutil.parser import parse
+
+# Project imports
+import common
+from app_identity import PROJECT_ID
+from constants import bq_utils as bq_consts
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.ehr_submission_data_cutoff import EhrSubmissionDataCutoff
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+tables = ['visit_occurrence', 'person']
+
+
+class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # set the expected test datasets
+        dataset_id = os.environ.get('UNIONED_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        # provides the cutoff_date argument
+        cutoff_date = "2020-05-01"
+        cls.kwargs.update({'cutoff_date': cutoff_date})
+
+        cls.rule_instance = EhrSubmissionDataCutoff(project_id, dataset_id,
+                                                    sandbox_id)
+
+        for table_name in tables:
+            sandbox_table_name = cls.rule_instance.sandbox_table_for(table_name)
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
+            cls.fq_table_names.append(
+                f'{cls.project_id}.{dataset_id}.{table_name}')
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and a common
+        fully qualified (fq) dataset name string used to load the data.
+        """
+
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+        fq_sandbox_name = self.fq_sandbox_table_names[0].split('.')
+        self.fq_sandbox_name = '.'.join(fq_sandbox_name[:-1])
+
+        super().setUp()
+
+    def test_ehr_submission_data_cutoff(self):
+        """
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+
+        queries = []
+
+        visit_occurrence_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{fq_dataset_name}}.{{cdm_table}}`
+            (visit_occurrence_id, person_id, visit_concept_id, visit_start_date, 
+                visit_start_datetime, visit_end_date, visit_end_datetime, visit_type_concept_id)
+            VALUES
+            (111, 222, 3, date('2018-03-06'), timestamp('2018-03-06 11:00:00'), 
+                date('2018-03-07'), timestamp('2018-03-07 11:00:00'), 4),
+            (222, 333, 3, date('2019-03-06'), timestamp('2019-03-06 11:00:00'), 
+                date('2019-03-07'), timestamp('2019-03-07 11:00:00'), 4),
+            (333, 444, 3, date('2020-03-06'), timestamp('2020-03-06 11:00:00'), 
+                date('2020-03-07'), timestamp('2020-03-07 11:00:00'), 4),
+            (444, 555, 3, date('2021-03-06'), timestamp('2021-03-06 11:00:00'), 
+                date('2021-03-07'), timestamp('2021-03-07 11:00:00'), 4),
+            (555, 666, 3, date('2022-03-06'), timestamp('2022-03-06 11:00:00'), 
+                date('2022-03-07'), timestamp('2022-03-07 11:00:00'), 4)
+            """).render(fq_dataset_name=self.fq_dataset_name,
+                        cdm_table=common.VISIT_OCCURRENCE)
+        queries.append(visit_occurrence_tmpl)
+
+        # Because the perosn table is not being cleaned in this cleaning rule, all of these values
+        # will be returned, nothing will be sandboxed and dropped
+        person_tmpl = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}.{{cdm_table}}`
+        (person_id, gender_concept_id, year_of_birth, 
+            birth_datetime, race_concept_id, ethnicity_concept_id)
+        VALUES
+        (111, 2, 2018, timestamp('2018-03-06 11:00:00'), 3, 4),
+        (222, 2, 2019, timestamp('2019-03-06 11:00:00'), 3, 4),
+        (333, 2, 2020, timestamp('2020-03-06 11:00:00'), 3, 4),
+        (444, 2, 2021, timestamp('2021-03-06 11:00:00'), 3, 4),
+        (555, 2, 2022, timestamp('2022-03-06 11:00:00'), 3, 4)
+        """).render(fq_dataset_name=self.fq_dataset_name,
+                    cdm_table=common.PERSON)
+        queries.append(person_tmpl)
+
+        self.load_test_data(queries)
+
+        table_and_counts = [{
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, 'visit_occurrence']),
+            'fq_sandbox_table_name':
+                f'{self.fq_sandbox_name}.{self.rule_instance.sandbox_table_for(common.VISIT_OCCURRENCE)}',
+            'loaded_ids': [111, 222, 333, 444, 555],
+            'sandboxed_ids': [111, 222, 333],
+            'fields': [
+                'visit_occurrence_id', 'person_id', 'visit_occurrence_id',
+                'visit_start_date', 'visit_start_datetime', 'visit_end_date',
+                'visit_end_datetime', 'visit_type_concept_id'
+            ],
+            'cleaned_values': [
+                (444, 555, parse('2021-03-06').date(),
+                 parse('2021-03-06 11:00:00'), parse('2021-03-07').date(),
+                 parse('2021-03-07 11:00:00'), 4),
+                (555, 666, 3, parse('2022-03-06').date(),
+                 parse('2022-03-06 11:00:00'), parse('2022-03-07').date,
+                 parse('2022-03-07 11:00:00'), 4)
+            ]
+        }, {
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, 'person']),
+            'fq_sandbox_table_name':
+                f'{self.fq_sandbox_name}.{self.rule_instance.sandbox_table_for(common.PERSON)}',
+            'loaded_ids': [111, 222, 333, 444, 555],
+            'sandboxed_ids': [],
+            'fields': [
+                'person_id', 'gender_concept_id', 'year_of_birth',
+                'birth_datetime', 'race_concept_id', 'ethnicity_concept_id'
+            ],
+            'cleaned_values': [
+                (111, 2, 2018, parse('2018-03-06 11:00:00'), 3, 4),
+                (222, 2, 2019, parse('2019-03-06 11:00:00'), 3, 4),
+                (333, 2, 2020, parse('2020-03-06 11:00:00'), 3, 4),
+                (444, 2, 2021, parse('2021-03-06 11:00:00'), 3, 4),
+                (555, 2, 2022, parse('2022-03-06 11:00:00'), 3, 4)
+            ]
+        }]

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -51,7 +51,8 @@ class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
             cls.fq_sandbox_table_names.append(
                 f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
 
-        cls.fq_table_names.append(f'{cls.project_id}.{cls.dataset_id}.{common.VISIT_OCCURRENCE}')
+        cls.fq_table_names.append(
+            f'{cls.project_id}.{cls.dataset_id}.{common.VISIT_OCCURRENCE}')
 
         # call super to set up the client, create datasets, and create
         # empty test tables

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -9,17 +9,14 @@ Intent of this integration test is to ensure that the data cutoff for the PPI da
 
 # Python imports
 import os
+from mock import patch
 from dateutil.parser import parse
 
 # Project imports
 import common
 from app_identity import PROJECT_ID
-from constants import bq_utils as bq_consts
-from constants.cdr_cleaner import clean_cdr as cdr_consts
 from cdr_cleaner.cleaning_rules.ehr_submission_data_cutoff import EhrSubmissionDataCutoff
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
-
-tables = ['visit_occurrence', 'person']
 
 
 class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
@@ -49,12 +46,12 @@ class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
         cls.rule_instance = EhrSubmissionDataCutoff(project_id, dataset_id,
                                                     sandbox_id)
 
-        for table_name in tables:
+        for table_name in common.VISIT_OCCURRENCE:
             sandbox_table_name = cls.rule_instance.sandbox_table_for(table_name)
             cls.fq_sandbox_table_names.append(
                 f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
-            cls.fq_table_names.append(
-                f'{cls.project_id}.{dataset_id}.{table_name}')
+
+        cls.fq_table_names.append(f'{cls.project_id}.{cls.dataset_id}.{common.VISIT_OCCURRENCE}')
 
         # call super to set up the client, create datasets, and create
         # empty test tables
@@ -77,14 +74,17 @@ class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
 
         super().setUp()
 
-    def test_ehr_submission_data_cutoff(self):
+    @patch.object(EhrSubmissionDataCutoff, 'get_affected_tables')
+    def test_ehr_submission_data_cutoff(self, mock_get_affected_tables):
         """
         Validates pre conditions, tests execution, and post conditions based on the load
         statements and the tables_and_counts variable.
         """
+        # mocks the return value of get_affected_tables as we only want to loop through the
+        # visit_occurrence not all of the CDM tables
+        mock_get_affected_tables.return_value = [common.VISIT_OCCURRENCE]
 
         queries = []
-
         visit_occurrence_tmpl = self.jinja_env.from_string("""
             INSERT INTO `{{fq_dataset_name}}.{{cdm_table}}`
             (visit_occurrence_id, person_id, visit_concept_id, visit_start_date, 
@@ -104,22 +104,6 @@ class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
                         cdm_table=common.VISIT_OCCURRENCE)
         queries.append(visit_occurrence_tmpl)
 
-        # Because the perosn table is not being cleaned in this cleaning rule, all of these values
-        # will be returned, nothing will be sandboxed and dropped
-        person_tmpl = self.jinja_env.from_string("""
-        INSERT INTO `{{fq_dataset_name}}.{{cdm_table}}`
-        (person_id, gender_concept_id, year_of_birth, 
-            birth_datetime, race_concept_id, ethnicity_concept_id)
-        VALUES
-        (111, 2, 2018, timestamp('2018-03-06 11:00:00'), 3, 4),
-        (222, 2, 2019, timestamp('2019-03-06 11:00:00'), 3, 4),
-        (333, 2, 2020, timestamp('2020-03-06 11:00:00'), 3, 4),
-        (444, 2, 2021, timestamp('2021-03-06 11:00:00'), 3, 4),
-        (555, 2, 2022, timestamp('2022-03-06 11:00:00'), 3, 4)
-        """).render(fq_dataset_name=self.fq_dataset_name,
-                    cdm_table=common.PERSON)
-        queries.append(person_tmpl)
-
         self.load_test_data(queries)
 
         table_and_counts = [{
@@ -130,34 +114,18 @@ class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [111, 222, 333, 444, 555],
             'sandboxed_ids': [111, 222, 333],
             'fields': [
-                'visit_occurrence_id', 'person_id', 'visit_occurrence_id',
+                'visit_occurrence_id', 'person_id', 'visit_concept_id',
                 'visit_start_date', 'visit_start_datetime', 'visit_end_date',
                 'visit_end_datetime', 'visit_type_concept_id'
             ],
             'cleaned_values': [
-                (444, 555, parse('2021-03-06').date(),
-                 parse('2021-03-06 11:00:00'), parse('2021-03-07').date(),
-                 parse('2021-03-07 11:00:00'), 4),
+                (444, 555, 3, parse('2021-03-06').date(),
+                 parse('2021-03-06 11:00:00 UTC'), parse('2021-03-07').date(),
+                 parse('2021-03-07 11:00:00 UTC'), 4),
                 (555, 666, 3, parse('2022-03-06').date(),
-                 parse('2022-03-06 11:00:00'), parse('2022-03-07').date,
-                 parse('2022-03-07 11:00:00'), 4)
-            ]
-        }, {
-            'fq_table_name':
-                '.'.join([self.fq_dataset_name, 'person']),
-            'fq_sandbox_table_name':
-                f'{self.fq_sandbox_name}.{self.rule_instance.sandbox_table_for(common.PERSON)}',
-            'loaded_ids': [111, 222, 333, 444, 555],
-            'sandboxed_ids': [],
-            'fields': [
-                'person_id', 'gender_concept_id', 'year_of_birth',
-                'birth_datetime', 'race_concept_id', 'ethnicity_concept_id'
-            ],
-            'cleaned_values': [
-                (111, 2, 2018, parse('2018-03-06 11:00:00'), 3, 4),
-                (222, 2, 2019, parse('2019-03-06 11:00:00'), 3, 4),
-                (333, 2, 2020, parse('2020-03-06 11:00:00'), 3, 4),
-                (444, 2, 2021, parse('2021-03-06 11:00:00'), 3, 4),
-                (555, 2, 2022, parse('2022-03-06 11:00:00'), 3, 4)
+                 parse('2022-03-06 11:00:00 UTC'), parse('2022-03-07').date(),
+                 parse('2022-03-07 11:00:00 UTC'), 4)
             ]
         }]
+
+        self.default_test(table_and_counts)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -50,27 +50,6 @@ class EhrSubmissionDataCutoffTest(unittest.TestCase):
 
         # No errors are raised, nothing will happen
 
-    def test_get_affected_tables(self):
-        """
-        Will test that the affected tables generated do no include the person table
-        """
-        # Pre conditions
-        expected_tables = [
-            'observation_period', 'visit_cost', 'drug_cost',
-            'procedure_occurrence', 'payer_plan_period', 'device_cost',
-            'device_exposure', 'procedure_cost', 'source_to_concept_map',
-            'observation', 'location', 'cohort', 'cost', 'death',
-            'drug_exposure', 'measurement', 'condition_era', 'note',
-            'cohort_definition', 'dose_era', 'care_site', 'fact_relationship',
-            'cohort_attribute', 'provider', 'condition_occurrence',
-            'cdm_source', 'attribute_definition', 'visit_occurrence',
-            'drug_era', 'specimen', 'cope_survey_semantic_version_map'
-        ]
-
-        actual_tables = self.rule_instance.get_affected_tables()
-
-        self.assertEqual(expected_tables, actual_tables)
-
     @patch.object(data_cutoff.EhrSubmissionDataCutoff, 'get_affected_tables')
     def test_get_query_specs(self, mock_get_affected_tables):
         # Pre conditions

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -1,0 +1,120 @@
+"""
+Unit test for the cleaning_rules.ehr_submission_data_cutoff.py module
+
+Original Issue: DC-1445
+
+Intent of this unit test is to ensure that the data cutoff for the PPI data in all CDM tables is enforced by sandboxing
+ and removing any records that persist after the data cutoff date.
+"""
+
+# Python imports
+import unittest
+from mock import patch
+from datetime import datetime
+
+# Project imports
+import common
+from constants import bq_utils as bq_consts
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+import cdr_cleaner.cleaning_rules.ehr_submission_data_cutoff as data_cutoff
+
+
+class EhrSubmissionDataCutoffTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'foo_project'
+        self.dataset_id = 'bar_dataset'
+        self.sandbox_id = 'baz_sandbox'
+        self.client = None
+
+        self.date_fields = ['visit_start_date', 'visit_end_date']
+        self.datetime_fields = ['visit_start_datetime', 'visit_end_datetime']
+        self.cutoff_date = str(datetime.now().date())
+
+        self.rule_instance = data_cutoff.EhrSubmissionDataCutoff(
+            self.project_id, self.dataset_id, self.sandbox_id)
+
+        self.assertEqual(self.rule_instance.project_id, self.project_id)
+        self.assertEqual(self.rule_instance.dataset_id, self.dataset_id)
+        self.assertEqual(self.rule_instance.sandbox_dataset_id, self.sandbox_id)
+
+    def test_setup_rule(self):
+        # Test
+        self.rule_instance.setup_rule(self.client)
+
+        # No errors are raised, nothing will happen
+
+    def test_get_affected_tables(self):
+        """
+        Will test that the affected tables generated do no include the person table
+        """
+        # Pre conditions
+        expected_tables = [
+            'observation_period', 'visit_cost', 'drug_cost',
+            'procedure_occurrence', 'payer_plan_period', 'device_cost',
+            'device_exposure', 'procedure_cost', 'source_to_concept_map',
+            'observation', 'location', 'cohort', 'cost', 'death',
+            'drug_exposure', 'measurement', 'condition_era', 'note',
+            'cohort_definition', 'dose_era', 'care_site', 'fact_relationship',
+            'cohort_attribute', 'provider', 'condition_occurrence',
+            'cdm_source', 'attribute_definition', 'visit_occurrence',
+            'drug_era', 'specimen', 'cope_survey_semantic_version_map'
+        ]
+
+        actual_tables = self.rule_instance.get_affected_tables()
+
+        self.assertEqual(expected_tables, actual_tables)
+
+    @patch.object(data_cutoff.EhrSubmissionDataCutoff, 'get_affected_tables')
+    def test_get_query_specs(self, mock_get_affected_tables):
+        # Pre conditions
+        mock_get_affected_tables.return_value = [common.VISIT_OCCURRENCE]
+
+        table = common.VISIT_OCCURRENCE
+
+        sandbox_query = {
+            cdr_consts.QUERY:
+                data_cutoff.SANDBOX_QUERY.render(
+                    project_id=self.project_id,
+                    sandbox_id=self.sandbox_id,
+                    intermediary_table=self.rule_instance.sandbox_table_for(table),
+                    dataset_id=self.dataset_id,
+                    cdm_table=table,
+                    date_fields=(", ".join(self.date_fields)),
+                    datetime_fields=(", ".join(self.datetime_fields)),
+                    cutoff_date=self.cutoff_date),
+        }
+
+        date_cutoff_query = {
+            cdr_consts.QUERY:
+                data_cutoff.DATE_CUTOFF_QUERY.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    cdm_table=table,
+                    sandbox_id=self.sandbox_id,
+                    intermediary_table=self.rule_instance.sandbox_table_for(table)),
+            cdr_consts.DESTINATION_TABLE:
+                table,
+            cdr_consts.DESTINATION_DATASET:
+                self.dataset_id,
+            cdr_consts.DISPOSITION:
+                bq_consts.WRITE_TRUNCATE
+        }
+
+        expected_list = [sandbox_query] + [date_cutoff_query]
+
+        # Test
+        results_list = self.rule_instance.get_query_specs()
+
+        # Post conditions
+        self.assertEqual(results_list, expected_list)
+
+
+
+

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -83,7 +83,8 @@ class EhrSubmissionDataCutoffTest(unittest.TestCase):
                 data_cutoff.SANDBOX_QUERY.render(
                     project_id=self.project_id,
                     sandbox_id=self.sandbox_id,
-                    intermediary_table=self.rule_instance.sandbox_table_for(table),
+                    intermediary_table=self.rule_instance.sandbox_table_for(
+                        table),
                     dataset_id=self.dataset_id,
                     cdm_table=table,
                     date_fields=(", ".join(self.date_fields)),
@@ -98,7 +99,8 @@ class EhrSubmissionDataCutoffTest(unittest.TestCase):
                     dataset_id=self.dataset_id,
                     cdm_table=table,
                     sandbox_id=self.sandbox_id,
-                    intermediary_table=self.rule_instance.sandbox_table_for(table)),
+                    intermediary_table=self.rule_instance.sandbox_table_for(
+                        table)),
             cdr_consts.DESTINATION_TABLE:
                 table,
             cdr_consts.DESTINATION_DATASET:
@@ -114,7 +116,3 @@ class EhrSubmissionDataCutoffTest(unittest.TestCase):
 
         # Post conditions
         self.assertEqual(results_list, expected_list)
-
-
-
-


### PR DESCRIPTION
* created cleaning rule to sandbox and drop data in OMOP tables by:
** getting all OMOP tables except for person table for cleaning rule
optimization
** only getting the date and datetime fields from those OMOP tables
** sandbox and drop the records that fall after the cutoff date

* integration test
* unit test
* added cleaning rule to the pipeline