### PR TITLE
[DC-1478] Remove deactivated participants script fails for tables without datetime fields

### DIFF
--- a/data_steward/retraction/retract_deactivated_pids.py
+++ b/data_steward/retraction/retract_deactivated_pids.py
@@ -26,7 +26,7 @@ FROM `{{project}}.{{dataset}}.INFORMATION_SCHEMA.COLUMNS`
 
 # Queries to create tables in associated sandbox with rows that will be removed per cleaning rule
 SANDBOX_QUERY = JINJA_ENV.from_string("""
-CREATE TABLE `{{sandbox_ref.project}}.{{sandbox_ref.dataset_id}}.{{sandbox_ref.table_id}}` AS (
+CREATE OR REPLACE TABLE `{{sandbox_ref.project}}.{{sandbox_ref.dataset_id}}.{{sandbox_ref.table_id}}` AS (
 SELECT t.*
 FROM `{{table_ref.project}}.{{table_ref.dataset_id}}.{{table_ref.table_id}}` t
 
@@ -59,6 +59,8 @@ OR verbatim_end_date >= d.deactivated_date)
 {% endif %}
 {% elif table_ref.table_id == 'death' %}
 WHERE COALESCE(death_date, EXTRACT(DATE FROM death_datetime)) >= d.deactivated_date
+{% elif table_ref.table_id in ['drug_era', 'condition_era', 'dose_era', 'payer_plan_period']  %}
+AND COALESCE({{table_ref.table_id + '_end_date'}}, {{table_ref.table_id + '_start_date'}}) >= d.deactivated_date
 {% else %}
 AND COALESCE({{date}}, EXTRACT(DATE FROM {{datetime}})) >= d.deactivated_date
 {% endif %})

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -127,8 +127,8 @@ def get_datasets_list(project_id, dataset_ids_list):
     dataset_ids = [
         dataset_id for dataset_id in dataset_ids
         if get_dataset_type(dataset_id) != common.OTHER and
-        not is_sandbox_dataset(dataset_id) and
-        not is_staging_dataset(dataset_id)
+        not is_sandbox_dataset(dataset_id)
+        # and not is_staging_dataset(dataset_id)
     ]
 
     LOGGER.info(f"Found datasets to retract from: {', '.join(dataset_ids)}")

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -128,7 +128,6 @@ def get_datasets_list(project_id, dataset_ids_list):
         dataset_id for dataset_id in dataset_ids
         if get_dataset_type(dataset_id) != common.OTHER and
         not is_sandbox_dataset(dataset_id)
-        # and not is_staging_dataset(dataset_id)
     ]
 
     LOGGER.info(f"Found datasets to retract from: {', '.join(dataset_ids)}")


### PR DESCRIPTION
 Fix the retract utils script works with staging dataset and add a condition on fields that are missing end_datetime

Signed-off-by: Krishna Kalluri <krishnasaikalluri@gmail.com>