### PR TITLE
[DC-1378] update add_cdr_metadata.py to be called from another modules

### DIFF
--- a/data_steward/tools/add_cdr_metadata.py
+++ b/data_steward/tools/add_cdr_metadata.py
@@ -1,8 +1,20 @@
+"""
+This module will populate the cdr_metadata table with CDR metadata in order to version control the pipeline for each
+    release. The metadata to be included is etl_version, ehr_source, ehr_cutoff_date, rdr_source, rdr_export_date,
+    cdr_generation_date, qa_handoff_date, and vocabulary_version.
+
+Original Issues: DC-1378, DC-347
+"""
+
+# Python imports
 import argparse
 
+# Project imports
 import bq_utils
 import resources
 from utils import bq
+from common import JINJA_ENV
+from cdr_cleaner import clean_cdr
 
 METADATA_TABLE = '_cdr_metadata'
 ETL_VERSION = 'etl_version'
@@ -18,28 +30,30 @@ JOB_COMPONENTS = [COPY, CREATE, INSERT]
 UPDATE_STRING_COLUMNS = "{field} = \'{field_value}\'"
 UPDATE_DATE_COLUMNS = "{field} = cast(\'{field_value}\' as DATE)"
 
-ETL_VERSION_CHECK = """
-select {etl} from `{dataset}.{table}`
-"""
-ADD_ETL_METADATA_QUERY = """
-insert into `{project}.{dataset}.{metadata_table}` ({etl_version}) values(\'{field_value}\')
-"""
+ETL_VERSION_CHECK = JINJA_ENV.from_string("""
+select {{etl}} from `{{dataset}}.{{table}}`
+""")
 
-UPDATE_QUERY = """
-update `{project}.{dataset}.{table}` set {statement} where {etl_version} = \'{etl_value}\'
-"""
+ADD_ETL_METADATA_QUERY = JINJA_ENV.from_string("""
+insert into `{{project}}.{{dataset}}.{{metadata_table}}` ({{etl_version}}) values(\'{{field_value}}\')
+""")
 
