### PR TITLE
[DC-1633] Create cleaning rule to update invalid ZIP entries

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -93,6 +93,7 @@ from cdr_cleaner.cleaning_rules.identifying_field_suppression import IDFieldSupp
 from cdr_cleaner.cleaning_rules.aggregate_zip_codes import AggregateZipCodes
 from cdr_cleaner.cleaning_rules.remove_extra_tables import RemoveExtraTables
 from cdr_cleaner.cleaning_rules.store_pid_rid_mappings import StoreNewPidRidMappings
+from cdr_cleaner.cleaning_rules.update_invalid_zip_codes import UpdateInvalidZipCodes
 from cdr_cleaner.manual_cleaning_rules.survey_version_info import COPESurveyVersionTask
 from cdr_cleaner.cleaning_rules.deid.string_fields_suppression import StringFieldsSuppression
 from constants.cdr_cleaner import clean_cdr_engine as ce_consts
@@ -163,6 +164,7 @@ RDR_CLEANING_CLASSES = [
     (DropDuplicatePpiQuestionsAndAnswers,),
     (extreme_measurements.get_drop_extreme_measurement_queries,),
     (drop_mult_meas.get_drop_multiple_measurement_queries,),
+    (UpdateInvalidZipCodes,),
 ]
 
 COMBINED_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
@@ -3,9 +3,12 @@ Sandbox and update invalid zip codes found in the observation table.
 
 Original Issues: DC-1633, DC-1645
 
-The intent of this cleaning rule is to sandbox and update any invalid zip code in the observation table. A zip code is
-    considered invalid if it does not match a zip3 code in the zip3 master lookup table or if it less than 5 digits.
-    The record is sandboxed and updated to have the following information:
+The intent of this cleaning rule is to remove any leading/trailing whitespace in the zip code string then sandbox and
+update any invalid zip code in the observation table. A zip code is considered invalid if it:
+        Is less than 5 digits in length
+        Is alpha-numeric
+        Does not match any zip3 code in the master zip3 lookup table
+If zip code is deemed invalid the record is sandboxed and updated to have the following information:
         value_as_string and value_source_value = 'Response removed due to invalid value'
         value_as_number = 0
         value_source_concept_id = 2000000010
@@ -22,26 +25,41 @@ from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 
 LOGGER = logging.getLogger(__name__)
 
