### PR TITLE
[DC-1506] Use Double Brackets in Jinja Template

### DIFF
--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -26,8 +26,8 @@ SCOPES = [
 ]
 
 ADD_ETL_METADATA_QUERY = JINJA_ENV.from_string("""
-INSERT INTO `{project_id}.{dataset_id}._cdr_metadata` (qa_handoff_date)
-VALUES ('{field_value}')
+INSERT INTO `{{project_id}}.{{dataset_id}}._cdr_metadata` (qa_handoff_date)
+VALUES ('{{field_value}}')
 """)
 
 
@@ -249,8 +249,8 @@ def create_tier(credentials_filepath, project_id, tier, input_dataset,
     if 'base' in deid_stage:
         add_etl_metadata_query = ADD_ETL_METADATA_QUERY.render(
             project_id=project_id,
-            dataset_id=final_dataset_name,
-            field_values=qa_handoff_date)
+            dataset_id=datasets[consts.STAGING],
+            field_value=qa_handoff_date)
         query_job = client.query(add_etl_metadata_query)
         query_job.result()
     else:


### PR DESCRIPTION
* Updated `ADD_ETL_METADATA_QUERY` to have double brackets
* Updated the `dataset_id` in the rendering of `ADD_ETL_METADATA_QUERY`
  so that it will use the STAGING dataset
* Updated the `field_value` variable name to match the one used in
  `ADD_ETL_METADATA_QUERY`