-COPY_QUERY = """
-select * from `{project}.{dataset}.{metadata_table}`
-"""
+UPDATE_QUERY = JINJA_ENV.from_string("""
+update `{{project}}.{{dataset}}.{{table}}` set {{statement}} where {{etl_version}} = \'{{etl_value}}\'
+""")
+
+COPY_QUERY = JINJA_ENV.from_string("""
+select * from `{{project}}.{{dataset}}.{{metadata_table}}`
+""")
 
 
 def create_metadata_table(dataset_id, fields_list):
     """
     Creates a metadata table in a given dataset.
+
     :param dataset_id: name of the dataset
     :param fields_list: name of the dataset
-    :return:
+    :return: None
     """
     if not bq_utils.table_exists(METADATA_TABLE, dataset_id):
         bq_utils.create_table(table_id=METADATA_TABLE,
@@ -50,12 +64,13 @@ def create_metadata_table(dataset_id, fields_list):
 def copy_metadata_table(project_id, source_dataset_id, target_dataset_id,
                         table_fields):
     """
+    Copies the metadata table
 
-    :param project_id:
-    :param source_dataset_id:
-    :param target_dataset_id:
-    :param table_fields:
-    :return:
+    :param project_id: identifies the project
+    :param source_dataset_id: name of the source dataset
+    :param target_dataset_id: name of the target dataset
+    :param table_fields: field list of the table
+    :return: None
     """
     create_metadata_table(target_dataset_id, table_fields)
     query = COPY_QUERY.format(project=project_id,
@@ -67,11 +82,23 @@ def copy_metadata_table(project_id, source_dataset_id, target_dataset_id,
 
 
 def parse_update_statement(table_fields, field_values):
+    """
+    Generates an update statement consisting of the field name corresponding value
+
+    :param table_fields: field list of the table
+    :param field_values: dictionary of field values passed as parameters
+    :return: update statement string
+    """
     statement_list = []
     field_types = dict()
+
+    # Retrieves the data type of the field
     for field_name in table_fields:
         field_types[field_name[NAME]] = field_name[TYPE]
+
     for field_name in field_values:
+        # Will generate update statements for date and string types if value is not empty and
+        # field does not equal etl_version
         if field_name != ETL_VERSION and field_values[field_name] is not None:
             if field_types[field_name] == DATE:
                 statement_list.append(
@@ -88,6 +115,13 @@ def parse_update_statement(table_fields, field_values):
 
 
 def get_etl_version(dataset_id, project_id):
+    """
+    Gets the etl version
+
+    :param dataset_id: Name of the dataset
+    :param project_id: Name of the project
+    :return: etl version
+    """
     etl_version = bq.query(ETL_VERSION_CHECK.format(etl=ETL_VERSION,
                                                     project=project_id,
                                                     dataset=dataset_id,
@@ -108,7 +142,7 @@ def add_metadata(dataset_id, project_id, table_fields, field_values=None):
     """
     etl_check = get_etl_version(dataset_id, project_id)
     if not etl_check:
-        add_etl_query = ADD_ETL_METADATA_QUERY.format(
+        add_etl_query = ADD_ETL_METADATA_QUERY.render(
             project=project_id,
             dataset=dataset_id,
             metadata_table=METADATA_TABLE,
@@ -118,7 +152,7 @@ def add_metadata(dataset_id, project_id, table_fields, field_values=None):
 
     update_statement = parse_update_statement(table_fields, field_values)
     if update_statement != '':
-        q = UPDATE_QUERY.format(project=project_id,
+        q = UPDATE_QUERY.render(project=project_id,
                                 dataset=dataset_id,
                                 table=METADATA_TABLE,
                                 statement=update_statement,
@@ -127,8 +161,9 @@ def add_metadata(dataset_id, project_id, table_fields, field_values=None):
         bq.query(q, project_id=project_id)
 
 
-if __name__ == '__main__':
+def parse_cdr_metadata_args(args=None):
     fields = resources.fields_for(METADATA_TABLE)
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
@@ -141,7 +176,7 @@ if __name__ == '__main__':
                         help='Identifies the dataset to copy metadata from')
     parser.add_argument('--target_dataset',
                         default=True,
-                        help='Identifies the dataset to copy metadata from')
+                        help='Identifies the dataset to copy metadata to')
     parser.add_argument('--source_dataset',
                         default=None,
                         help='Identifies the dataset to copy metadata from')
@@ -150,7 +185,17 @@ if __name__ == '__main__':
         parser.add_argument(f'--{field[NAME]}',
                             default=None,
                             help=f'{field[DESCRIPTION]}')
-    args = parser.parse_args()
+
+    cdr_metadata_args, unknown_args = parser.parse_known_args(args)
+    custom_args = clean_cdr._get_kwargs(unknown_args)
+    return cdr_metadata_args, custom_args
+
+
+def main(raw_args=None):
+    args, kwargs = parse_cdr_metadata_args(raw_args)
+
+    fields = resources.fields_for(METADATA_TABLE)
+
     if args.component == CREATE:
         create_metadata_table(args.target_dataset, fields)
     if args.component == COPY:
@@ -166,3 +211,7 @@ if __name__ == '__main__':
     if args.component == INSERT:
         add_metadata(args.target_dataset, args.project_id, fields,
                      field_values_dict)
+
+
+if __name__ == '__main__':
+    main()

--- a/data_steward/tools/add_cdr_metadata.py
+++ b/data_steward/tools/add_cdr_metadata.py
@@ -207,7 +207,7 @@ def main(raw_args=None):
             args.rdr_source, args.rdr_export_date, args.cdr_generation_date,
             args.qa_handoff_date, args.vocabulary_version
         ]))
-    print(field_values_dict)
+
     if args.component == INSERT:
         add_metadata(args.target_dataset, args.project_id, fields,
                      field_values_dict)

--- a/data_steward/tools/add_cdr_metadata.py
+++ b/data_steward/tools/add_cdr_metadata.py
@@ -73,7 +73,7 @@ def copy_metadata_table(project_id, source_dataset_id, target_dataset_id,
     :return: None
     """
     create_metadata_table(target_dataset_id, table_fields)
-    query = COPY_QUERY.format(project=project_id,
+    query = COPY_QUERY.render(project=project_id,
                               dataset=source_dataset_id,
                               metadata_table=METADATA_TABLE)
     bq_utils.query(query,
@@ -122,7 +122,7 @@ def get_etl_version(dataset_id, project_id):
     :param project_id: Name of the project
     :return: etl version
     """
-    etl_version = bq.query(ETL_VERSION_CHECK.format(etl=ETL_VERSION,
+    etl_version = bq.query(ETL_VERSION_CHECK.render(etl=ETL_VERSION,
                                                     project=project_id,
                                                     dataset=dataset_id,
                                                     table=METADATA_TABLE),

--- a/data_steward/tools/add_cdr_metadata.py
+++ b/data_steward/tools/add_cdr_metadata.py
@@ -201,14 +201,14 @@ def main(raw_args=None):
     if args.component == COPY:
         copy_metadata_table(args.project_id, args.source_dataset,
                             args.target_dataset, fields)
-    field_values_dict = dict(
-        zip([field[NAME] for field in fields], [
-            args.etl_version, args.ehr_source, args.ehr_cutoff_date,
-            args.rdr_source, args.rdr_export_date, args.cdr_generation_date,
-            args.qa_handoff_date, args.vocabulary_version
-        ]))
 
     if args.component == INSERT:
+        field_values_dict = dict(
+            zip([field[NAME] for field in fields], [
+                args.etl_version, args.ehr_source, args.ehr_cutoff_date,
+                args.rdr_source, args.rdr_export_date, args.cdr_generation_date,
+                args.qa_handoff_date, args.vocabulary_version
+            ]))
         add_metadata(args.target_dataset, args.project_id, fields,
                      field_values_dict)
 

--- a/tests/unit_tests/data_steward/tools/add_cdr_metadata_test.py
+++ b/tests/unit_tests/data_steward/tools/add_cdr_metadata_test.py
@@ -17,6 +17,9 @@ class AddCdrMetadataTest(unittest.TestCase):
     def setUp(self):
         self.dataset_id = 'dataset_id'
         self.project_id = 'project_id'
+        self.target_dataset = 'foo_dataset'
+        self.component = 'copy'
+
         self.fields = [{
             "type": "string",
             "name": "etl_version",
@@ -39,6 +42,25 @@ class AddCdrMetadataTest(unittest.TestCase):
             'ehr_cutoff_date': '2020-01-01'
         }
         self.update_string_value = "ehr_source = 'test', ehr_cutoff_date = cast('2020-01-01' as DATE)"
+
+        self.correct_parameter_list = [
+            '--component', self.component, '--project_id', self.project_id,
+            '--target_dataset', self.target_dataset, '--source_dataset',
+            self.dataset_id, '--etl_version', None, '--ehr_cutoff_date', None,
+            '--rdr_source', None, '--rdr_export_date', None,
+            '--cdr_generation_date', None, '--qa_handoff_date', None,
+            '--vocabulary_version', None, '--ehr_source', None
+        ]
+
+        # Required fields removed
+        self.incorrect_parameter_list_1 = [
+            '--project_id', self.project_id, '--target_dataset',
+            self.target_dataset, '--source_dataset_id', self.dataset_id
+        ]
+        self.incorrect_parameter_list_2 = [
+            '--component', self.component, '--target_dataset',
+            self.target_dataset, '--source_dataset', self.dataset_id
+        ]
 
     def test_parse_update_statement(self):
         expected_statement = self.update_string_value
@@ -76,22 +98,61 @@ class AddCdrMetadataTest(unittest.TestCase):
         self.assertEqual(mock_create_table.call_count, 1)
 
     def test_etl_metadata_query(self):
-        expected_query = ADD_ETL_METADATA_QUERY.format(
+        expected_query = ADD_ETL_METADATA_QUERY.render(
             project=self.project_id,
             dataset=self.dataset_id,
             metadata_table=METADATA_TABLE,
             etl_version=ETL_VERSION,
             field_value=self.field_values[ETL_VERSION])
 
-        actual_query = f'\ninsert into `{self.project_id}.{self.dataset_id}.{METADATA_TABLE}` ({ETL_VERSION}) values(\'{self.field_values[ETL_VERSION]}\')\n'
+        actual_query = f'\ninsert into `{self.project_id}.{self.dataset_id}.{METADATA_TABLE}` ({ETL_VERSION}) values(\'{self.field_values[ETL_VERSION]}\')'
 
-        self.assertEquals(expected_query, actual_query)
+        self.assertEqual(expected_query, actual_query)
 
     def test_copy_query(self):
-        expected_query = COPY_QUERY.format(project=self.project_id,
+        expected_query = COPY_QUERY.render(project=self.project_id,
                                            dataset=self.dataset_id,
                                            metadata_table=METADATA_TABLE)
 
-        actual_query = f'\nselect * from `{self.project_id}.{self.dataset_id}.{METADATA_TABLE}`\n'
+        actual_query = f'\nselect * from `{self.project_id}.{self.dataset_id}.{METADATA_TABLE}`'
 
         self.assertEqual(expected_query, actual_query)
+
+    def test_parse_cdr_metadata_args(self):
+        # Tests if incorrect parameters are given
+        self.assertRaises(SystemExit, parse_cdr_metadata_args,
+                          self.incorrect_parameter_list_1)
+        self.assertRaises(SystemExit, parse_cdr_metadata_args,
+                          self.incorrect_parameter_list_2)
+
+        # Tests if incorrect choice for component are given
+        incorrect_component_choice_args = [[
+            '--component', 'delete', '--project_id', self.project_id,
+            '--target_dataset', self.target_dataset, '--source_dataset',
+            self.dataset_id
+        ],
+                                           [
+                                               '--component', 'update',
+                                               '--project_id', self.project_id,
+                                               '--target_dataset',
+                                               self.target_dataset,
+                                               '--source_dataset',
+                                               self.dataset_id
+                                           ]]
+
+        for args in incorrect_component_choice_args:
+            self.assertRaises(SystemExit, parse_cdr_metadata_args, args)
+
+        # Preconditions
+        it = iter(self.correct_parameter_list)
+        correct_parameter_dict = dict(zip(it, it))
+        correct_parameter_dict = {
+            k.strip('-'): v for (k, v) in correct_parameter_dict.items()
+        }
+
+        # Test if correct parameters are given
+        args, kwargs = parse_cdr_metadata_args(self.correct_parameter_list)
+        results_dict = vars(args)
+
+        # Post conditions
+        self.assertEqual(correct_parameter_dict, results_dict)


### PR DESCRIPTION
In `add_cdr_metadata.py` module:
* Updated queries to use jinja template
* Updated/created doc strings for functions
* Added clarifying comments
* Updated query generation to use render instead of format
* Split `__name__ == '__main__'` to two functions to allow other module to call `add_cdr_metadata.py`
     * Created `parser_cdr_metadata_args` and `main`
* `__name__ == '__main__'` only calls `main()` function now

In `add_cdr_metadata_test.py` module:
* Added variables to `setUp` function to be used in `test_parse_cdr_metadata_args` function
* Updated query generation to use render
* Fixed `actual_query` in `test_etl_metadata_query` and `test_copy_query` to not have extra carriage return
* Created `test_parser_cdr_metadata_args` function to:
    * Test if incorrect parameters are given, `project_id` and `component`
      are required args
    * Test if incorrect choice for component are given, component can
      only be `COPY`, `INSERT`, or `CREATE`
    * Test if overall, all the correct parameters are given