### PR TITLE
[DC-1511] Insert instead of Update is used to add cdr metadata

### DIFF
--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -9,7 +9,6 @@ from datetime import datetime
 # Project imports
 from utils import auth
 from utils import bq
-from common import JINJA_ENV
 from utils import pipeline_logging
 from cdr_cleaner import clean_cdr
 from tools import add_cdr_metadata
@@ -25,11 +24,6 @@ SCOPES = [
     'https://www.googleapis.com/auth/bigquery',
     'https://www.googleapis.com/auth/devstorage.read_write',
 ]
-
-ADD_ETL_METADATA_QUERY = JINJA_ENV.from_string("""
-INSERT INTO `{{project_id}}.{{dataset_id}}._cdr_metadata` (qa_handoff_date)
-VALUES ('{{field_value}}')
-""")
 
 
 def add_kwargs_to_args(args_list, kwargs):

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -243,10 +243,16 @@ def create_tier(credentials_filepath, project_id, tier, input_dataset,
 
     # Will update the qa_handoff_date to current date
     if 'base' in deid_stage:
+        versions = add_cdr_metadata.get_etl_version(datasets[consts.STAGING],
+                                                    project_id)
+        if not versions:
+            raise RuntimeError(
+                'etl version does not exist, make sure _cdr_metadata table was created in combined step'
+            )
         add_cdr_metadata.main([
             '--component', add_cdr_metadata.INSERT, '--project_id', project_id,
             '--target_dataset', datasets[consts.STAGING], '--qa_handoff_date',
-            qa_handoff_date
+            qa_handoff_date, '--etl_version', versions[0]
         ])
     else:
         LOGGER.info(

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -417,7 +417,8 @@ class CreateTierTest(unittest.TestCase):
                                     mock_create_datasets,
                                     mock_add_cdr_metadata_main, mock_get_client,
                                     mock_impersonate_credentials,
-                                    mock_add_kwargs, mock_cdr_main, mock_create_schemaed_snapshot):
+                                    mock_add_kwargs, mock_cdr_main,
+                                    mock_create_schemaed_snapshot):
         final_dataset_name = f"{self.tier[0].upper()}{self.release_tag}_deid_base"
         datasets = {
             consts.CLEAN: final_dataset_name,

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -405,6 +405,7 @@ class CreateTierTest(unittest.TestCase):
             self.project_id, datasets[consts.STAGING], final_dataset_name,
             False)
 
+    @mock.patch('tools.add_cdr_metadata.get_etl_version')
     @mock.patch('tools.create_tier.create_schemaed_snapshot_dataset')
     @mock.patch('tools.create_tier.clean_cdr.main')
     @mock.patch('tools.create_tier.add_kwargs_to_args')
@@ -418,7 +419,7 @@ class CreateTierTest(unittest.TestCase):
                                     mock_add_cdr_metadata_main, mock_get_client,
                                     mock_impersonate_credentials,
                                     mock_add_kwargs, mock_cdr_main,
-                                    mock_create_schemaed_snapshot):
+                                    mock_create_schemaed_snapshot, mock_etl_version):
         final_dataset_name = f"{self.tier[0].upper()}{self.release_tag}_deid_base"
         datasets = {
             consts.CLEAN: final_dataset_name,
@@ -439,6 +440,7 @@ class CreateTierTest(unittest.TestCase):
         mock_add_kwargs.return_value = controlled_tier_cleaning_args
         mock_get_client.return_value = self.mock_bq_client
         cleaning_args = mock_add_kwargs.return_value = controlled_tier_cleaning_args
+        versions = mock_etl_version.return_value = ['test']
 
         kwargs = {}
 
@@ -451,7 +453,7 @@ class CreateTierTest(unittest.TestCase):
         updated_qa_handoff_date_args = [
             '--component', INSERT, '--project_id', self.project_id,
             '--target_dataset', datasets[consts.STAGING], '--qa_handoff_date',
-            datetime.strftime(datetime.now(), '%Y-%m-%d')
+            datetime.strftime(datetime.now(), '%Y-%m-%d'), '--etl_version', versions[0]
         ]
 
         mock_add_cdr_metadata_main.assert_called_with(

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -414,12 +414,11 @@ class CreateTierTest(unittest.TestCase):
     @mock.patch('tools.add_cdr_metadata.main')
     @mock.patch('tools.create_tier.create_datasets')
     @mock.patch('tools.create_tier.get_dataset_name')
-    def test_qa_handoff_date_update(self, mock_dataset_name,
-                                    mock_create_datasets,
-                                    mock_add_cdr_metadata_main, mock_get_client,
-                                    mock_impersonate_credentials,
-                                    mock_add_kwargs, mock_cdr_main,
-                                    mock_create_schemaed_snapshot, mock_etl_version):
+    def test_qa_handoff_date_update(
+        self, mock_dataset_name, mock_create_datasets,
+        mock_add_cdr_metadata_main, mock_get_client,
+        mock_impersonate_credentials, mock_add_kwargs, mock_cdr_main,
+        mock_create_schemaed_snapshot, mock_etl_version):
         final_dataset_name = f"{self.tier[0].upper()}{self.release_tag}_deid_base"
         datasets = {
             consts.CLEAN: final_dataset_name,
@@ -453,7 +452,8 @@ class CreateTierTest(unittest.TestCase):
         updated_qa_handoff_date_args = [
             '--component', INSERT, '--project_id', self.project_id,
             '--target_dataset', datasets[consts.STAGING], '--qa_handoff_date',
-            datetime.strftime(datetime.now(), '%Y-%m-%d'), '--etl_version', versions[0]
+            datetime.strftime(datetime.now(),
+                              '%Y-%m-%d'), '--etl_version', versions[0]
         ]
 
         mock_add_cdr_metadata_main.assert_called_with(


### PR DESCRIPTION
* Updated logic to update `qa_handoff_date` if base is in the deid_tier
* Created `test_qa_handoff_date_update` function to test changes in
  create_tier.py