### PR TITLE
[DC-1501] Create a unique site mapping when a new site is on boarded

### DIFF
--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -258,7 +258,8 @@ def update_site_masking_table():
     for query in queries:
         query_job = client.query(query)
         if query_job.errors:
-            raise RuntimeError(f'{query} failed to run because of {query_job.errors}.')
+            raise RuntimeError(
+                f'{query} failed to run because of {query_job.errors}.')
         jobs.append(query_job.result())
 
     return jobs

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -1,7 +1,8 @@
 """
-Add a new HPO site to config file and BigQuery lookup tables and adds the new masked src_id and hpo_id to
-    the site_maskings table
-
+Add a new HPO site to config file and BigQuery lookup tables and updates the `pipeline_table_sandbox.site_masking`
+    sandbox table created in `generate_site_mappings_and_ext_tables` with any missing hpo_sites in
+    `lookup_tables.hpo_site_id_mappings`
+    
 Note: GAE environment must still be set manually
 """
 # Python imports

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -244,8 +244,8 @@ def update_site_masking_table():
 
     update_site_maskings_query = UPDATE_SITE_MASKING_QUERY.render(
         project_id=project_id,
-        dataset_id=dataset_id,
-        pipeline_dataset_id=intermediary_dataset_id,
+        pipeline_dataset_id=PIPELINE_TABLES,
+        pipeline_sandbox_id=intermediary_dataset_id,
         table_id=table_id)
     queries.append(update_site_maskings_query)
 
@@ -258,7 +258,7 @@ def update_site_masking_table():
     for query in queries:
         query_job = client.query(query)
         if query_job.errors:
-            raise RuntimeError(f'{query} failed to run.')
+            raise RuntimeError(f'{query} failed to run because of {query_job.errors}.')
         jobs.append(query_job.result())
 
     return jobs

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -24,7 +24,6 @@ from utils import pipeline_logging
 from common import JINJA_ENV, PIPELINE_TABLES
 from cdr_cleaner.cleaning_rules.deid.generate_site_mappings_and_ext_tables import SITE_MASKING_TABLE_ID
 
-
 LOGGER = logging.getLogger(__name__)
 
 EHR_SITE_PREFIX = 'EHR site '
@@ -266,8 +265,7 @@ def update_site_masking_table():
         sandbox_id=sandbox_id,
         table_id=SITE_MASKING_TABLE_ID,
         lookup_tables_dataset=bq_consts.LOOKUP_TABLES_DATASET_ID,
-        hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID
-    )
+        hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)
 
     LOGGER.info(
         f'Updating site_masking table with new hpo_id and src_id with the following '

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -21,7 +21,7 @@ import constants.bq_utils as bq_consts
 from utils import bq
 from cdr_cleaner.cleaning_rules.deid.generate_site_mappings_and_ext_tables import GenerateSiteMappingsAndExtTables, \
     SITE_TABLE_ID
-# from tools import cli_util
+from tools import cli_util
 from common import JINJA_ENV, PIPELINE_TABLES
 
 LOGGER = logging.getLogger(__name__)

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -19,10 +19,11 @@ import gcs_utils
 import app_identity
 import constants.bq_utils as bq_consts
 from utils import bq
+from tools import cli_util
+from utils import pipeline_logging
+from common import JINJA_ENV, PIPELINE_TABLES
 from cdr_cleaner.cleaning_rules.deid.generate_site_mappings_and_ext_tables import GenerateSiteMappingsAndExtTables, \
     SITE_TABLE_ID
-from tools import cli_util
-from common import JINJA_ENV, PIPELINE_TABLES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -295,6 +296,8 @@ def main(hpo_id, org_id, hpo_name, bucket_name, display_order, addition_type):
 
 if __name__ == '__main__':
     import argparse
+
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
 
     parser = argparse.ArgumentParser(
         description='Add a new HPO site to hpo config file and lookup tables',

--- a/tests/unit_tests/data_steward/tools/add_hpo_test.py
+++ b/tests/unit_tests/data_steward/tools/add_hpo_test.py
@@ -88,11 +88,10 @@ class AddHPOTest(TestCase):
 
         mock_query = mock_get_client.return_value.query
 
-        # Mocks the job returns
+        # Mocks the job return
         query_job_reference_results = mock.MagicMock(
             name="query_job_reference_results")
         query_job_reference_results.return_value = query_job_reference_results
-
         mock_query.side_effect = query_job_reference_results
 
         # Test

--- a/tests/unit_tests/data_steward/tools/add_hpo_test.py
+++ b/tests/unit_tests/data_steward/tools/add_hpo_test.py
@@ -82,9 +82,11 @@ class AddHPOTest(TestCase):
                           new_site['hpo_id'], new_site['hpo_name'],
                           new_site['org_id'], new_site['display_order'])
 
-    @mock.patch('cdr_cleaner.cleaning_rules.deid.generate_site_mappings_and_ext_tables')
+    @mock.patch(
+        'cdr_cleaner.cleaning_rules.deid.generate_site_mappings_and_ext_tables')
     @mock.patch('utils.bq.get_client')
-    def test_update_site_masking_table(self, mock_client, mock_generate_site_mappings):
+    def test_update_site_masking_table(self, mock_client,
+                                       mock_generate_site_mappings):
         # Preconditions
         client = mock_client.return_value = self.mock_bq_client
         client.side_effects = add_hpo.update_site_masking_table()
@@ -94,7 +96,3 @@ class AddHPOTest(TestCase):
 
         # Post conditions
         self.assertEqual(mock_client.call_count, 2)
-
-
-
-

--- a/tests/unit_tests/data_steward/tools/add_hpo_test.py
+++ b/tests/unit_tests/data_steward/tools/add_hpo_test.py
@@ -87,11 +87,13 @@ class AddHPOTest(TestCase):
 
         # Mocks the job returns
         query_job_reference_1 = mock.MagicMock(name="query_job_reference_1")
-        query_job_reference_1_results = mock.MagicMock(name="query_job_reference_result_1")
+        query_job_reference_1_results = mock.MagicMock(
+            name="query_job_reference_result_1")
         query_job_reference_1.result.return_value = query_job_reference_1_results
 
         query_job_reference_2 = mock.MagicMock(name="query_job_reference_2")
-        query_job_reference_2_results = mock.MagicMock(name="query_job_reference_result_2")
+        query_job_reference_2_results = mock.MagicMock(
+            name="query_job_reference_result_2")
         query_job_reference_2.result.return_value = query_job_reference_2_results
 
         type(query_job_reference_1).errors = mock.PropertyMock(
@@ -110,7 +112,9 @@ class AddHPOTest(TestCase):
             pipeline_sandbox_id=intermediary_dataset_id,
             table_id=add_hpo.SITE_TABLE_ID)
 
-        expected_jobs = [query_job_reference_1_results, query_job_reference_2_results]
+        expected_jobs = [
+            query_job_reference_1_results, query_job_reference_2_results
+        ]
         mock_query.assert_any_call(update_site_masking_query)
 
         self.assertEqual(actual_jobs, expected_jobs)


### PR DESCRIPTION
* Modified module to separate the generation of the site masking sandbox table and extension table creation in `generate_site_mappings_and_ext_tables.py` module
* Created `UPDATE_SITE_MASKING_QUERY` in `add_hpo.py` module
* Created `update_site_masking_table` function in `add_hpo.py` module to create the unique site masking and update the `site_maskings` table in `pipeline_tables` dataset
* Modified the `main` function in `add_hpo.py` module to update the site masking table when updating the lookup tables
* Created `test_update_site_masking_table` to test the functionality in the `add_hpo.update_site_masking_table` function