### PR TITLE
[DC-706] Modify parameters of cleaning rule from DC-584

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -15,8 +15,7 @@ import cdr_cleaner.cleaning_rules.domain_alignment as domain_alignment
 import cdr_cleaner.cleaning_rules.drop_duplicate_states as drop_duplicate_states
 import cdr_cleaner.cleaning_rules.drop_extreme_measurements as extreme_measurements
 import cdr_cleaner.cleaning_rules.drop_multiple_measurements as drop_mult_meas
-import \
-    cdr_cleaner.cleaning_rules.drop_participants_without_ppi_or_ehr as drop_participants_without_ppi_or_ehr
+from cdr_cleaner.cleaning_rules.drop_participants_without_ppi_or_ehr import DropParticipantsWithoutPPI
 import cdr_cleaner.cleaning_rules.drug_refills_days_supply as drug_refills_supply
 import cdr_cleaner.cleaning_rules.maps_to_value_ppi_vocab_update as maps_to_value_vocab_update
 import cdr_cleaner.cleaning_rules.populate_route_ids as populate_routes
@@ -177,7 +176,7 @@ COMBINED_CLEANING_CLASSES = [
     # setup_query_execution function to load dependencies before query execution
     (
         domain_alignment.domain_alignment,),
-    (drop_participants_without_ppi_or_ehr.get_queries,),
+    (DropParticipantsWithoutPPI,),
     (clean_years.get_year_of_birth_queries,),
     (NegativeAges,),
     (NoDataAfterDeath,),

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
@@ -89,8 +89,6 @@ class DropParticipantsWithoutPPI(DropMissingParticipants):
 
         The removal criteria is for participants is as follows:
         1. They have not completed "The Basics" PPI module, via the RDR
-        OR
-        2. They do not have any EHR data
         These participants are not particularly useful for analysis, so remove them
         here.
         :return:  A list of string queries that can be executed to sandbox and delete data-poor

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
@@ -28,7 +28,7 @@ ISSUE_NUMBERS = ["DC584", "DC696", "DC706"]
 BASICS_MODULE_CONCEPT_ID = 1586134
 
 SELECT_QUERY = JINJA_ENV.from_string("""
-CREATE OR REPLACE `{{project}}.{{sandbox_dataset}}.{{sandbox_table}} AS
+CREATE OR REPLACE TABLE `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` AS
 SELECT p.*
 """)
 

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
@@ -99,20 +99,20 @@ def get_queries(project_id=None, dataset_id=None, sandbox_dataset_id=None):
 
     queries = []
     templates = {'basics': PERSON_WITH_NO_BASICS, 'ehr': PERSON_WITH_NO_EHR}
-    for missing_type in ['basics', 'ehr']:
+    for missing_type, template in templates.items():
         select_stmt = SELECT_QUERY.render(
             project=project_id,
             sandbox_dataset=sandbox_dataset_id,
             sandbox_table=f'{issue_numbers_str}_no_{missing_type}')
 
-        select_query = templates[missing_type].render(
+        select_query = template.render(
             query_type=select_stmt,
             project=project_id,
             dataset=dataset_id,
             basics_concept_id=BASICS_MODULE_CONCEPT_ID,
             mapped_clinical_data_configs=mapped_clinical_data_configs)
 
-        delete_query = templates[missing_type].render(
+        delete_query = template.render(
             query_type="DELETE",
             project=project_id,
             dataset=dataset_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_rows_for_missing_persons.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_rows_for_missing_persons.py
@@ -1,5 +1,17 @@
+"""
+Deletes records for participants who are missing from the person table.
+
+Developed to assist drop_participants_without_ppi_or_ehr.py in removing records
+"""
+
+# Python imports
+
+# Third party imports
+
+# Project imports
 import common
-from constants.cdr_cleaner import clean_cdr as clean_consts
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from constants.cdr_cleaner import clean_cdr as cdr_consts
 
 NON_PID_TABLES = [
     common.CARE_SITE, common.LOCATION, common.FACT_RELATIONSHIP, common.PROVIDER
@@ -8,34 +20,91 @@ NON_PID_TABLES = [
 TABLES_TO_DELETE_FROM = set(common.AOU_REQUIRED +
                             [common.OBSERVATION_PERIOD]) - set(NON_PID_TABLES)
 
-# Select rows where the person_id is in the person table
-DELETE_NON_EXISTING_PERSON_IDS = common.JINJA_ENV.from_string("""
-DELETE
-FROM `{project}.{dataset}.{table}`
-WHERE person_id NOT IN
-(SELECT person_id
-FROM `{project}.{dataset}.person`)
+SELECT_QUERY = common.JINJA_ENV.from_string("""
+CREATE OR REPLACE `{{project}}.{{sandbox_dataset}}.{{sandbox_table}} AS
+SELECT *
 """)
 
+# Delete rows in tables where the person_id is not in the person table
+RECORDS_FOR_NON_EXISTING_PIDS = common.JINJA_ENV.from_string("""
+{{query_type}}
+FROM `{{project}}.{{dataset}}.{{table_id}}`
+WHERE person_id NOT IN
+(SELECT person_id
+FROM `{{project}}.{{dataset}}.person`)
+""")
 
-def get_queries(project=None, dataset=None, sandbox_dataset_id=None):
+ISSUE_NUMBERS = ["DC584", "DC706"]
+
+
+class DropMissingParticipants(BaseCleaningRule):
     """
-    Return a list of queries to remove data for missing persons.
-
-    Removes data from person_id linked tables for any persons which do not
-    exist in the person table.
-    :param sandbox_dataset_id: Identifies the sandbox dataset to store rows
-    #TODO use sandbox_dataset_id for CR
-
-    :return:  A list of string queries that can be executed to delete data from
-        other tables for non-person users.
+    Drops participant data for pids missing from the person table
     """
-    query_list = []
-    for table in TABLES_TO_DELETE_FROM:
-        delete_query = DELETE_NON_EXISTING_PERSON_IDS.render(project=project,
-                                                             dataset=dataset,
-                                                             table=table)
 
-        query_list.append({clean_consts.QUERY: delete_query})
+    def __init__(self, issue_numbers, description, affected_datasets,
+                 affected_tables, project_id, dataset_id, sandbox_dataset_id,
+                 namer):
+        desc = f'Sandbox and remove rows for PIDs missing from the person table.'
 
-    return query_list
+        super().__init__(
+            issue_numbers=list(set(ISSUE_NUMBERS) | set(issue_numbers)),
+            description=f'{description} AND {desc}',
+            affected_datasets=affected_datasets,
+            affected_tables=affected_tables + list(TABLES_TO_DELETE_FROM),
+            project_id=project_id,
+            dataset_id=dataset_id,
+            sandbox_dataset_id=sandbox_dataset_id,
+            table_namer=namer)
+
+    def get_query_specs(self):
+        """
+        Return a list of queries to remove data for missing persons.
+
+        Removes data from person_id linked tables for any persons which do not
+        exist in the person table.
+        :return:  A list of string queries that can be executed to delete data from
+            other tables for non-person users.
+        """
+        query_list = []
+        for table in TABLES_TO_DELETE_FROM:
+            create_sandbox_ddl = SELECT_QUERY.render(
+                project=self.project_id,
+                sandbox_dataset=self.sandbox_dataset_id,
+                sandbox_table=self.sandbox_table_for(table))
+
+            sandbox_query = RECORDS_FOR_NON_EXISTING_PIDS.render(
+                query_type=create_sandbox_ddl,
+                project=self.project_id,
+                dataset=self.dataset_id,
+                table=table)
+            query_list.append({cdr_consts.QUERY: sandbox_query})
+
+            delete_query = RECORDS_FOR_NON_EXISTING_PIDS.render(
+                query_type="DELETE",
+                project=self.project_id,
+                dataset=self.dataset_id,
+                table=table)
+            query_list.append({cdr_consts.QUERY: delete_query})
+
+        return query_list
+
+    def sandbox_table_for(self, affected_table):
+        issue_numbers_str = '_'.join(
+            [issue_num.lower() for issue_num in self.issue_numbers])
+        return f'{issue_numbers_str}_{affected_table}'
+
+    def get_sandbox_tablenames(self):
+        return [
+            self.sandbox_table_for(affected_table)
+            for affected_table in self.affected_tables
+        ]
+
+    def setup_rule(self, client, *args, **keyword_args):
+        pass
+
+    def setup_validation(self, client, *args, **keyword_args):
+        pass
+
+    def validate_rule(self, client, *args, **keyword_args):
+        pass

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_rows_for_missing_persons.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_rows_for_missing_persons.py
@@ -52,7 +52,7 @@ class DropMissingParticipants(BaseCleaningRule):
             issue_numbers=list(set(ISSUE_NUMBERS) | set(issue_numbers)),
             description=f'{description} AND {desc}',
             affected_datasets=affected_datasets,
-            affected_tables=affected_tables + list(TABLES_TO_DELETE_FROM),
+            affected_tables=list(TABLES_TO_DELETE_FROM),
             project_id=project_id,
             dataset_id=dataset_id,
             sandbox_dataset_id=sandbox_dataset_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/person_id_validator.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/person_id_validator.py
@@ -69,7 +69,7 @@ def get_person_id_validation_queries(project=None,
     combined and unidentified dataset, the last portion of the dataset name is
     removed to access these tables.  Any other dataset is expected to have
     these tables and uses the mapping tables from within the same dataset.
-    :param sandbox_dataset_id: Identifies the sandbox dataset to store rows 
+    :param sandbox_dataset_id: Identifies the sandbox dataset to store rows
     #TODO use sandbox_dataset_id for CR
 
     :return:  A list of string queries that can be executed to delete invalid
@@ -105,9 +105,21 @@ def get_person_id_validation_queries(project=None,
         }
         query_list.append(query_dict)
 
+    # TODO use inheritance from DropMissingParticipants to create PersonIdValidator cleaning rule
+    # and reorganize similar to drop_participants_without_ppi_or_ehr
+    drop_rows_for_missing_persons_rule_instance = drop_rows_for_missing_persons.DropMissingParticipants(
+        issue_numbers=[],
+        description='',
+        affected_datasets=[],
+        affected_tables=[],
+        project_id=project,
+        dataset_id=dataset,
+        sandbox_dataset_id=sandbox_dataset_id,
+        namer='data_stage')
+
     # generate queries to remove person_ids of people not in the person table
     query_list.extend(
-        drop_rows_for_missing_persons.get_queries(project, dataset))
+        drop_rows_for_missing_persons_rule_instance.get_query_specs())
 
     return query_list
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
@@ -1,6 +1,7 @@
 # Python imports
 import os
 from datetime import date, datetime
+from unittest.mock import patch
 
 # Third party imports
 
@@ -36,17 +37,19 @@ class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
                                                        cls.dataset_id,
                                                        cls.sandbox_id)
 
-        cls.tables = [common.PERSON, common.OBSERVATION, common.DRUG_EXPOSURE]
+        cls.affected_tables = [
+            common.PERSON, common.OBSERVATION, common.DRUG_EXPOSURE
+        ]
         supporting_tables = ['_mapping_observation']
         # Generates list of fully qualified table names and their corresponding sandbox table names
         cls.fq_table_names = [
             f"{cls.project_id}.{cls.dataset_id}.{table}"
-            for table in cls.tables + supporting_tables
+            for table in cls.affected_tables + supporting_tables
         ]
 
         cls.fq_sandbox_table_names = [
             f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(table)}'
-            for table in cls.tables
+            for table in cls.affected_tables
         ]
 
         # call super to set up the client, create datasets
@@ -132,6 +135,9 @@ class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
             f'{self.project_id}.{self.vocabulary_id}.concept_ancestor',
             f'{self.project_id}.{self.dataset_id}.concept_ancestor')
 
+    @patch(
+        'cdr_cleaner.cleaning_rules.drop_rows_for_missing_persons.TABLES_TO_DELETE_FROM',
+        [common.PERSON, common.OBSERVATION, common.DRUG_EXPOSURE])
     def test_queries(self):
         """
         Validates pre-conditions, test execution and post conditions based on the tables_and_counts variable.
@@ -174,10 +180,10 @@ class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
                 'drug_type_concept_id'
             ],
             'loaded_ids': [200, 201],
-            'cleaned_values': [(200, 3, 10, date.fromisoformat('2021-01-01'),
-                                datetime.fromisoformat('2021-01-01+00:00'), 1),
-                               (201, 4, 11, date.fromisoformat('2021-01-01'),
-                                datetime.fromisoformat('2021-01-01+00:00'), 2)]
+            'cleaned_values': [
+                (201, 4, 11, date.fromisoformat('2021-01-01'),
+                 datetime.fromisoformat('2021-01-01 00:00:00+00:00'), 2)
+            ]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
@@ -1,74 +1,21 @@
 # Python imports
-import unittest
+import os
+from datetime import date, datetime
 
 # Third party imports
-from jinja2 import Template
 
 # Project imports
-import bq_utils
 import common
-from cdr_cleaner import clean_cdr_engine
-from cdr_cleaner.cleaning_rules import drop_participants_without_ppi_or_ehr
-from tests import test_util
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.drop_participants_without_ppi_or_ehr import DropParticipantsWithoutPPI
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
-# Participant 1: no data (to be removed)
-# Participant 2: has the basics only
-# Participant 3: has EHR data only
-# Participant 4: has both basics and EHR
-# Participant 5: has only RDR consent (to be removed)
-# Participant 6: has EHR observation only
-INSERT_FAKE_PARTICIPANTS_TMPLS = [
-    # TODO(calbach): Ideally these tests should not manipulate concept table, not currently hermetic.
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}.concept` (concept_id)
-VALUES
-  ({{rdr_basics_concept_id}}),
-  ({{rdr_basics_module_concept_id}}),
-  ({{rdr_consent_concept_id}}),
-  ({{ehr_obs_concept_id}})
-"""),
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}.concept_ancestor` (descendant_concept_id, ancestor_concept_id)
-VALUES ({{rdr_basics_concept_id}}, {{rdr_basics_module_concept_id}})
-"""),
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}.person` (person_id)
-VALUES (1), (2), (3), (4), (5), (6)
-"""),
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}.observation` (person_id, observation_id, observation_concept_id)
-VALUES
-  (2, 100, {{rdr_basics_concept_id}}),
-  (2, 101, {{rdr_consent_concept_id}}),
-  (4, 102, {{rdr_basics_concept_id}}),
-  (5, 103, {{rdr_consent_concept_id}}),
-  (6, 104, {{ehr_obs_concept_id}})
-"""),
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}._mapping_observation` (observation_id, src_hpo_id)
-VALUES
-  (100, "rdr"),
-  (101, "rdr"),
-  (102, "rdr"),
-  (103, "rdr"),
-  (104, "fake-hpo")
-"""),
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}.drug_exposure` (person_id, drug_exposure_id)
-VALUES
-  (3, 200),
-  (4, 201)
-"""),
-    Template("""
-INSERT INTO `{{project_id}}.{{dataset_id}}._mapping_drug_exposure` (drug_exposure_id, src_hpo_id)
-VALUES
-  (200, "fake-hpo"),
-  (201, "fake-hpo")
-""")
-]
+CONSENT_CONCEPT_ID = 1586100
+BASICS_CONCEPT_ID = 1586134
+TYPE_CONCEPT_ID_SURVEY = 45905771
 
 
-class DropParticipantsWithoutPpiOrEhrTest(unittest.TestCase):
+class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
 
     @classmethod
     def setUpClass(cls):
@@ -76,60 +23,140 @@ class DropParticipantsWithoutPpiOrEhrTest(unittest.TestCase):
         print(cls.__name__)
         print('**************************************************************')
 
-    def test_get_queries(self):
-        results = drop_participants_without_ppi_or_ehr.get_queries('foo', 'bar')
+        super().initialize_class_vars()
 
-        self.assertEqual(
-            len(results), 1 + len(common.CLINICAL_DATA_TABLES),
-            'wanted one person deletion query and a deletion query per clinical table'
-        )
+        # Set the test project identifier
+        cls.project_id = os.environ.get(PROJECT_ID)
 
-    @unittest.skip(
-        "TODO(calbach): Move into integration test package, once that exists")
-    def test_execute_queries(self):
-        project_id = bq_utils.app_identity.get_application_id()
-        dataset_id = bq_utils.get_combined_dataset_id()
-        sandbox_id = bq_utils.get_unioned_dataset_id()
-        test_util.delete_all_tables(dataset_id)
+        # Set the expected test datasets
+        cls.dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.sandbox_id = f'{cls.dataset_id}_sandbox'
+        cls.vocabulary_id = os.environ.get('VOCABULARY_DATASET')
+        cls.rule_instance = DropParticipantsWithoutPPI(cls.project_id,
+                                                       cls.dataset_id,
+                                                       cls.sandbox_id)
 
-        create_tables = (
-            ['person'] + common.CLINICAL_DATA_TABLES +
-            ['_mapping_' + t for t in common.MAPPED_CLINICAL_DATA_TABLES])
-        # TODO(calbach): Make the setup/teardown of these concept tables hermetic.
-        for tbl in ['concept', 'concept_ancestor']:
-            if not bq_utils.table_exists(tbl, dataset_id=dataset_id):
-                create_tables.push(tbl)
-        for tbl in create_tables:
-            bq_utils.create_standard_table(tbl,
-                                           tbl,
-                                           dataset_id=dataset_id,
-                                           force_all_nullable=True)
+        cls.tables = [common.PERSON, common.OBSERVATION, common.DRUG_EXPOSURE]
+        # Generates list of fully qualified table names and their corresponding sandbox table names
+        cls.fq_table_names = [
+            f"{cls.project_id}.{cls.dataset_id}.{table}" for table in cls.tables
+        ]
 
-        for tmpl in INSERT_FAKE_PARTICIPANTS_TMPLS:
-            resp = bq_utils.query(
-                tmpl.render(project_id=project_id,
-                            dataset_id=dataset_id,
-                            rdr_basics_concept_id=123,
-                            rdr_consent_concept_id=345,
-                            ehr_obs_concept_id=567,
-                            rdr_basics_module_concept_id=
-                            drop_participants_without_ppi_or_ehr.
-                            BASICS_MODULE_CONCEPT_ID))
-            self.assertTrue(resp["jobComplete"])
+        cls.fq_sandbox_table_names = [
+            f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(table)}'
+            for table in cls.tables
+        ]
 
-        clean_cdr_engine.clean_dataset(
-            project_id, dataset_id, sandbox_id,
-            [(drop_participants_without_ppi_or_ehr.get_queries,)])
+        # call super to set up the client, create datasets
+        cls.up_class = super().setUpClass()
 
-        def table_to_person_ids(t):
-            rows = bq_utils.response2rows(
-                bq_utils.query("SELECT person_id FROM `{}.{}.{}`".format(
-                    project_id, dataset_id, t)))
-            return set([r["person_id"] for r in rows])
+    def setUp(self):
+        # create tables
+        super().setUp()
 
-        # We expect participants 1, 5 to have been removed from all tables.
-        self.assertEqual(set([2, 3, 4, 6]), table_to_person_ids("person"))
-        self.assertEqual(set([2, 4, 6]), table_to_person_ids("observation"))
-        self.assertEquals(set([3, 4]), table_to_person_ids("drug_exposure"))
+        self.copy_vocab_tables()
 
-        test_util.delete_all_tables(dataset_id)
+        # Participant 1: no data (to be removed)
+        # Participant 2: has the basics only
+        # Participant 3: has EHR data only (to be removed as of DC-706)
+        # Participant 4: has both basics and EHR
+        # Participant 5: has only RDR consent (to be removed)
+        # Participant 6: has EHR observation only (to be removed as of DC-706)
+        drug_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{project_id}}.{{dataset_id}}.drug_exposure`
+                (drug_exposure_id, person_id, drug_concept_id, drug_exposure_start_date,
+                drug_exposure_start_datetime)
+            VALUES
+                (200, 3, 10, '2021-01-01', TIMESTAMP('2021-01-01')),
+                (201, 4, 11, '2021-01-01', TIMESTAMP('2021-01-01'))
+            """)
+        observation_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+                (observation_id, person_id, observation_concept_id, observation_date,
+                observation_type_concept_id)
+            VALUES
+                (100, 2, {{rdr_basics_concept_id}}, '2021-01-01', {{survey_concept_id}}),
+                (101, 2, {{rdr_consent_concept_id}}, '2021-01-01', {{survey_concept_id}}),
+                (102, 4, {{rdr_basics_concept_id}}), '2021-01-01', {{survey_concept_id}},
+                (103, 5, {{rdr_consent_concept_id}}, '2021-01-01', {{survey_concept_id}})
+            """)
+        person_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{project_id}}.{{dataset_id}}.person`
+                (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
+            VALUES 
+                (1, 2, 2000, 3, 4),
+                (2, 3, 2001, 4, 5),
+                (3, 4, 2001, 5, 6),
+                (4, 5, 2002, 6, 7),
+                (5, 6, 2002, 6, 7),
+                (6, 7, 2002, 7, 8)
+            """)
+
+        drug_query = drug_tmpl.render(project=self.project_id,
+                                      dataset=self.dataset_id)
+        observation_query = observation_tmpl.render(
+            project=self.project_id,
+            dataset=self.dataset_id,
+            rdr_basics_concept_id=BASICS_CONCEPT_ID,
+            rdr_consent_concept_id=CONSENT_CONCEPT_ID,
+            survey_concept_id=TYPE_CONCEPT_ID_SURVEY)
+        person_query = person_tmpl.render(project=self.project_id,
+                                          dataset=self.dataset_id)
+
+        # load the test data
+        self.load_test_data([drug_query, observation_query, person_query])
+
+    def copy_vocab_tables(self):
+        self.client.copy_table(
+            f'{self.project_id}.{self.vocabulary_id}.concept',
+            f'{self.project_id}.{self.dataset_id}.concept')
+        self.client.copy_table(
+            f'{self.project_id}.{self.vocabulary_id}.concept_ancestor',
+            f'{self.project_id}.{self.dataset_id}.concept_ancestor')
+
+    def test_queries(self):
+        """
+        Validates pre-conditions, test execution and post conditions based on the tables_and_counts variable.
+        """
+        tables_and_counts = [{
+            'name': common.PERSON,
+            'fq_table_name': self.fq_table_names[0],
+            'fields': [
+                'person_id', 'gender_concept_id', 'year_of_birth',
+                'race_concept_id', 'ethnicity_concept_id'
+            ],
+            'loaded_ids': [1, 2, 3, 4, 5, 6],
+            'cleaned_values': [(2, 3, 2001, 4, 5), (4, 5, 2002, 6, 7)]
+        }, {
+            'name':
+                common.OBSERVATION,
+            'fq_table_name':
+                self.fq_table_names[1],
+            'fields': [
+                'observation_id', 'person_id', 'observation_concept_id',
+                'observation_date', 'observation_type_concept_id'
+            ],
+            'loaded_ids': [100, 101, 102, 103],
+            'cleaned_values': [(100, 2, BASICS_CONCEPT_ID, date('2021-01-01'),
+                                TYPE_CONCEPT_ID_SURVEY),
+                               (101, 2, CONSENT_CONCEPT_ID, date('2021-01-01'),
+                                TYPE_CONCEPT_ID_SURVEY),
+                               (102, 4, BASICS_CONCEPT_ID, date('2021-01-01'),
+                                TYPE_CONCEPT_ID_SURVEY)]
+        }, {
+            'name':
+                common.DRUG_EXPOSURE,
+            'fq_table_name':
+                self.fq_table_names[2],
+            'fields': [
+                'drug_exposure_id', 'person_id', 'drug_concept_id',
+                'drug_exposure_start_date', 'drug_exposure_start_datetime'
+            ],
+            'loaded_ids': [200, 201],
+            'cleaned_values': [(200, 3, 10, date('2021-01-01'),
+                                datetime.fromisoformat('2021-01-01+00:00')),
+                               (201, 4, 11, date('2021-01-01'),
+                                datetime.fromisoformat('2021-01-01+00:00'))]
+        }]
+
+        self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
@@ -41,10 +41,12 @@ class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
             common.PERSON, common.OBSERVATION, common.DRUG_EXPOSURE
         ]
         supporting_tables = ['_mapping_observation']
+        cls.vocab_tables = ['concept', 'concept_ancestor']
         # Generates list of fully qualified table names and their corresponding sandbox table names
         cls.fq_table_names = [
             f"{cls.project_id}.{cls.dataset_id}.{table}"
-            for table in cls.affected_tables + supporting_tables
+            for table in cls.affected_tables + supporting_tables +
+            cls.vocab_tables
         ]
 
         cls.fq_sandbox_table_names = [
@@ -128,12 +130,10 @@ class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
         ])
 
     def copy_vocab_tables(self):
-        self.client.copy_table(
-            f'{self.project_id}.{self.vocabulary_id}.concept',
-            f'{self.project_id}.{self.dataset_id}.concept')
-        self.client.copy_table(
-            f'{self.project_id}.{self.vocabulary_id}.concept_ancestor',
-            f'{self.project_id}.{self.dataset_id}.concept_ancestor')
+        for table in self.vocab_tables:
+            self.client.copy_table(
+                f'{self.project_id}.{self.vocabulary_id}.{table}',
+                f'{self.project_id}.{self.dataset_id}.{table}')
 
     @patch(
         'cdr_cleaner.cleaning_rules.drop_rows_for_missing_persons.TABLES_TO_DELETE_FROM',

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/person_id_validator_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/person_id_validator_test.py
@@ -12,6 +12,20 @@ from cdr_cleaner.cleaning_rules import drop_rows_for_missing_persons
 from cdr_cleaner.cleaning_rules import person_id_validator as validator
 import resources
 
+SANDBOX_DDL = """
+CREATE OR REPLACE TABLE `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` AS
+SELECT *
+"""
+
+
+# to use method from DropMissingParticipants
+def drop_rows_for_missing_persons_sandbox_for(affected_table):
+    issue_numbers_str = '_'.join([
+        issue_num.lower()
+        for issue_num in set(drop_rows_for_missing_persons.ISSUE_NUMBERS)
+    ])
+    return f'{issue_numbers_str}_{affected_table}'
+
 
 class PersonIDValidatorTest(unittest.TestCase):
 
@@ -22,6 +36,11 @@ class PersonIDValidatorTest(unittest.TestCase):
         print('**************************************************************')
 
     def setUp(self):
+        self.project = 'foo'
+        self.dataset = 'bar'
+        self.sandbox = f'{self.dataset}_sandbox'
+        self.deid_dataset = 'bar_deid'
+        self.deid_sandbox = f'{self.deid_dataset}_sandbox'
         self.mapped_tables = copy.copy(common.MAPPED_CLINICAL_DATA_TABLES)
         self.drop_tables = copy.copy(
             drop_rows_for_missing_persons.TABLES_TO_DELETE_FROM)
@@ -30,14 +49,15 @@ class PersonIDValidatorTest(unittest.TestCase):
         # pre conditions
 
         # test
-        results = validator.get_person_id_validation_queries('foo', 'bar')
+        results = validator.get_person_id_validation_queries(
+            self.project, self.dataset, self.sandbox)
 
         # post conditions
         self.assertEqual(len(results),
-                         len(self.drop_tables) + len(self.mapped_tables))
+                         len(self.mapped_tables) + len(self.drop_tables) * 2)
 
         existing_and_consenting = validator.EXISTING_AND_VALID_CONSENTING_RECORDS
-        existing_in_person_table = drop_rows_for_missing_persons.DELETE_NON_EXISTING_PERSON_IDS
+        existing_in_person_table = drop_rows_for_missing_persons.RECORDS_FOR_NON_EXISTING_PIDS
 
         expected = []
         for table in self.mapped_tables:
@@ -49,24 +69,39 @@ class PersonIDValidatorTest(unittest.TestCase):
 
             expected.append({
                 clean_consts.QUERY:
-                    existing_and_consenting.format(project='foo',
-                                                   dataset='bar',
-                                                   mapping_dataset='bar',
+                    existing_and_consenting.format(project=self.project,
+                                                   dataset=self.dataset,
+                                                   mapping_dataset=self.dataset,
                                                    table=table,
                                                    fields=fields),
                 clean_consts.DESTINATION_TABLE:
                     table,
                 clean_consts.DESTINATION_DATASET:
-                    'bar',
+                    self.dataset,
                 clean_consts.DISPOSITION:
                     bq_consts.WRITE_TRUNCATE,
             })
 
         for table in self.drop_tables:
+            sandbox_ddl_query = common.JINJA_ENV.from_string(
+                SANDBOX_DDL).render(
+                    project=self.project,
+                    sandbox_dataset=self.sandbox,
+                    sandbox_table=drop_rows_for_missing_persons_sandbox_for(
+                        table))
             expected.append({
                 clean_consts.QUERY:
-                    existing_in_person_table.render(project='foo',
-                                                    dataset='bar',
+                    existing_in_person_table.render(
+                        query_type=sandbox_ddl_query,
+                        project=self.project,
+                        dataset=self.dataset,
+                        table=table)
+            })
+            expected.append({
+                clean_consts.QUERY:
+                    existing_in_person_table.render(query_type='DELETE',
+                                                    project=self.project,
+                                                    dataset=self.dataset,
                                                     table=table)
             })
 
@@ -76,14 +111,15 @@ class PersonIDValidatorTest(unittest.TestCase):
         # pre conditions
 
         # test
-        results = validator.get_person_id_validation_queries('foo', 'bar_deid')
+        results = validator.get_person_id_validation_queries(
+            self.project, 'bar_deid', 'bar_deid_sandbox')
 
         # post conditions
         self.assertEqual(len(results),
-                         len(self.mapped_tables) + len(self.drop_tables))
+                         len(self.mapped_tables) + len(self.drop_tables) * 2)
 
         existing_and_consenting = validator.EXISTING_AND_VALID_CONSENTING_RECORDS
-        existing_in_person_table = drop_rows_for_missing_persons.DELETE_NON_EXISTING_PERSON_IDS
+        existing_in_person_table = drop_rows_for_missing_persons.RECORDS_FOR_NON_EXISTING_PIDS
 
         expected = []
         for table in self.mapped_tables:
@@ -95,9 +131,9 @@ class PersonIDValidatorTest(unittest.TestCase):
 
             expected.append({
                 clean_consts.QUERY:
-                    existing_and_consenting.format(project='foo',
+                    existing_and_consenting.format(project=self.project,
                                                    dataset='bar_deid',
-                                                   mapping_dataset='bar',
+                                                   mapping_dataset=self.dataset,
                                                    table=table,
                                                    fields=fields),
                 clean_consts.DESTINATION_TABLE:
@@ -109,10 +145,25 @@ class PersonIDValidatorTest(unittest.TestCase):
             })
 
         for table in self.drop_tables:
+            sandbox_ddl_query = common.JINJA_ENV.from_string(
+                SANDBOX_DDL).render(
+                    project=self.project,
+                    sandbox_dataset=self.deid_sandbox,
+                    sandbox_table=drop_rows_for_missing_persons_sandbox_for(
+                        table))
             expected.append({
                 clean_consts.QUERY:
-                    existing_in_person_table.render(project='foo',
-                                                    dataset='bar_deid',
+                    existing_in_person_table.render(
+                        query_type=sandbox_ddl_query,
+                        project=self.project,
+                        dataset=self.deid_dataset,
+                        table=table)
+            })
+            expected.append({
+                clean_consts.QUERY:
+                    existing_in_person_table.render(query_type='DELETE',
+                                                    project=self.project,
+                                                    dataset=self.deid_dataset,
                                                     table=table)
             })
 


### PR DESCRIPTION
* [DC-706] Separate out queries for missing basics and missing ehr data
* [DC-706] Consider all pid tables for deletion
* [DC-706] Sandbox person rows before deleting
* [DC-706] Use dict and add back basics constant

[DC-706]: https://precisionmedicineinitiative.atlassian.net/browse/DC-706
[DC-706]: https://precisionmedicineinitiative.atlassian.net/browse/DC-706
[DC-706]: https://precisionmedicineinitiative.atlassian.net/browse/DC-706
[DC-706]: https://precisionmedicineinitiative.atlassian.net/browse/DC-706