### PR TITLE
[DC-1206] [DC-1486] Integration Test for Death Date Validation CR

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -28,7 +28,7 @@ current_date = 'CURRENT_DATE()'
 KEEP_VALID_DEATH_DATE_ROWS = common.JINJA_ENV.from_string("""
 SELECT * FROM `{{project_id}}.{{dataset_id}}.{{table}}` 
 WHERE person_id NOT IN (
-SELECT person_id FROM `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}`
+SELECT person_id FROM `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}`)
 """)
 
 # Selects all the invalid rows. Invalid means the death_date occurs before the AoU program start
@@ -101,7 +101,7 @@ class ValidDeathDates(BaseCleaningRule):
                     current_date=current_date)
         }
 
-        return [keep_valid_death_dates, sandbox_invalid_death_dates]
+        return [sandbox_invalid_death_dates, keep_valid_death_dates]
 
     def setup_rule(self, client, *args, **keyword_args):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -90,7 +90,8 @@ class ValidDeathDatesTest(BaseTest.CleaningRulesTestBase):
         (104, DATE_ADD(CURRENT_DATE(), INTERVAL 5 DAY), 4), -- death_date will be five days in the future --
         -- records won't be dropped because death_date is between AoU program start date and current date --
         (105, DATE('2017-01-01'), 5),
-        (106, DATE('2020-01-01'), 6)""").render(fq_dataset_name=self.fq_dataset_name)
+        (106, DATE('2020-01-01'), 6)""").render(
+            fq_dataset_name=self.fq_dataset_name)
 
         self.load_test_data([death])
 
@@ -99,18 +100,11 @@ class ValidDeathDatesTest(BaseTest.CleaningRulesTestBase):
                 '.'.join([self.fq_dataset_name, DEATH]),
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'loaded_ids': [
-                101, 102, 103, 104, 105, 106
-            ],
+            'loaded_ids': [101, 102, 103, 104, 105, 106],
             'sandboxed_ids': [101, 102, 103, 104],
-            'fields': [
-                'person_id', 'death_date', 'death_type_concept_id'
-            ],
+            'fields': ['person_id', 'death_date', 'death_type_concept_id'],
             'cleaned_values': [(105, parse('2017-01-01').date(), 5),
-                               (106, parse('2020-01-01').date(), 6)
-                               ]
+                               (106, parse('2020-01-01').date(), 6)]
         }]
 
         self.default_test(tables_and_counts)
-
-

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -1,0 +1,116 @@
+"""
+Integration test for valid_death_dates.py module
+
+This cleaning rule removes data containing death_dates which fall outside of the AoU program dates or
+    after the current date.
+
+Original Issue: DC-1376, DC-1206
+
+Ensures that any records that have death_dates falling outside of the AoU program start date or after the current date
+    are sandboxed and dropped.
+"""
+
+# Python Imports
+import os
+
+# Third party imports
+from dateutil.parser import parse
+
+# Project imports
+from common import DEATH
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.valid_death_dates import ValidDeathDates, program_start_date, current_date
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+
+class ValidDeathDatesTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # set the expected test datasets
+        dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        cls.rule_instance = ValidDeathDates(project_id, dataset_id, sandbox_id)
+
+        sb_table_names = cls.rule_instance.sandbox_table_for(DEATH)
+
+        # Generates list of fully qualified sandbox table names
+        cls.fq_sandbox_table_names.append(
+            f'{cls.project_id}.{cls.sandbox_id}.{sb_table_names}')
+
+        cls.fq_table_names = [f'{project_id}.{cls.dataset_id}.{DEATH}']
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and a common
+        fully qualified (fq) dataset name string to load the data.
+        """
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+        super().setUp()
+
+    def test_valid_death_dates(self):
+        """
+        Tests that the specifications for the KEEP_VALID_DEATH_DATE_ROWS and SANDBOX_INVALID_DEATH_DATE_ROWS
+        perform as designed.
+
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+
+        death = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}.death` (person_id, death_date, death_type_concept_id)
+        VALUES 
+        -- records will be dropped because death_date is before AoU start date (Jan 1, 2017) --
+        (101, DATE('2015-01-01'), 1), 
+        (102, DATE('2016-01-01'), 2),
+        -- records will be dropped because death_date is in the future -- 
+        (103, DATE_ADD(CURRENT_DATE(), INTERVAL 1 DAY), 3), -- death_date will be one day in the future -- 
+        (104, DATE_ADD(CURRENT_DATE(), INTERVAL 5 DAY), 4), -- death_date will be five days in the future --
+        -- records won't be dropped because death_date is between AoU program start date and current date --
+        (105, DATE('2017-01-01'), 5),
+        (106, DATE('2020-01-01'), 6)""").render(fq_dataset_name=self.fq_dataset_name)
+
+        self.load_test_data([death])
+
+        tables_and_counts = [{
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, DEATH]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
+            'loaded_ids': [
+                101, 102, 103, 104, 105, 106
+            ],
+            'sandboxed_ids': [101, 102, 103, 104],
+            'fields': [
+                'person_id', 'death_date', 'death_type_concept_id'
+            ],
+            'cleaned_values': [(105, parse('2017-01-01').date(), 5),
+                               (106, parse('2020-01-01').date(), 6)
+                               ]
+        }]
+
+        self.default_test(tables_and_counts)
+
+

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -59,6 +59,17 @@ class ValidDeathDatesTest(unittest.TestCase):
         # Post conditions
         expected_list = [{
             cdr_consts.QUERY:
+                SANDBOX_INVALID_DEATH_DATE_ROWS.render(
+                    project_id=self.project_id,
+                    sandbox_id=self.sandbox_dataset_id,
+                    sandbox_table=self.rule_instance.sandbox_table_for(
+                        common.DEATH),
+                    dataset_id=self.dataset_id,
+                    table=common.DEATH,
+                    program_start_date=program_start_date,
+                    current_date=current_date)
+        }, {
+            cdr_consts.QUERY:
                 KEEP_VALID_DEATH_DATE_ROWS.render(
                     project_id=self.project_id,
                     dataset_id=self.dataset_id,
@@ -72,17 +83,6 @@ class ValidDeathDatesTest(unittest.TestCase):
                 self.dataset_id,
             cdr_consts.DISPOSITION:
                 WRITE_TRUNCATE
-        }, {
-            cdr_consts.QUERY:
-                SANDBOX_INVALID_DEATH_DATE_ROWS.render(
-                    project_id=self.project_id,
-                    sandbox_id=self.sandbox_dataset_id,
-                    sandbox_table=self.rule_instance.sandbox_table_for(
-                        common.DEATH),
-                    dataset_id=self.dataset_id,
-                    table=common.DEATH,
-                    program_start_date=program_start_date,
-                    current_date=current_date)
         }]
 
         self.assertEqual(result_list, expected_list)


### PR DESCRIPTION
In `valid_death_dates.py` module:
* Fixed syntax error in `KEEP_VALID_DEATH_DATES_ROW` query
* Swapped order of list of returned queries

In `valid_death_dates_test.py` unit test:
* Swapped order of `expected_list` list

* integration test