+ZIPS_WITH_WHITESPACE_SANDBOX = 'dc1633_zips_with_whitespace'
+
+# Creates sandbox that contains any zips that have leading/trailing whitespace
+SANDBOX_ZIPS_WITH_WHITESPACE = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{whitespace_sandbox}}` AS
+SELECT * FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}`
+WHERE observation_source_concept_id = 1585250 
+AND REGEXP_CONTAINS(value_as_string, ' ')
+""")
+
 # Creates sandbox that contains all invalid zip codes which are deemed invalid because they:
 # 1. Are not 5 digits in length
-# 2. Do not match a zip3 code in the master zip3 lookup table
+# 2. Are are alpha-numeric
+# 3. Do not match a zip3 code in the master zip3 lookup table
 SANDBOX_INVALID_ZIP_CODES = JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}` AS (
--- Only selects columns from one observation table --
-SELECT L.* FROM (
--- Selects all zips that are less than 5 digits in length --
+-- Selects all zips that are less than 5 digits in length and/or alpha-numeric --
 SELECT * FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}`
-WHERE observation_source_concept_id = 1585250 AND LENGTH(value_as_string) < 5) AS L
--- Using left join in order not to get duplicate records for zips that are both less than 5 digits in length --
--- and do not match a zip in the master zip3 lookup table --
-LEFT JOIN (
+WHERE observation_source_concept_id = 1585250 
+AND (LENGTH(value_as_string) < 5 
+OR NOT REGEXP_CONTAINS(value_as_string, r'^[0-9]{5}(?:-[0-9]{4})?$'))
+-- Using union distinct to prevent duplicates --
+UNION DISTINCT (
 -- Selects all zips that do not match one in the master zip3 lookup table --
 SELECT o.* FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` o
 LEFT JOIN `{{project_id}}.{{pipeline_tables}}.{{zip3_lookup}}` z
-ON CAST(SUBSTR(o.value_as_string, 1, 3) AS INT64) = z.zip3
-WHERE (observation_source_concept_id = 1585250
-AND z.zip3 IS NULL)
-) AS R ON L.person_id = R.person_id)
+ON SUBSTR(o.value_as_string, 1, 3) = CAST(z.zip3 AS STRING)
+WHERE (observation_source_concept_id = 1585250 AND z.zip3 IS NULL)))
+""")
+
+CLEAN_ZIPS_OF_WHITESPACE = JINJA_ENV.from_string("""
+UPDATE `{{project_id}}.{{dataset_id}}.{{obs_table}}` SET
+value_as_string = TRIM(value_as_string)
+WHERE person_id IN (
+SELECT person_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{whitespace_sandbox}}`)
 """)
 
 UPDATE_INVALID_ZIP_CODES = JINJA_ENV.from_string("""
@@ -85,14 +103,14 @@ class UpdateInvalidZipCodes(BaseCleaningRule):
             and a specification for how to execute that query. The specifications
             are optional but the query is required.
         """
-        keep_valid_zip_codes = {
+        sandbox_zips_with_whitespace = {
             cdr_consts.QUERY:
-                UPDATE_INVALID_ZIP_CODES.render(
+                SANDBOX_ZIPS_WITH_WHITESPACE.render(
                     project_id=self.project_id,
-                    dataset_id=self.dataset_id,
-                    obs_table=OBSERVATION,
                     sandbox_dataset_id=self.sandbox_dataset_id,
-                    sandbox_table=self.sandbox_table_for(OBSERVATION))
+                    whitespace_sandbox=ZIPS_WITH_WHITESPACE_SANDBOX,
+                    dataset_id=self.dataset_id,
+                    obs_table=OBSERVATION)
         }
 
         sandbox_invalid_zip_codes = {
@@ -107,7 +125,30 @@ class UpdateInvalidZipCodes(BaseCleaningRule):
                     zip3_lookup=ZIP3_LOOKUP)
         }
 
-        return [sandbox_invalid_zip_codes, keep_valid_zip_codes]
+        clean_zips_of_whitespace = {
+            cdr_consts.QUERY:
+                CLEAN_ZIPS_OF_WHITESPACE.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    obs_table=OBSERVATION,
+                    sandbox_dataset_id=self.sandbox_dataset_id,
+                    whitespace_sandbox=ZIPS_WITH_WHITESPACE_SANDBOX)
+        }
+
+        update_zip_codes = {
+            cdr_consts.QUERY:
+                UPDATE_INVALID_ZIP_CODES.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    obs_table=OBSERVATION,
+                    sandbox_dataset_id=self.sandbox_dataset_id,
+                    sandbox_table=self.sandbox_table_for(OBSERVATION))
+        }
+
+        return [
+            sandbox_zips_with_whitespace, clean_zips_of_whitespace,
+            sandbox_invalid_zip_codes, update_zip_codes
+        ]
 
     def setup_rule(self, client, *args, **keyword_args):
         """
@@ -116,7 +157,10 @@ class UpdateInvalidZipCodes(BaseCleaningRule):
         pass
 
     def get_sandbox_tablenames(self):
-        return [self.sandbox_table_for(OBSERVATION)]
+        return [
+            ZIPS_WITH_WHITESPACE_SANDBOX,
+            self.sandbox_table_for(OBSERVATION)
+        ]
 
     def setup_validation(self, client, *args, **keyword_args):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
@@ -1,0 +1,155 @@
+"""
+Sandbox and update invalid zip codes found in the observation table.
+
+Original Issues: DC-1633, DC-1645
+
+The intent of this cleaning rule is to sandbox and update any invalid zip code in the observation table. A zip code is
+    considered invalid if it does not match a zip3 code in the zip3 master lookup table or if it less than 5 digits.
+    The record is sandboxed and updated to have the following information:
+        value_as_string and value_source_value = 'Response removed due to invalid value'
+        value_as_number = 0
+        value_source_concept_id = 2000000010
+"""
+
+# Python imports
+import logging
+
+# Project imports
+from utils import pipeline_logging
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from common import JINJA_ENV, OBSERVATION, PIPELINE_TABLES, ZIP3_LOOKUP
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+
+LOGGER = logging.getLogger(__name__)
+
+# Creates sandbox that contains all invalid zip codes which are deemed invalid because they:
+# 1. Are not 5 digits in length
+# 2. Do not match a zip3 code in the master zip3 lookup table
+SANDBOX_INVALID_ZIP_CODES = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}` AS (
+-- Only selects columns from one observation table --
+SELECT L.* FROM (
+-- Selects all zips that are less than 5 digits in length --
+SELECT * FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}`
+WHERE observation_source_concept_id = 1585250 AND LENGTH(value_as_string) < 5) AS L
+-- Using left join in order not to get duplicate records for zips that are both less than 5 digits in length --
+-- and do not match a zip in the master zip3 lookup table --
+LEFT JOIN (
+-- Selects all zips that do not match one in the master zip3 lookup table --
+SELECT o.* FROM `{{project_id}}.{{dataset_id}}.{{obs_table}}` o
+LEFT JOIN `{{project_id}}.{{pipeline_tables}}.{{zip3_lookup}}` z
+ON CAST(SUBSTR(o.value_as_string, 1, 3) AS INT64) = z.zip3
+WHERE (observation_source_concept_id = 1585250
+AND z.zip3 IS NULL)
+) AS R ON L.person_id = R.person_id)
+""")
+
+# Updates value_as_string to 'Invalid Zip', and value_as_number to 0 in observation table if that record is found
+# in the sandbox table.
+UPDATE_INVALID_ZIP_CODES = JINJA_ENV.from_string("""
+UPDATE `{{project_id}}.{{dataset_id}}.{{obs_table}}` SET
+value_as_string = 'Response removed due to invalid value',
+value_source_value = 'Response removed due to invalid value',
+value_as_number = 0,
+value_source_concept_id = 2000000010
+WHERE person_id IN (
+SELECT person_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}`)
+""")
+
+
+class UpdateInvalidZipCodes(BaseCleaningRule):
+    """
+    Any invalid zip code will be sandboxed and updated.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id):
+        """
+        Initialize the class with proper information.
+
+        Set the issue numbers, description and affected datasets. As other tickets may affect
+        this SQL, append them to the list of Jira Issues.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = 'Sandbox and update invalid zip codes found in the observation table.'
+        super().__init__(issue_numbers=['DC1633'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         affected_tables=[OBSERVATION],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
+
+    def get_query_specs(self, *args, **keyword_args):
+        """
+        Return a list of dictionary query specifications.
+
+        :return:  A list of dictionaries. Each dictionary contains a single query
+            and a specification for how to execute that query. The specifications
+            are optional but the query is required.
+        """
+        keep_valid_zip_codes = {
+            cdr_consts.QUERY:
+                UPDATE_INVALID_ZIP_CODES.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    obs_table=OBSERVATION,
+                    sandbox_dataset_id=self.sandbox_dataset_id,
+                    sandbox_table=self.sandbox_table_for(OBSERVATION))
+        }
+
+        sandbox_invalid_zip_codes = {
+            cdr_consts.QUERY:
+                SANDBOX_INVALID_ZIP_CODES.render(
+                    project_id=self.project_id,
+                    sandbox_dataset_id=self.sandbox_dataset_id,
+                    sandbox_table=self.sandbox_table_for(OBSERVATION),
+                    dataset_id=self.dataset_id,
+                    obs_table=OBSERVATION,
+                    pipeline_tables=PIPELINE_TABLES,
+                    zip3_lookup=ZIP3_LOOKUP)
+        }
+
+        return [sandbox_invalid_zip_codes, keep_valid_zip_codes]
+
+    def setup_rule(self, client, *args, **keyword_args):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def get_sandbox_tablenames(self):
+        return [self.sandbox_table_for(OBSERVATION)]
+
+    def setup_validation(self, client, *args, **keyword_args):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client, *args, **keyword_args):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.parse_args()
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(ARGS.project_id,
+                                                 ARGS.dataset_id,
+                                                 ARGS.sandbox_dataset_id,
+                                                 [(UpdateInvalidZipCodes,)])
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(UpdateInvalidZipCodes,)])

