### PR TITLE
[DC-1494] StringFieldsSuppression class not in controlled tier cleaning class list

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -92,6 +92,7 @@ from cdr_cleaner.cleaning_rules.identifying_field_suppression import IDFieldSupp
 from cdr_cleaner.cleaning_rules.aggregate_zip_codes import AggregateZipCodes
 from cdr_cleaner.cleaning_rules.remove_extra_tables import RemoveExtraTables
 from cdr_cleaner.manual_cleaning_rules.survey_version_info import COPESurveyVersionTask
+from cdr_cleaner.cleaning_rules.deid.string_fields_suppression import StringFieldsSuppression
 from constants.cdr_cleaner import clean_cdr_engine as ce_consts
 from constants.cdr_cleaner.clean_cdr import DataStage
 
@@ -234,6 +235,7 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (ExplicitIdentifierSuppression,),
     (GeoLocationConceptSuppression,),
     (BirthInformationSuppression,),
+    (StringFieldsSuppression,),
     (IDFieldSuppression,),  # Should run after any data remapping
     (GenerateSiteMappingsAndExtTables,),
     (COPESurveyVersionTask,

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression.py
@@ -18,6 +18,7 @@ ISSUE_NUMBERS = ['DC1369']
 OBSERVATION_SOURCE_CONCEPT_ID = 'observation_source_concept_id'
 VALUE_AS_STRING = 'value_as_string'
 PPI_ZIP_CODE_CONCEPT_ID = 1585250
+APPROXIMATE_DATE_OF_SYMPTOMS = 715711
 
 SUPPRESSION_EXCEPTION_SANDBOX_QUERY_TEMPLATE = JINJA_ENV.from_string("""
 -- Only sandboxing records that are not in sandbox_table --
@@ -174,6 +175,12 @@ class StringFieldsSuppression(BaseCleaningRule):
                 sandbox_table=self.sandbox_table_for(OBSERVATION),
                 field_name=OBSERVATION_SOURCE_CONCEPT_ID,
                 field_value=PPI_ZIP_CODE_CONCEPT_ID,
+                restore_fields=[VALUE_AS_STRING]),
+            SuppressionException(
+                domain_table=OBSERVATION,
+                sandbox_table=self.sandbox_table_for(OBSERVATION),
+                field_name=OBSERVATION_SOURCE_CONCEPT_ID,
+                field_value=APPROXIMATE_DATE_OF_SYMPTOMS,
                 restore_fields=[VALUE_AS_STRING])
         ]
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression_test.py
@@ -95,11 +95,11 @@ class StringFieldsSuppressionTestBase(BaseTest.CleaningRulesTestBase):
         observation_data_template = self.jinja_env.from_string("""
             CREATE OR REPLACE TABLE `{{project_id}}.{{dataset_id}}.observation`
             (
-                observation_id int64, 
-                person_id int64, 
+                observation_id int64,
+                person_id int64,
                 observation_concept_id int64,
                 observation_source_concept_id int64,
-                value_as_string STRING, 
+                value_as_string STRING,
                 observation_source_value STRING,
                 unit_source_value STRING,
                 qualifier_source_value STRING,
@@ -123,7 +123,8 @@ class StringFieldsSuppressionTestBase(BaseTest.CleaningRulesTestBase):
                    (2, 1, 0, 0, 'value_as_string', 'observation_source_value', 'unit_source_value', 'qualifier_source_value', 'value_source_value'),
                    (3, 1, 0, 0, 'value_as_string', 'observation_source_value', 'unit_source_value', 'qualifier_source_value', 'value_source_value'),
                    (4, 1, 0, 0, 'value_as_string', 'observation_source_value', 'unit_source_value', 'qualifier_source_value', 'value_source_value'),
-                   (5, 1, 0, 0, 'value_as_string', 'observation_source_value', 'unit_source_value', 'qualifier_source_value', 'value_source_value')] col
+                   (5, 1, 0, 0, 'value_as_string', 'observation_source_value', 'unit_source_value', 'qualifier_source_value', 'value_source_value'),
+                   (6, 1, 0, 715711, 'foo_date', 'observation_source_value', 'unit_source_value', 'qualifier_source_value', 'value_source_value')] col
             )
             SELECT 
                 observation_id,
@@ -172,20 +173,22 @@ class StringFieldsSuppressionTestBase(BaseTest.CleaningRulesTestBase):
                 f'{self.project_id}.{self.dataset_id}.observation',
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'loaded_ids': [1, 2, 3, 4, 5],
-            'sandboxed_ids': [1],
+            'loaded_ids': [1, 2, 3, 4, 5, 6],
+            'sandboxed_ids': [1, 6],
             'fields': [
                 'observation_id', 'person_id', 'observation_concept_id',
                 'observation_source_concept_id', 'value_as_string',
                 'observation_source_value', 'unit_source_value',
                 'qualifier_source_value', 'value_source_value'
             ],
-            'cleaned_values': [(1, 1, 0, 1585250, '111111', None, None,
-                                None, None),
-                               (2, 1, 0, 0, None, None, None, None, None),
-                               (3, 1, 0, 0, None, None, None, None, None),
-                               (4, 1, 0, 0, None, None, None, None, None),
-                               (5, 1, 0, 0, None, None, None, None, None)]
+            'cleaned_values': [
+                (1, 1, 0, 1585250, '111111', None, None, None, None),
+                (2, 1, 0, 0, None, None, None, None, None),
+                (3, 1, 0, 0, None, None, None, None, None),
+                (4, 1, 0, 0, None, None, None, None, None),
+                (5, 1, 0, 0, None, None, None, None, None),
+                (6, 1, 0, 715711, 'foo_date', None, None, None, None)
+            ]
         }]
 
         self.default_test(tables_and_counts)


### PR DESCRIPTION
* Add missing StringFieldsSuppression class to clean_cdr.py
* Add 715711 to exclusion list
* Add integration test case for excluded concept_id

Signed-off-by: Krishna Kalluri <krishnasaikalluri@gmail.com>