### PR TITLE
[DC-1581] Copy sex_at_birth_* columns at output time

### DIFF
--- a/data_steward/tools/recreate_person.py
+++ b/data_steward/tools/recreate_person.py
@@ -4,6 +4,7 @@ import logging
 # Project imports
 from utils import bq
 from common import JINJA_ENV
+from utils import pipeline_logging
 
 LOGGER = logging.getLogger(__name__)
 
@@ -12,14 +13,23 @@ ALTER TABLE `{{person.project}}.{{person.dataset_id}}.{{person.table_id}}`
 ADD COLUMN IF NOT EXISTS state_of_residence_concept_id INT64 
     OPTIONS(description="[All of Us OMOP extension] A foreign key for the state of residence"),
 ADD COLUMN IF NOT EXISTS state_of_residence_source_value STRING 
-    OPTIONS(description="[All of Us OMOP extension] The source code for the state of residence")
+    OPTIONS(description="[All of Us OMOP extension] The source code for the state of residence"),
+ADD COLUMN IF NOT EXISTS sex_at_birth_concept_id INT64
+    OPTIONS(description="[All of Us OMOP extension] A foreign key to the biological sex at birth concept."),
+ADD COLUMN IF NOT EXISTS sex_at_birth_source_concept_id INT64
+    OPTIONS(description="[All of Us OMOP extension] A foreign key to the biological sex at birth source concept."),
+ADD COLUMN IF NOT EXISTS sex_at_birth_source_value STRING
+    OPTIONS(description="[All of Us OMOP extension] The source code for the biological sex at birth.")
 """)
 
 UPDATE_PERSON_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{person.project}}.{{person.dataset_id}}.{{person.table_id}}` p
 SET
     state_of_residence_concept_id = ext.state_of_residence_concept_id,
-    state_of_residence_source_value = ext.state_of_residence_source_value
+    state_of_residence_source_value = ext.state_of_residence_source_value,
+    sex_at_birth_concept_id = ext.sex_at_birth_concept_id,
+    sex_at_birth_source_concept_id = ext.sex_at_birth_source_concept_id,
+    sex_at_birth_source_value = ext.sex_at_birth_source_value
 FROM
     `{{person_ext.project}}.{{person_ext.dataset_id}}.{{person_ext.table_id}}` ext
 WHERE p.person_id = ext.person_id
@@ -58,6 +68,8 @@ def update_person(client, project_id, dataset_id):
 
 if __name__ == '__main__':
     from argparse import ArgumentParser, RawDescriptionHelpFormatter
+
+    pipeline_logging.configure(logging.DEBUG, add_console_handler=True)
 
     parser = ArgumentParser(description='Parse project_id and dataset_id',
                             formatter_class=RawDescriptionHelpFormatter)

--- a/tests/integration_tests/data_steward/tools/recreate_person_test.py
+++ b/tests/integration_tests/data_steward/tools/recreate_person_test.py
@@ -26,13 +26,14 @@ VALUES
 
 POPULATE_PERSON_EXT = JINJA_ENV.from_string("""
 INSERT INTO `{{person_ext.project}}.{{person_ext.dataset_id}}.person_ext`
-(person_id, state_of_residence_concept_id, state_of_residence_source_value)
+(person_id, state_of_residence_concept_id, state_of_residence_source_value, sex_at_birth_concept_id, 
+    sex_at_birth_source_concept_id, sex_at_birth_source_value)
 VALUES 
-    (1, 1585266, 'PIIState_CA'),
-    (2, 1585297, 'PIIState_NY'),
-    (3, 1585286, 'PIIState_MA'),
-    (4, 1585297, 'PIIState_NY'),
-    (5, 1585266, 'PIIState_CA')
+    (1, 1585266, 'PIIState_CA', 123, 101, 'gender'),
+    (2, 1585297, 'PIIState_NY', 234, 202, 'gender'),
+    (3, 1585286, 'PIIState_MA', 345, 303, 'gender'),
+    (4, 1585297, 'PIIState_NY', 456, 404, 'gender'),
+    (5, 1585266, 'PIIState_CA', 567, 505, 'gender')
 """)
 
 
@@ -83,18 +84,20 @@ class RecreatePersonTest(TestCase):
         recreate_person.update_person(self.client, self.project_id,
                                       self.dataset_id)
         new_person_cols = (
-            f'SELECT state_of_residence_concept_id, state_of_residence_source_value '
+            f'SELECT state_of_residence_concept_id, state_of_residence_source_value, '
+            f'sex_at_birth_concept_id, sex_at_birth_source_concept_id, sex_at_birth_source_value '
             f'FROM {self.project_id}.{self.dataset_id}.person')
         person_ext_cols = (
-            f'SELECT state_of_residence_concept_id, state_of_residence_source_value '
+            f'SELECT state_of_residence_concept_id, state_of_residence_source_value, '
+            f'sex_at_birth_concept_id, sex_at_birth_source_concept_id, sex_at_birth_source_value '
             f'FROM {self.project_id}.{self.dataset_id}.person_ext')
         new_person_vals = self.client.query(new_person_cols).to_dataframe()
         person_ext_vals = self.client.query(person_ext_cols).to_dataframe()
         testing.assert_frame_equal(
             new_person_vals.set_index(
-                'state_of_residence_concept_id').sort_index(),
+                ['state_of_residence_concept_id', 'sex_at_birth_concept_id']).sort_index(),
             person_ext_vals.set_index(
-                'state_of_residence_concept_id').sort_index())
+                ['state_of_residence_concept_id', 'sex_at_birth_concept_id']).sort_index())
 
     def tearDown(self) -> None:
         for table in self.table_ids:

--- a/tests/integration_tests/data_steward/tools/recreate_person_test.py
+++ b/tests/integration_tests/data_steward/tools/recreate_person_test.py
@@ -95,9 +95,11 @@ class RecreatePersonTest(TestCase):
         person_ext_vals = self.client.query(person_ext_cols).to_dataframe()
         testing.assert_frame_equal(
             new_person_vals.set_index(
-                ['state_of_residence_concept_id', 'sex_at_birth_concept_id']).sort_index(),
+                ['state_of_residence_concept_id',
+                 'sex_at_birth_concept_id']).sort_index(),
             person_ext_vals.set_index(
-                ['state_of_residence_concept_id', 'sex_at_birth_concept_id']).sort_index())
+                ['state_of_residence_concept_id',
+                 'sex_at_birth_concept_id']).sort_index())
 
     def tearDown(self) -> None:
         for table in self.table_ids:


### PR DESCRIPTION
* Added `pipeline_logging`
* Updated `ADD_COLUMNS_QUERY` to add `sex_at_birth_*` columns
* Updated `UPDATE_PERSON_QUERY` to set `sex_at_birth_*` columns
* Updated unit test to test new functionality in `recreate_person.py`