### PR TITLE
[DC-1487] Fixes for remove_non_matching_participant

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/remove_non_matching_participant.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_non_matching_participant.py
@@ -158,11 +158,10 @@ def get_non_match_participant_query(project_id, validation_dataset_id,
     return select_non_match_participants_query
 
 
-def delete_records_for_non_matching_participants(project_id,
-                                                 dataset_id,
-                                                 sandbox_dataset_id=None,
-                                                 ehr_dataset_id=None,
-                                                 validation_dataset_id=None):
+def delete_records_for_non_matching_participants(project_id, dataset_id,
+                                                 sandbox_dataset_id,
+                                                 ehr_dataset_id,
+                                                 validation_dataset_id):
     """
     This function generates the queries that delete participants and their corresponding data points, for which the 
     participant_match data is missing and DRC matching algorithm flags it as a no match 
@@ -178,10 +177,14 @@ def delete_records_for_non_matching_participants(project_id,
     """
 
     if ehr_dataset_id is None:
-        ehr_dataset_id = bq_utils.get_unioned_dataset_id()
+        raise RuntimeError(
+            'Required parameter ehr_dataset_id not'
+            'set in delete_records_for_non_matching_participants')
 
     if validation_dataset_id is None:
-        validation_dataset_id = bq.get_latest_validation_dataset_id(project_id)
+        raise RuntimeError(
+            'Required parameter validation_dataset_id not'
+            'set in delete_records_for_non_matching_participants')
 
     non_matching_person_ids = []
 
@@ -208,7 +211,7 @@ def delete_records_for_non_matching_participants(project_id,
             .format(person_ids=non_matching_person_ids,
                     combined_dataset_id=dataset_id))
 
-        queries.append(
+        queries.extend(
             remove_pids.get_sandbox_queries(project_id, dataset_id,
                                             non_matching_person_ids,
                                             TICKET_NUMBER))

--- a/data_steward/tools/generate_combined_dataset.sh
+++ b/data_steward/tools/generate_combined_dataset.sh
@@ -8,6 +8,7 @@ Usage: generate_combined_dataset.sh
   --vocab_dataset <vocab dataset>
   --unioned_ehr_dataset <unioned dataset>
   --rdr_dataset <RDR dataset>
+  --ehr_dataset <EHR dataset>
   --validation_dataset <Validation dataset ID>
   --dataset_release_tag <release tag for the CDR>
   --ehr_cutoff <ehr_cut_off date format yyyy-mm-dd>
@@ -22,6 +23,10 @@ while true; do
     ;;
   --unioned_ehr_dataset)
     unioned_ehr_dataset=$2
+    shift 2
+    ;;
+  --ehr_dataset)
+    ehr_dataset=$2
     shift 2
     ;;
   --vocab_dataset)
@@ -56,7 +61,7 @@ while true; do
   esac
 done
 
-if [[ -z "${key_file}" ]] || [[ -z "${unioned_ehr_dataset}" ]] || [[ -z "${vocab_dataset}" ]] || [[ -z "${rdr_dataset}" ]] || [[ -z "${validation_dataset}" ]] || [[ -z "${dataset_release_tag}" ]] || [[ -z "${ehr_cutoff}" ]] || [[ -z "${rdr_export_date}" ]]; then
+if [[ -z "${key_file}" ]] || [[ -z "${unioned_ehr_dataset}" ]] || [[ -z "${ehr_dataset}" ]] || [[ -z "${vocab_dataset}" ]] || [[ -z "${rdr_dataset}" ]] || [[ -z "${validation_dataset}" ]] || [[ -z "${dataset_release_tag}" ]] || [[ -z "${ehr_cutoff}" ]] || [[ -z "${rdr_export_date}" ]]; then
   echo "$USAGE"
   exit 1
 fi
@@ -139,7 +144,7 @@ export BIGQUERY_DATASET_ID="${combined_staging}"
 data_stage='combined'
 
 # run cleaning_rules on combined staging dataset
-python "${CLEANER_DIR}/clean_cdr.py" --project_id "${app_id}" --dataset_id "${combined_staging}" --sandbox_dataset_id "${combined_staging_sandbox}" --data_stage ${data_stage} -s --cutoff_date "${ehr_cutoff}" 2>&1 | tee combined_cleaning_log_"${combined}".txt
+python "${CLEANER_DIR}/clean_cdr.py" --project_id "${app_id}" --dataset_id "${combined_staging}" --sandbox_dataset_id "${combined_staging_sandbox}" --data_stage ${data_stage} -s --cutoff_date "${ehr_cutoff}" --validation_dataset_id "${validation_dataset}" --ehr_dataset_id "${ehr_dataset}" 2>&1 | tee combined_cleaning_log_"${combined}".txt
 
 # Create a snapshot dataset with the result
 python "${TOOLS_DIR}/snapshot_by_query.py" --project_id "${app_id}" --dataset_id "${combined_staging}" --snapshot_dataset_id "${combined}"

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_non_matching_participant_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_non_matching_participant_test.py
@@ -202,7 +202,9 @@ class RemoveNonMatchingParticipantTest(unittest.TestCase):
         mock_get_hpo_site_names.return_value = [self.hpo_id_1, self.hpo_id_2]
         mock_exist_participant_match.side_effect = [True, False]
         mock_get_list_non_match_participants.return_value = self.person_ids
-        mock_get_sandbox_queries.return_value = self.drop_participant_query_dict
+        mock_get_sandbox_queries.return_value = [
+            self.drop_participant_query_dict
+        ]
         mock_get_remove_pids_queries.return_value = self.drop_domain_records_query_dicts
 
         expected = [self.drop_participant_query_dict


### PR DESCRIPTION
 * Return query dict rather than list for sandbox queries
 * Make ehr_dataset_id, validation_dataset_id args required
 * In generate_combined_dataset.sh add ehr_dataset param