### PR TITLE
[DC-1479] EHR data cutoff invalid query for tables without datetime fields

### DIFF
--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -113,19 +113,22 @@ class EhrSubmissionDataCutoffTest(BaseTest.CleaningRulesTestBase):
             'fq_sandbox_table_name':
                 f'{self.fq_sandbox_name}.{self.rule_instance.sandbox_table_for(common.VISIT_OCCURRENCE)}',
             'loaded_ids': [111, 222, 333, 444, 555],
-            'sandboxed_ids': [111, 222, 333],
+            'sandboxed_ids': [444, 555],
             'fields': [
                 'visit_occurrence_id', 'person_id', 'visit_concept_id',
                 'visit_start_date', 'visit_start_datetime', 'visit_end_date',
                 'visit_end_datetime', 'visit_type_concept_id'
             ],
             'cleaned_values': [
-                (444, 555, 3, parse('2021-03-06').date(),
-                 parse('2021-03-06 11:00:00 UTC'), parse('2021-03-07').date(),
-                 parse('2021-03-07 11:00:00 UTC'), 4),
-                (555, 666, 3, parse('2022-03-06').date(),
-                 parse('2022-03-06 11:00:00 UTC'), parse('2022-03-07').date(),
-                 parse('2022-03-07 11:00:00 UTC'), 4)
+                (111, 222, 3, parse('2018-03-06').date(),
+                 parse('2018-03-06 11:00:00 UTC'), parse('2018-03-07').date(),
+                 parse('2018-03-07 11:00:00 UTC'), 4),
+                (222, 333, 3, parse('2019-03-06').date(),
+                 parse('2019-03-06 11:00:00 UTC'), parse('2019-03-07').date(),
+                 parse('2019-03-07 11:00:00 UTC'), 4),
+                (333, 444, 3, parse('2020-03-06').date(),
+                 parse('2020-03-06 11:00:00 UTC'), parse('2020-03-07').date(),
+                 parse('2020-03-07 11:00:00 UTC'), 4)
             ]
         }]
 

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ehr_submission_data_cutoff_test.py
@@ -34,7 +34,15 @@ class EhrSubmissionDataCutoffTest(unittest.TestCase):
         self.client = None
 
         self.date_fields = ['visit_start_date', 'visit_end_date']
+        self.updated_date_fields = [
+            f'COALESCE({field}, DATE("1900-01-01"))'
+            for field in self.date_fields
+        ]
         self.datetime_fields = ['visit_start_datetime', 'visit_end_datetime']
+        self.updated_datetime_fields = [
+            f'COALESCE({field}, TIMESTAMP("1900-01-01"))'
+            for field in self.datetime_fields
+        ]
         self.cutoff_date = str(datetime.now().date())
 
         self.rule_instance = data_cutoff.EhrSubmissionDataCutoff(
@@ -66,8 +74,8 @@ class EhrSubmissionDataCutoffTest(unittest.TestCase):
                         table),
                     dataset_id=self.dataset_id,
                     cdm_table=table,
-                    date_fields=(", ".join(self.date_fields)),
-                    datetime_fields=(", ".join(self.datetime_fields)),
+                    date_fields=(", ".join(self.updated_date_fields)),
+                    datetime_fields=(", ".join(self.updated_datetime_fields)),
                     cutoff_date=self.cutoff_date),
         }
 


### PR DESCRIPTION
Fix submission cutoff date comparison by using '1900-01-01' for null values

Signed-off-by: Krishna Kalluri <krishnasaikalluri@gmail.com>