### PR TITLE
[DC-542] PMI_PreferNotToAnswer appear as an observation_source_concept_id

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -59,6 +59,7 @@ from cdr_cleaner.cleaning_rules.no_data_30_days_after_death import NoDataAfterDe
 from cdr_cleaner.cleaning_rules.null_concept_ids_for_numeric_ppi import NullConceptIDForNumericPPI
 from cdr_cleaner.cleaning_rules.null_invalid_foreign_keys import NullInvalidForeignKeys
 from cdr_cleaner.cleaning_rules.ppi_branching import PpiBranching
+from cdr_cleaner.cleaning_rules.prefer_not_to_answer_codes_suppression import PreferNotToAnswerSuppression
 from cdr_cleaner.cleaning_rules.rdr_observation_source_concept_id_suppression import (
     ObservationSourceConceptIDRowSuppression)
 from cdr_cleaner.cleaning_rules.remove_multiple_race_ethnicity_answers import RemoveMultipleRaceEthnicityAnswersQueries
@@ -122,6 +123,7 @@ RDR_CLEANING_CLASSES = [
     (
         FixUnmappedSurveyAnswers,),
     (ObservationSourceConceptIDRowSuppression,),
+    (PreferNotToAnswerSuppression,),
     (UpdateFieldsNumbersAsStrings,),
     (maps_to_value_vocab_update.get_maps_to_value_ppi_vocab_update_queries,),
     (back_fill_pmi_skip.get_run_pmi_fix_queries,),

--- a/data_steward/cdr_cleaner/cleaning_rules/prefer_not_to_answer_codes_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/prefer_not_to_answer_codes_suppression.py
@@ -1,0 +1,70 @@
+"""
+Original Issue: DC-524
+
+The intent of this cleaning rule is to sandbox and drop any rows in the observation table where the
+observation_source_concept_id is 903079
+"""
+
+# Python imports
+import logging
+
+# Project imports
+from common import OBSERVATION
+from utils import pipeline_logging
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.deid.concept_suppression import AbstractInMemoryLookupTableConceptSuppression
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PreferNotToAnswerSuppression(AbstractInMemoryLookupTableConceptSuppression
+                                  ):
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper info.
+
+        Set the issue numbers, description and affected datasets.  As other
+        tickets may affect this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = ('Sandbox and record suppress all records with a concept_id '
+                'relating to PMI_PreferNotToAnswer in the observation table. ')
+        super().__init__(issue_numbers=['DC524'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         affected_tables=[OBSERVATION])
+
+    def get_suppressed_concept_ids(self):
+        # https://athena.ohdsi.org/search-terms/terms/903079
+        return [903079]
+
+    def setup_validation(self, client, *args, **keyword_args):
+        pass
+
+    def validate_rule(self, client, *args, **keyword_args):
+        pass
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.default_parse_args()
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(
+            ARGS.project_id, ARGS.dataset_id, ARGS.sandbox_dataset_id,
+            [(PreferNotToAnswerSuppression,)])
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(PreferNotToAnswerSuppression,)])

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/prefer_not_to_answer_codes_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/prefer_not_to_answer_codes_suppression_test.py
@@ -1,0 +1,129 @@
+"""
+Integration test for the prefer_not_to_answer_codes_suppression.py module
+
+Original Issue: DC-524
+
+The intent of this integration test is to ensure that any records that have an observation_source_concept_id of 903079
+    are sandboxed and dropped.
+"""
+
+# Python Imports
+import os
+
+# Third party imports
+from dateutil import parser
+
+# Project Imports
+from common import OBSERVATION
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.prefer_not_to_answer_codes_suppression import PreferNotToAnswerSuppression
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+
+class PreferNotToAnswerSuppressionTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # Set the test project identifier
+        cls.project_id = os.environ.get(PROJECT_ID)
+
+        # Set the expected test datasets
+        cls.dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.sandbox_id = cls.dataset_id + '_sandbox'
+
+        cls.rule_instance = PreferNotToAnswerSuppression(
+            cls.project_id, cls.dataset_id, cls.sandbox_id)
+
+        # Generates list of fully qualified table names
+        for table_name in [OBSERVATION]:
+            cls.fq_table_names.append(
+                f'{cls.project_id}.{cls.dataset_id}.{table_name}')
+            sandbox_table_name = cls.rule_instance.sandbox_table_for(table_name)
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{sandbox_table_name}')
+
+        # call super to set up the client, create datasets
+        cls.up_class = super().setUpClass()
+
+    def setUp(self):
+        """
+        Create empty tables on which the rule will run
+        """
+
+        # Create domain tables required for the test
+        super().setUp()
+
+        # Load the test data
+        observation_tmpl = self.jinja_env.from_string("""
+        DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.observation`;
+        CREATE TABLE `{{project_id}}.{{dataset_id}}.observation`
+        AS (
+        WITH w AS (
+            SELECT ARRAY<STRUCT<
+                observation_id INT64,
+                person_id INT64,
+                observation_concept_id INT64,
+                observation_date DATE,
+                observation_type_concept_id INT64,
+                value_as_concept_id INT64,
+                qualifier_concept_id INT64,
+                unit_concept_id INT64,
+                observation_source_concept_id INT64,
+                value_source_concept_id INT64
+                >>
+              -- Concepts to suppress --
+              -- 903079: PMI Prefer Not To Answer --
+              [(1, 2, 111111, date('2017-05-02'), 111111, 111111, 111111, 111111, 111111, 111111),
+               (2, 3, 222222, date('2017-05-02'), 222222, 222222, 222222, 222222, 903079, 222222),
+               (3, 4, 333333, date('2017-05-02'), 333333, 333333, 333333, 333333, 333333, 333333)] col
+            )
+            SELECT
+                observation_id,
+                person_id,
+                observation_concept_id,
+                observation_date,
+                observation_type_concept_id,
+                value_as_concept_id,
+                qualifier_concept_id,
+                unit_concept_id,
+                observation_source_concept_id,
+                value_source_concept_id
+            FROM w, UNNEST(w.col))
+            """)
+
+        insert_observation_query = observation_tmpl.render(
+            project_id=self.project_id, dataset_id=self.dataset_id)
+
+        # Load the test data
+        self.load_test_data([f'''{insert_observation_query};'''])
+
+    def test_prefer_not_to_answer_code_suppression(self):
+        # Expected results list
+        tables_and_counts = [{
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.observation',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.'
+                f'{self.rule_instance.sandbox_table_for("observation")}',
+            'loaded_ids': [1, 2, 3],
+            'sandboxed_ids': [2],
+            'fields': [
+                'observation_id', 'person_id', 'observation_concept_id',
+                'observation_date', 'observation_type_concept_id',
+                'value_as_concept_id', 'qualifier_concept_id',
+                'unit_concept_id', 'observation_source_concept_id',
+                'value_source_concept_id'
+            ],
+            'cleaned_values': [(1, 2, 111111, parser.parse('2017-05-02').date(),
+                                111111, 111111, 111111, 111111, 111111, 111111),
+                               (3, 4, 333333, parser.parse('2017-05-02').date(),
+                                333333, 333333, 333333, 333333, 333333, 333333)]
+        }]
+
+        self.default_test(tables_and_counts)


### PR DESCRIPTION
* Suppresses any records in the `observation` table with an `observation_source_concept_id` as `903079`
* Integration test
* Added cleaning rule to the pipeline