--- a/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
@@ -44,8 +44,6 @@ AND z.zip3 IS NULL)
 ) AS R ON L.person_id = R.person_id)
 """)
 
-# Updates value_as_string to 'Invalid Zip', and value_as_number to 0 in observation table if that record is found
-# in the sandbox table.
 UPDATE_INVALID_ZIP_CODES = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.{{obs_table}}` SET
 value_as_string = 'Response removed due to invalid value',

--- a/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes.py
@@ -58,8 +58,8 @@ WHERE (observation_source_concept_id = 1585250 AND z.zip3 IS NULL)))
 CLEAN_ZIPS_OF_WHITESPACE = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.{{obs_table}}` SET
 value_as_string = TRIM(value_as_string)
-WHERE person_id IN (
-SELECT person_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{whitespace_sandbox}}`)
+WHERE observation_id IN (
+SELECT observation_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{whitespace_sandbox}}`)
 """)
 
 UPDATE_INVALID_ZIP_CODES = JINJA_ENV.from_string("""
@@ -68,8 +68,8 @@ value_as_string = 'Response removed due to invalid value',
 value_source_value = 'Response removed due to invalid value',
 value_as_number = 0,
 value_source_concept_id = 2000000010
-WHERE person_id IN (
-SELECT person_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}`)
+WHERE observation_id IN (
+SELECT observation_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}`)
 """)
 
 

