### PR TITLE
[DC-1446] Re-map race_concept_id

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
@@ -52,7 +52,7 @@ from cdr_cleaner.cleaning_rules.deid.repopulate_person_using_observation import 
 
 LOGGER = logging.getLogger(__name__)
 
-JIRA_ISSUE_NUMBERS = ['DC1439']
+JIRA_ISSUE_NUMBERS = ['DC1439', 'DC1446']
 
 # Gender question concept id
 GENDER_IDENTITY_CONCEPT_ID = 1585838

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_using_observation.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_using_observation.py
@@ -22,6 +22,9 @@ ethnicity_source_concept_id
 sex_at_birth_concept_id (extension)
 sex_at_birth_source_concept_id (extension)
 sex_at_birth_source_value (extension)
+
+As per ticket DC-1446, for participants who have not answered the question "What is you race/ethnicity" we need to set
+    their race_concept_id to 2100000001.
 """
 import logging
 from abc import abstractmethod
@@ -47,7 +50,7 @@ SELECT DISTINCT
     bs.day_of_birth,
     bs.birth_datetime,
     CASE -- a special case to handle that requires inputs from both race ethnicity --
-        WHEN (es.ethnicity_concept_id = 38003563 AND rs.race_concept_id = 0)  THEN {{aou_none_indicated_concept_id}}
+        WHEN rs.race_concept_id = 0  THEN {{aou_none_indicated_concept_id}}
         ELSE rs.race_concept_id 
     END AS race_concept_id,
     es.ethnicity_concept_id,
@@ -58,7 +61,7 @@ SELECT DISTINCT
     gs.gender_source_value,
     gs.gender_source_concept_id,
     CASE -- a special case to handle that requires inputs from both race ethnicity --
-        WHEN (es.ethnicity_concept_id = 38003563 AND rs.race_concept_id = 0) THEN '{{aou_none_indicated_source_value}}'
+        WHEN rs.race_concept_id = 0 THEN '{{aou_none_indicated_source_value}}'
         ELSE rs.race_source_value 
     END AS race_source_value,
     rs.race_source_concept_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid.py
@@ -22,6 +22,9 @@ ethnicity_source_concept_id
 sex_at_birth_concept_id (extension)
 sex_at_birth_source_concept_id (extension)
 sex_at_birth_source_value (extension)
+
+As per ticket DC-1446, for participants who have not answered the question "What is you race/ethnicity" we need to set
+    their race_concept_id to 2100000001.
 """
 import logging
 
@@ -32,7 +35,7 @@ from common import JINJA_ENV, PERSON
 
 LOGGER = logging.getLogger(__name__)
 
-JIRA_ISSUE_NUMBERS = ['DC516', 'DC836']
+JIRA_ISSUE_NUMBERS = ['DC516', 'DC836', 'DC1446']
 
 GENDER_CONCEPT_ID = 1585838
 SEX_AT_BIRTH_CONCEPT_ID = 1585845
@@ -181,7 +184,7 @@ SELECT
   day_of_birth,
   birth_datetime,
   CASE
-    WHEN (ethnicity_concept_id = 38003563 AND race_concept_id = 0) THEN {{aou_custom_concept}}
+    WHEN race_concept_id = 0 THEN {{aou_custom_concept}}
   ELSE
   race_concept_id
 END
@@ -194,7 +197,7 @@ END
   gender_source_value,
   gender_source_concept_id,
   CASE
-    WHEN (ethnicity_concept_id = 38003563 AND race_concept_id = 0) THEN "None Indicated"
+    WHEN race_concept_id = 0 THEN "None Indicated"
   ELSE
   race_source_value
 END

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid_test.py
@@ -36,7 +36,8 @@ from dateutil import parser
 # Project imports
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.repopulate_person_post_deid import (
-    RepopulatePersonPostDeid, GENDER_CONCEPT_ID, SEX_AT_BIRTH_CONCEPT_ID)
+    RepopulatePersonPostDeid, GENDER_CONCEPT_ID, SEX_AT_BIRTH_CONCEPT_ID,
+    AOU_NONE_INDICATED_CONCEPT_ID)
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from common import PERSON, OBSERVATION, CONCEPT
 
@@ -162,11 +163,13 @@ class RepopulatePersonPostDeidTest(BaseTest.CleaningRulesTestBase):
                 'sex_at_birth_concept_id', 'sex_at_birth_source_concept_id',
                 'sex_at_birth_source_value'
             ],
-            'cleaned_values': [(1, 1585841, 1991, 0, 38003564, "nonbinary_src",
-                                123, SEX_FEMALE_CONCEPT_ID,
-                                SEX_FEMALE_SOURCE_CONCEPT_ID, "female_src"),
-                               (2, 0, 1976, 0, 38003564, "No matching concept",
-                                0, 0, 0, "No matching concept")]
+            'cleaned_values': [
+                (1, 1585841, 1991, AOU_NONE_INDICATED_CONCEPT_ID, 38003564,
+                 "nonbinary_src", 123, SEX_FEMALE_CONCEPT_ID,
+                 SEX_FEMALE_SOURCE_CONCEPT_ID, "female_src"),
+                (2, 0, 1976, AOU_NONE_INDICATED_CONCEPT_ID, 38003564,
+                 "No matching concept", 0, 0, 0, "No matching concept")
+            ]
         }]
 
         self.default_test(tables_and_counts)


### PR DESCRIPTION
* removed the condition of having `ethnicity_concept_id = 38003563` in
  both `repopulate_person_using_observation.py` and
  `repopulate_person_post_deid.py` queries
* added clarifying comment to module doc strings explaining the change