### PR TITLE
[DC-1542] integration test for storing pid/rid/shift mappings in primary table

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings.py
@@ -172,7 +172,7 @@ class StoreNewPidRidMappings(BaseCleaningRule):
         ]
 
     def get_sandbox_tablenames(self):
-        return [self.rdr_sandbox_table]
+        return [self.rdr_sandbox_table.table_id]
 
     def setup_rule(self, export_date):
         pass

--- a/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings.py
@@ -96,6 +96,7 @@ class StoreNewPidRidMappings(BaseCleaningRule):
         dataset_ref = bigquery.DatasetReference(project_id, PIPELINE_TABLES)
         self.primary_mapping_table = bigquery.TableReference(
             dataset_ref, PRIMARY_PID_RID_MAPPING)
+
         # rdr table ref
         dataset_ref = bigquery.DatasetReference(project_id, dataset_id)
         self.rdr_table = bigquery.TableReference(dataset_ref, PID_RID_MAPPING)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings_test.py
@@ -4,7 +4,7 @@ import os
 import mock
 
 from app_identity import get_application_id
-from common import PID_RID_MAPPING, PIPELINE_TABLES, PRIMARY_PID_RID_MAPPING
+from common import PID_RID_MAPPING, PRIMARY_PID_RID_MAPPING
 from resources import fields_for
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from cdr_cleaner.cleaning_rules.store_pid_rid_mappings import StoreNewPidRidMappings

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings_test.py
@@ -5,10 +5,8 @@ import mock
 
 from app_identity import get_application_id
 from common import PID_RID_MAPPING, PRIMARY_PID_RID_MAPPING
-from resources import fields_for
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from cdr_cleaner.cleaning_rules.store_pid_rid_mappings import StoreNewPidRidMappings
-from utils import bq
 
 
 class StoreMappingsTest(BaseTest.CleaningRulesTestBase):

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/store_pid_rid_mappings_test.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+import os
+
+from app_identity import get_application_id
+from common import PID_RID_MAPPING, PIPELINE_TABLES, PRIMARY_PID_RID_MAPPING
+from resources import fields_for
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+from cdr_cleaner.cleaning_rules.store_pid_rid_mappings import StoreNewPidRidMappings
+from utils import bq
+
+
+class StoreMappingsTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        cls.project_id = get_application_id()
+
+        # set the expected test datasets
+        cls.dataset_id = os.getenv('RDR_DATASET_ID')
+        cls.sandbox_id = f'{cls.dataset_id}_sandbox'
+
+        cls.rule_instance = StoreNewPidRidMappings(cls.project_id,
+                                                   cls.dataset_id,
+                                                   cls.sandbox_id)
+
+        sb_table_names = cls.rule_instance.get_sandbox_tablenames()
+        for table_name in sb_table_names:
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{table_name}')
+
+        cls.import_map_name = f'{cls.project_id}.{cls.dataset_id}.{PID_RID_MAPPING}'
+        cls.stable_map_name = f'{cls.project_id}.{PIPELINE_TABLES}.{PRIMARY_PID_RID_MAPPING}'
+        cls.fq_table_names = [cls.import_map_name, cls.stable_map_name]
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+
+        # pre-conditions
+        import_map_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{import_map_name}}`
+                (person_id, research_id)
+            VALUES
+                -- should not get added because research_id is a repeat --
+                (100000000, 20),
+                -- should not get added because it is a repeat --
+                (200000000, 21),
+                -- should not get added because person_id is a repeat --
+                (300000000, 34),
+                -- should get added, it is unique --
+                (400000000, 45),
+                (600000000, 70)
+        """).render(import_map_name=self.import_map_name)
+
+        primary_map_tmpl = self.jinja_env.from_string("""
+        INSERT INTO `{{primary_map_name}}`
+            (person_id, research_id, shift, import_date)
+        VALUES
+            (500000000, 88, 78, date('2020-09-01')),
+            (1000000000, 100, 222, date('2020-08-01')),
+            (200000000, 21, 1, date('2020-07-01')),
+            (300000000, 44, 364, date('2020-06-01')),
+            (800000000, 20, 90, date('2020-05-01'))
+        """).render(primary_map_name=self.stable_map_name)
+
+        queries = [import_map_tmpl, primary_map_tmpl]
+        self.load_test_data(queries)
+
+    def test_store_mapping(self):
+        tables_and_counts = [{
+            'fq_table_name':
+                self.stable_map_name,
+            'fields': ['person_id', 'research_id', 'import_date'],
+            'loaded_ids': [
+                500000000, 1000000000, 200000000, 300000000, 800000000
+            ],
+            'cleaned_values': [
+                (500000000, 88, datetime.strptime('2020-09-01',
+                                                  '%Y-%m-%d').date()),
+                (1000000000, 100, datetime.strptime('2020-08-01',
+                                                    '%Y-%m-%d').date()),
+                (200000000, 21, datetime.strptime('2020-07-01',
+                                                  '%Y-%m-%d').date()),
+                (300000000, 44, datetime.strptime('2020-06-01',
+                                                  '%Y-%m-%d').date()),
+                (800000000, 20, datetime.strptime('2020-05-01',
+                                                  '%Y-%m-%d').date()),
+                # should have been added, it is unique --
+                (400000000, 45, datetime.now().date()),
+                (600000000, 70, datetime.now().date())
+            ]
+        }]
+
+        self.default_test(tables_and_counts)
+
+
+#    def tearDown(self):
+#        print("SKIPPING TEAR DOWN PROCESS")
+#
+#    @classmethod
+#    def tearDownClass(cls):
+#        print("SKIPPING TEAR DOWN CLASS PROCESS")


### PR DESCRIPTION
* fixes one bug in the cleaning rule
* mocks the hard coded PIPELINE_TABLES primary dataset reference
* makes sure existing values are not overwritten.
* makes sure new values are added along with random shift elements and partition dates