--- a/data_steward/common.py
+++ b/data_steward/common.py
@@ -220,6 +220,8 @@ PRIMARY_PID_RID_MAPPING = 'primary_pid_rid_mapping'
 PIPELINE_TABLES = 'pipeline_tables'
 COPE_SURVEY_MAP = 'cope_survey_semantic_version_map'
 
+ZIP3_LOOKUP = 'zip3_lookup'
+
 # JINJA
 JINJA_ENV = jinja2.Environment(
     # block tags on their own lines

--- a/data_steward/resource_files/schemas/pipeline_tables/zip3_lookup.json
+++ b/data_steward/resource_files/schemas/pipeline_tables/zip3_lookup.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "integer",
+    "name": "zip3",
+    "mode": "nullable",
+    "description": "Integer representation of ZIP3 code (e.g. 3, 370, etc.)"
+  },
+  {
+    "type": "string",
+    "name": "zip3_as_string",
+    "mode": "nullable",
+    "description": "String representation of de-ied ZIP3 value (e.g. 003**, 370**)"
+  }
+]

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes_test.py
@@ -1,0 +1,157 @@
+"""
+Integration test for drop_invalid_zip_codes.py module.
+
+This cleaning rule sandboxes and updates any invalid zip codes.
+
+Original Issues: DC-1633, DC-1645
+
+Ensures that any invalid zip codes are sandboxed and updated. Invalid zip codes are those that are less than 5 digits
+    in length or do not match a zip3 value in the zip3 lookup table. If a zip code is invalid, the value_as_string is
+    updated to 'Invalid Zip' and the value_as_number is updated to 0.
+"""
+
+# Python imports
+import os
+
+# Third party imports
+import mock
+from dateutil import parser
+
+# Project imports
+from common import OBSERVATION, ZIP3_LOOKUP
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.update_invalid_zip_codes import UpdateInvalidZipCodes
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+
+class UpdateInvalidZipCodesTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # set the expected test datasets
+        # intended to be run on the deid_base dataset.  The combined dataset
+        # environment variable should be guaranteed to exist
+        dataset_id = os.environ.get('RDR_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        cls.rule_instance = UpdateInvalidZipCodes(project_id, dataset_id,
+                                                  sandbox_id)
+
+        sb_table_names = cls.rule_instance.get_sandbox_tablenames()
+        for table_name in sb_table_names:
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{table_name}')
+
+        # This will normally be the PIPELINE_TABLES dataset, but is being
+        # mocked for this test
+        cls.zip3_lookup_name = f'{cls.project_id}.{cls.dataset_id}.{ZIP3_LOOKUP}'
+
+        cls.fq_table_names = [
+            f"{project_id}.{dataset_id}.{OBSERVATION}", cls.zip3_lookup_name
+        ]
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    def setUp(self):
+        """
+        Create common information for tests.
+
+        Creates common expected parameter types from cleaned tables and a common fully qualified (fq)
+        dataset name string used to load the data.
+        """
+        fq_dataset_name = self.fq_table_names[0].split('.')
+        self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
+
+        self.date = parser.parse('2019-03-03').date()
+        self.invalid_zip_response = 'Response removed due to invalid value'
+        self.invalid_zip_concept = 2000000010
+
+        super().setUp()
+
+    def test_update_invalid_zip_codes(self):
+        """
+        Tests that the specifications for SANDBOX_INVALID_ZIP_CODES and UPDATE_INVALID_ZIP_CODES perform as designed.
+
+        Validates pre conditions, tests execution, and post conditions based on the load
+        statements and the tables_and_counts variable.
+        """
+
+        zip3_lookup_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{fq_dataset_name}}.zip3_lookup` (zip3)
+            VALUES
+                (123), (234)
+            """).render(fq_dataset_name=self.fq_dataset_name)
+
+        observation_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{fq_dataset_name}}.observation` (observation_id, person_id, observation_concept_id, 
+                observation_date, observation_type_concept_id, observation_source_concept_id, value_as_number, 
+                value_as_string, value_source_concept_id, value_source_value)
+            VALUES
+                -- valid zip codes, will not be affected --
+                (1, 1, 0, date('2019-03-03'), 0, 1585250, null, '12345', null, null), 
+                (2, 2, 0, date('2019-03-03'), 0, 1585250, null, '23456-1234', null, null),
+                
+                -- invalid zip codes, will be sandboxed and updated in observation table --
+                (3, 3, 0, date('2019-03-03'), 0, 1585250, null, '1234', null, null), 
+                (4, 4, 0, date('2019-03-03'), 0, 1585250, null, '123', null, null),
+                (5, 5, 0, date('2019-03-03'), 0, 1585250, null, '12', null, null),
+                (6, 6, 0, date('2019-03-03'), 0, 1585250, null, '1', null, null),
+                
+                -- not zip codes (not zip code concept id), will not be affected --
+                (7, 7, 0, date('2019-03-03'), 0, 1111111, null, '111', null, null),
+                (8, 8, 0, date('2019-03-03'), 0, 2222222, null, '222', null, null)
+            """).render(fq_dataset_name=self.fq_dataset_name)
+
+        self.load_test_data([zip3_lookup_tmpl, observation_tmpl])
+
+        tables_and_counts = [{
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, 'observation']),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
+            'fields': [
+                'observation_id', 'person_id', 'observation_concept_id',
+                'observation_date', 'observation_type_concept_id',
+                'observation_source_concept_id', 'value_as_number',
+                'value_as_string', 'value_source_concept_id',
+                'value_source_value'
+            ],
+            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8],
+            'sandboxed_ids': [3, 4, 5, 6],
+            'cleaned_values': [
+                (1, 1, 0, self.date, 0, 1585250, None, '12345', None, None),
+                (2, 2, 0, self.date, 0, 1585250, None, '23456-1234', None,
+                 None),
+                (3, 3, 0, self.date, 0, 1585250, 0.0, self.invalid_zip_response,
+                 self.invalid_zip_concept, self.invalid_zip_response),
+                (4, 4, 0, self.date, 0, 1585250, 0.0, self.invalid_zip_response,
+                 self.invalid_zip_concept, self.invalid_zip_response),
+                (5, 5, 0, self.date, 0, 1585250, 0.0, self.invalid_zip_response,
+                 self.invalid_zip_concept, self.invalid_zip_response),
+                (6, 6, 0, self.date, 0, 1585250, 0.0, self.invalid_zip_response,
+                 self.invalid_zip_concept, self.invalid_zip_response),
+                (7, 7, 0, self.date, 0, 1111111, None, '111', None, None),
+                (8, 8, 0, self.date, 0, 2222222, None, '222', None, None)
+            ]
+        }]
+
+        # mock the PIPELINE_TABLES variable so tests on different branches
+        # don't overwrite each other.
+        with mock.patch(
+                'cdr_cleaner.cleaning_rules.update_invalid_zip_codes.PIPELINE_TABLES',
+                self.dataset_id):
+            self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/update_invalid_zip_codes_test.py
@@ -6,8 +6,11 @@ This cleaning rule sandboxes and updates any invalid zip codes.
 Original Issues: DC-1633, DC-1645
 
 Ensures that any invalid zip codes are sandboxed and updated. Invalid zip codes are those that are less than 5 digits
-    in length or do not match a zip3 value in the zip3 lookup table. If a zip code is invalid, the value_as_string is
-    updated to 'Invalid Zip' and the value_as_number is updated to 0.
+    in length or do not match a zip3 value in the zip3 lookup table. If a zip code is invalid the record is sandboxed
+    and updated to have the following information:
+        value_as_string and value_source_value = 'Response removed due to invalid value'
+        value_as_number = 0
+        value_source_concept_id = 2000000010
 """
 
 # Python imports
@@ -39,8 +42,7 @@ class UpdateInvalidZipCodesTest(BaseTest.CleaningRulesTestBase):
         cls.project_id = project_id
 
         # set the expected test datasets
-        # intended to be run on the deid_base dataset.  The combined dataset
-        # environment variable should be guaranteed to exist
+        # intended to be run on the rdr dataset
         dataset_id = os.environ.get('RDR_DATASET_ID')
         cls.dataset_id = dataset_id
         sandbox_id = dataset_id + '_sandbox'


### PR DESCRIPTION
* Added `zip3_lookup` table constant to `common.py`
* Created `update_invalid_zip_codes.py` module to update any zip codes that are less than 5 digits and/or don't match a value in the `zip3_lookup` view.
* Created `update_invalid_zip_codes_test.py` module to test functionality of the main module
* Created a schema file for `zip3_lookup` table which will only be used for the integration test module since it is actually a view in the pipeline tables dataset
* Added CR to `RDR_CLEANING_RULES` list