### PR TITLE
[DC-1504] Aggregated Zip Codes Should Ignore value_source_value update

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes.py
@@ -5,7 +5,7 @@ those zip codes with low population density.
 It is expected that this lookup table will be static and will remain unchanged. 
 It is based on US population, and not on participant address metrics.
 
-Original Issues: DC-1379
+Original Issues: DC-1379, DC-1504
 """
 
 # Python imports
@@ -114,8 +114,7 @@ UNION ALL
 SELECT
     obs.* REPLACE (
         COALESCE(state_vocab.concept_id, obs.value_source_concept_id) AS value_source_concept_id,
-        COALESCE(state_vocab.concept_id, obs.value_as_concept_id) AS value_as_concept_id,
-        COALESCE(state_vocab.concept_code, obs.value_source_value) AS value_source_value
+        COALESCE(state_vocab.concept_id, obs.value_as_concept_id) AS value_as_concept_id
     )
 FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` obs
 JOIN unique_state_transforms mzc
@@ -124,57 +123,6 @@ JOIN unique_state_transforms mzc
 LEFT JOIN `{{project_id}}.{{pipeline_tables_dataset}}.{{pii_state_vocab}}` state_vocab
     ON state_vocab.postal_code = mzc.transformed_state
 """)
-
-# MODIFY_ZIP_CODES_QUERY = JINJA_ENV.from_string("""
-# WITH unique_zip_code_transforms AS (
-#     SELECT DISTINCT
-#         zip_code_obs.person_id, zip_code_obs.observation_id zip_code_observation_id,
-#         map.zip_code_3, map.transformed_zip_code_3
-#     FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` zip_code_obs
-#     JOIN `{{project_id}}.{{pipeline_tables_dataset}}.{{zip_code_aggregation_map}}` map
-#         ON map.zip_code_3 = zip_code_obs.value_as_string
-#     WHERE zip_code_obs.observation_source_concept_id = 1585250
-# )
-# SELECT
-#     obs.* REPLACE (
-#         COALESCE(mzc.transformed_zip_code_3, obs.value_as_string) AS value_as_string
-#     )
-# FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` obs
-# LEFT JOIN unique_zip_code_transforms mzc
-#     ON mzc.zip_code_observation_id = obs.observation_id
-#         AND mzc.person_id = obs.person_id
-# """)
-
-# MODIFY_STATES_QUERY = JINJA_ENV.from_string("""
-# WITH unique_state_transforms AS (
-#     SELECT DISTINCT
-#         zip_code_obs.person_id,
-#         state_obs.observation_id state_observation_id,
-#         map.state, map.transformed_state
-#     FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` zip_code_obs
-#     JOIN `{{project_id}}.{{pipeline_tables_dataset}}.{{zip_code_aggregation_map}}` map
-#         ON map.zip_code_3 = zip_code_obs.value_as_string
-#     JOIN `{{project_id}}.{{pipeline_tables_dataset}}.{{pii_state_vocab}}` state_vocab
-#         ON state_vocab.postal_code = map.state
-#     LEFT JOIN `{{project_id}}.{{dataset_id}}.{{obs_table}}` state_obs
-#         ON state_obs.person_id = zip_code_obs.person_id
-#             AND state_obs.observation_source_concept_id = 1585249
-#             AND state_vocab.concept_id = state_obs.value_source_concept_id
-#     WHERE zip_code_obs.observation_source_concept_id = 1585250
-# )
-# SELECT
-#     obs.* REPLACE (
-#         COALESCE(state_vocab.concept_id, obs.value_source_concept_id) AS value_source_concept_id,
-#         COALESCE(state_vocab.concept_id, obs.value_as_concept_id) AS value_as_concept_id,
-#         COALESCE(state_vocab.concept_code, obs.value_source_value) AS value_source_value
-#     )
-# FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` obs
-# LEFT JOIN unique_state_transforms mzc
-#     ON mzc.state_observation_id = obs.observation_id
-#         AND mzc.person_id = obs.person_id
-# LEFT JOIN `{{project_id}}.{{pipeline_tables_dataset}}.{{pii_state_vocab}}` state_vocab
-#     ON state_vocab.postal_code = mzc.transformed_state
-# """)
 
 
 class AggregateZipCodes(BaseCleaningRule):

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes_test.py
@@ -7,7 +7,7 @@ It is expected that this lookup table will be static and will remain unchanged.
 It is based on US population, and not on participant address metrics.
 
 
-Original Issue: DC-1379, DC-1506
+Original Issue: DC-1379, DC-1504
 """
 
 # Python Imports

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes_test.py
@@ -16,7 +16,7 @@ import os
 # Third party imports
 from dateutil import parser
 
-#Project imports
+# Project imports
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.aggregate_zip_codes import AggregateZipCodes
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/aggregate_zip_codes_test.py
@@ -7,7 +7,7 @@ It is expected that this lookup table will be static and will remain unchanged.
 It is based on US population, and not on participant address metrics.
 
 
-Original Issue: DC-1379
+Original Issue: DC-1379, DC-1506
 """
 
 # Python Imports
@@ -70,14 +70,13 @@ class AggregateZipCodesTest(BaseTest.CleaningRulesTestBase):
 
     def test_aggregate_zip_codes_cleaning(self):
         """
-        Tests that the sepcifications for queries perform as designed.
+        Tests that the specifications for queries perform as designed.
 
         Validates pre conditions, tests execution, and post conditions based on the load
         statements and the tables_and_counts variable.        
         """
-        queries = []
 
-        #Append some queries
+        # Append some queries
         observations_query_tmpl = self.jinja_env.from_string("""
             INSERT INTO `{{fq_dataset_name}}.observation`
                 (observation_id, person_id, observation_date,
@@ -101,8 +100,6 @@ class AggregateZipCodesTest(BaseTest.CleaningRulesTestBase):
 
         queries = [observations_query_tmpl]
         self.load_test_data(queries)
-
-        #Uncomment below and fill
 
         tables_and_counts = [{
             'fq_table_name':
@@ -130,7 +127,7 @@ class AggregateZipCodesTest(BaseTest.CleaningRulesTestBase):
                 (5, 5, self.date, "062**", 0, 1585250, 0, None,
                  "StreetAddress_PIIZIP", 0, 0),
                 (6, 1, self.date, "New York", 1585268, 1585249, 1585268,
-                 "PIIState_CT", "StreetAddress_PIIState", 0, 0),
+                 "PIIState_NY", "StreetAddress_PIIState", 0, 0),
                 (7, 1, self.date, "Connecticut", 1585268, 1585249, 1585268,
                  "PIIState_CT", "StreetAddress_PIIState", 0, 0),
                 (8, 2, self.date, "Minnesota", 1585288, 1585249, 1585288,


### PR DESCRIPTION
In `aggregate_zip_codes.py`
* Removed line in `MODIFY_ZIP_CODES_AND_STATES_QUERY` that sets the `value_source_value` to a state
* Removed commented out code
* Updated original issues list in doc string

In `aggregate_zip_codes_test.py`
* Removed commented out code
* Updated original issues list in doc string
* Updated `cleaned_values` list
