### PR TITLE
[DC-1663] Fix bad test smells

### DIFF
--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_height_weight_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_height_weight_test.py
@@ -81,32 +81,27 @@ from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_te
 # partitioning by _PARTITIONTIME doesn't work using a query_statement for creating a table,
 # therefore CREATE OR REPLACE TABLE doesn' work and we need to DROP the table first.
 MEASUREMENT_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.measurement`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.measurement` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<measurement_id INT64,
-      person_id INT64,
-      measurement_concept_id INT64,
-      measurement_date DATE,
-      measurement_datetime TIMESTAMP,
-      measurement_type_concept_id INT64,
-      operator_concept_id INT64,
-      value_as_number FLOAT64,
-      value_as_concept_id INT64,
-      unit_concept_id INT64,
-      range_low FLOAT64,
-      range_high FLOAT64,
-      provider_id INT64,
-      visit_occurrence_id INT64,
-      measurement_source_value STRING,
-      measurement_source_concept_id INT64,
-      unit_source_value STRING,
-      value_source_value STRING>>
-      [(1,1,3036277,"2017-03-25","2017-03-25 01:00:00 UTC",44818701,4172703,5.6,0,9330,null,null,null,1,"8302-2",3036277,"in",""),
+    INSERT INTO `{{project_id}}.{{dataset_id}}.measurement` (
+      measurement_id,
+      person_id,
+      measurement_concept_id,
+      measurement_date,
+      measurement_datetime,
+      measurement_type_concept_id,
+      operator_concept_id,
+      value_as_number,
+      value_as_concept_id,
+      unit_concept_id,
+      range_low,
+      range_high,
+      provider_id,
+      visit_occurrence_id,
+      measurement_source_value,
+      measurement_source_concept_id,
+      unit_source_value,
+      value_source_value)
+    VALUES
+       (1,1,3036277,"2017-03-25","2017-03-25 01:00:00 UTC",44818701,4172703,5.6,0,9330,null,null,null,1,"8302-2",3036277,"in",""),
         (2,2,3036277,"2017-10-18","2017-10-18 01:00:00 UTC",44818701,4172703,62.5,0,9330,null,null,null,2,"8302-2",3036277,"in",""),
         (3,3,3036277,"2017-02-07","2017-02-07 01:00:00 UTC",44818701,4172703,1.8,null,8582,null,null,null,3,"8302-2",3036277,"cm",""),
         (4,4,3036277,"2017-01-06","2017-01-06 01:00:00 UTC",44818701,4172703,193.0,0,8582,null,null,null,4,"8302-2",3036277,"cm",""),
@@ -146,54 +141,11 @@ CREATE TABLE
         (38,4,3025315,"2018-06-19","2018-06-19 01:00:00 UTC",44818701,4172703,67.9,0,9529,null,null,null,38,"29463-7",3025315,"KG",""),
         (39,4,3025315,"2018-06-19","2018-06-19 01:00:00 UTC",44818701,4172703,81.4,0,9529,null,null,null,39,"29463-7",3025315,"KG",""),
         (40,2,3025315,"2018-04-01","2018-04-01 01:00:00 UTC",44818701,4172703,24.9,0,9529,null,null,null,40,"29463-7",3025315,"KG",""),
-        (41,2,3025315,"2018-04-20","2018-04-20 01:00:00 UTC",44818701,4172703,40.0,0,9529,null,null,null,40,"29463-7",3025315,"KG","")] col
-)
- SELECT
-    measurement_id,
-    person_id,
-    measurement_concept_id,
-    measurement_date,
-    measurement_datetime,
-    measurement_type_concept_id,
-    operator_concept_id,
-    value_as_number,
-    value_as_concept_id,
-    unit_concept_id,
-    range_low,
-    range_high,
-    provider_id,
-    visit_occurrence_id,
-    measurement_source_value,
-    measurement_source_concept_id,
-    unit_source_value,
-    value_source_value
-  FROM
-    w,
-    UNNEST(w.col))
+        (41,2,3025315,"2018-04-20","2018-04-20 01:00:00 UTC",44818701,4172703,40.0,0,9529,null,null,null,40,"29463-7",3025315,"KG","")
 """)
 
 CONDITION_OCCURRENCE_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.condition_occurrence`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.condition_occurrence` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<condition_occurrence_id INT64,
-      person_id INT64,
-      condition_concept_id INT64,
-      condition_start_date DATE,
-      condition_start_datetime TIMESTAMP,
-      condition_end_date DATE,
-      condition_end_datetime TIMESTAMP,
-      condition_type_concept_id INT64>>
-            [(1,7,80502,"2019-08-20","2019-08-20 01:00:00 UTC",null,null,38000245),
-             (2,8,321661,"2018-09-10","2018-09-10 01:00:00 UTC",null,null,38000245),
-             (3,1,435928,"2017-08-15","2017-08-15 00:00:00 UTC",null,null,38000245),
-             (4,4,434005,"2018-08-03","2018-08-03 05:00:00 UTC",null,null,32020)] col
-)
-SELECT
+    INSERT INTO `{{project_id}}.{{dataset_id}}.condition_occurrence` (
     condition_occurrence_id,
     person_id,
     condition_concept_id,
@@ -201,23 +153,20 @@ SELECT
     condition_start_datetime,
     condition_end_date,
     condition_end_datetime,
-    condition_type_concept_id,
-  FROM
-    w,
-    UNNEST(w.col))
+    condition_type_concept_id)
+    VALUES
+        (1,7,80502,"2019-08-20","2019-08-20 01:00:00 UTC",null,null,38000245),
+        (2,8,321661,"2018-09-10","2018-09-10 01:00:00 UTC",null,null,38000245),
+        (3,1,435928,"2017-08-15","2017-08-15 00:00:00 UTC",null,null,38000245),
+        (4,4,434005,"2018-08-03","2018-08-03 05:00:00 UTC",null,null,32020)
 """)
 
 MEASUREMENT_EXT_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.measurement_ext`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.measurement_ext` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<measurement_id INT64,
-      src_id STRING>>
-      [(1,"EHR site 111"),
+INSERT INTO `{{project_id}}.{{dataset_id}}.measurement_ext` (
+      measurement_id,
+      src_id)
+VALUES
+        (1,"EHR site 111"),
         (2,"EHR site 111"),
         (3,"EHR site 111"),
         (4,"EHR site 111"),
@@ -257,67 +206,74 @@ CREATE TABLE
         (38,"EHR site 111"),
         (39,"EHR site 111"),
         (40,"EHR site 111"),
-        (41,"EHR site 111")] col
-    )
-    SELECT
-        measurement_id,
-        src_id
-    FROM
-        w,
-        UNNEST(w.col))
+        (41,"EHR site 111")
 """)
 
 PERSON_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.person`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.person` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<person_id INT64,
-      gender_concept_id INT64,
-      birth_datetime TIMESTAMP>>
-        [(1,8507,"1990-03-03 00:00:00 UTC"),
-        (2,8507,"1984-02-08 00:00:00 UTC"),
-        (3,8532,"1983-10-29 00:00:00 UTC"),
-        (4,8532,"1971-05-31 00:00:00 UTC"),
-        (5,8507,"1990-05-07 00:00:00 UTC"),
-        (6,8532,"1969-04-29 00:00:00 UTC"),
-        (7,8532,"1975-09-23 00:00:00 UTC"),
-        (8,8507,"1976-03-17 00:00:00 UTC"),
-        (9,8532,"1993-03-20 00:00:00 UTC"),
-        (10,8532,"1982-03-08 00:00:00 UTC")] col
-)
-    SELECT
-        person_id,
-        gender_concept_id,
-        birth_datetime
-    FROM
-        w,
-        UNNEST(w.col))
+INSERT INTO `{{project_id}}.{{dataset_id}}.person` (
+      person_id,
+      gender_concept_id,
+      birth_datetime,
+      year_of_birth,
+      race_concept_id,
+      ethnicity_concept_id)
+    VALUES
+        (1,8507,"1990-03-03 00:00:00 UTC", 1990, 0, 0),
+        (2,8507,"1984-02-08 00:00:00 UTC", 1984, 0, 0),
+        (3,8532,"1983-10-29 00:00:00 UTC", 1983, 0, 0),
+        (4,8532,"1971-05-31 00:00:00 UTC", 1971, 0, 0),
+        (5,8507,"1990-05-07 00:00:00 UTC", 1990, 0, 0),
+        (6,8532,"1969-04-29 00:00:00 UTC", 1969, 0, 0),
+        (7,8532,"1975-09-23 00:00:00 UTC", 1975, 0, 0),
+        (8,8507,"1976-03-17 00:00:00 UTC", 1976, 0, 0),
+        (9,8532,"1993-03-20 00:00:00 UTC", 1993, 0, 0),
+        (10,8532,"1982-03-08 00:00:00 UTC", 1983, 0, 0)
 """)
 
 CONCEPT_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.concept`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.concept` AS (
+INSERT INTO
+  `{{project_id}}.{{dataset_id}}.concept` (
+    concept_id,
+    concept_name,
+    domain_id,
+    vocabulary_id,
+    concept_class_id,
+    standard_concept,
+    concept_code,
+    valid_start_date,
+    valid_end_date,
+    invalid_reason
+) 
   SELECT
-    *
+    concept_id,
+    concept_name,
+    domain_id,
+    vocabulary_id,
+    concept_class_id,
+    standard_concept,
+    concept_code,
+    valid_start_date,
+    valid_end_date,
+    invalid_reason
   FROM
-    `{{project_id}}.{{vocab_dataset}}.concept` )
+    `{{project_id}}.{{vocab_dataset}}.concept`
 """)
 
 CONCEPT_ANCESTOR_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.concept_ancestor`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.concept_ancestor` AS (
+INSERT INTO
+  `{{project_id}}.{{dataset_id}}.concept_ancestor`(
+    ancestor_concept_id,
+    descendant_concept_id,
+    min_levels_of_separation,
+    max_levels_of_separation
+)
   SELECT
-    *
+    ancestor_concept_id,
+    descendant_concept_id,
+    min_levels_of_separation,
+    max_levels_of_separation
   FROM
-    `{{project_id}}.{{vocab_dataset}}.concept_ancestor` )
+    `{{project_id}}.{{vocab_dataset}}.concept_ancestor`
 """)
 
 
@@ -343,8 +299,14 @@ class CleanHeightWeightTest(BaseTest.CleaningRulesTestBase):
                                                  cls.sandbox_id)
 
         # Generates list of fully qualified table names and their corresponding sandbox table names
-        cls.fq_table_names.append(
-            f'{cls.project_id}.{cls.dataset_id}.{MEASUREMENT}')
+        cls.fq_table_names.extend([
+            f'{cls.project_id}.{cls.dataset_id}.{MEASUREMENT}',
+            f'{cls.project_id}.{cls.dataset_id}.measurement_ext',
+            f'{cls.project_id}.{cls.dataset_id}.condition_occurrence',
+            f'{cls.project_id}.{cls.dataset_id}.person',
+            f'{cls.project_id}.{cls.dataset_id}.concept',
+            f'{cls.project_id}.{cls.dataset_id}.concept_ancestor'
+        ])
         sandbox_table_names = cls.rule_instance.get_sandbox_tablenames()
         for table in sandbox_table_names:
             cls.fq_sandbox_table_names.append(

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_height_weight_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_height_weight_test.py
@@ -77,9 +77,6 @@ from common import MEASUREMENT
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import \
     BaseTest
 
-# The existing person table is created and partitioned on the pseudo column _PARTITIONTIME,
-# partitioning by _PARTITIONTIME doesn't work using a query_statement for creating a table,
-# therefore CREATE OR REPLACE TABLE doesn' work and we need to DROP the table first.
 MEASUREMENT_DATA_TEMPLATE = JINJA_ENV.from_string("""
     INSERT INTO `{{project_id}}.{{dataset_id}}.measurement` (
       measurement_id,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/cope_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/cope_survey_response_suppression_test.py
@@ -60,51 +60,8 @@ class CopeSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
 
         # Load the test data
         observation_data_template = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.observation`;
-            CREATE TABLE `{{project_id}}.{{dataset_id}}.observation`
-            AS (
-            WITH w AS (
-              SELECT ARRAY<STRUCT<
-                    observation_id int64, 
-                    person_id int64, 
-                    observation_concept_id int64, 
-                    observation_type_concept_id int64,
-                    value_as_concept_id int64,
-                    observation_source_concept_id int64,
-                    value_source_concept_id int64,
-                    qualifier_concept_id int64,
-                    unit_concept_id int64
-                    >>
-                    
-                  -- Concepts to suppress --
-                  -- 1333234: What breathing treatments did you receive? --
-                  -- 1310066: How were you tested? --
-                  -- 715725: What do you think is the main reason(s) for these experiences? --
-                  -- 1310147: How has your prenatal care changed since COVID-19? --
-                  -- 702686: Who do you know who has died? --
-                  -- 1310054: Were you tested for COVID-19? --
-                  -- 715726: Are you currently covered by any of the following types of health insurance...? --
-                  -- 715724: Other substance? --
-                  -- 715714: What type of household do you live in? --
-                  -- 1310146: What factors might make you less likely to get the vaccine? --
-                  -- 1310058: Thinking about your current social habits, in the last 5 days: I have...? --
-
-                  [(1, 101, 0, 0, 0, 1333234, 0, 0, 0),
-                   (2, 102, 0, 0, 0, 1310066, 0, 0, 0),
-                   (3, 103, 0, 0, 0, 715725, 0, 0, 0),
-                   (4, 104, 0, 0, 0, 1310147, 0, 0, 0),
-                   (5, 105, 0, 0, 0, 702686, 0, 0, 0),
-                   (6, 106, 0, 0, 0, 1310054, 0, 0, 0),
-                   (7, 107, 0, 0, 0, 715726, 0, 0, 0),
-                   (8, 108, 0, 0, 0, 715724, 0, 0, 0),
-                   (9, 109, 0, 0, 0, 715714, 0, 0, 0),
-                   (10, 110, 0, 0, 0, 1310146, 0, 0, 0),
-                   (11, 111, 0, 0, 0, 1310058, 0, 0, 0),
-                   -- not concepts to be suppressed --
-                   (12, 112, 0, 0, 0, 1111111, 0, 0, 0),
-                   (13, 113, 0, 0, 0, 2222222, 0, 0, 0)] col
-            )
-            SELECT 
+            INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+            (
                 observation_id, 
                 person_id, 
                 observation_concept_id, 
@@ -113,8 +70,37 @@ class CopeSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
                 observation_source_concept_id,
                 value_source_concept_id,
                 qualifier_concept_id,
-                unit_concept_id
-            FROM w, UNNEST(w.col))
+                unit_concept_id,
+                observation_date
+            )
+            VALUES
+              -- Concepts to suppress --
+              -- 1333234: What breathing treatments did you receive? --
+              -- 1310066: How were you tested? --
+              -- 715725: What do you think is the main reason(s) for these experiences? --
+              -- 1310147: How has your prenatal care changed since COVID-19? --
+              -- 702686: Who do you know who has died? --
+              -- 1310054: Were you tested for COVID-19? --
+              -- 715726: Are you currently covered by any of the following types of health insurance...? --
+              -- 715724: Other substance? --
+              -- 715714: What type of household do you live in? --
+              -- 1310146: What factors might make you less likely to get the vaccine? --
+              -- 1310058: Thinking about your current social habits, in the last 5 days: I have...? --
+
+              (1, 101, 0, 0, 0, 1333234, 0, 0, 0, '2020-01-01'),
+              (2, 102, 0, 0, 0, 1310066, 0, 0, 0, '2020-01-01'),
+              (3, 103, 0, 0, 0, 715725, 0, 0, 0, '2020-01-01'),
+              (4, 104, 0, 0, 0, 1310147, 0, 0, 0, '2020-01-01'),
+              (5, 105, 0, 0, 0, 702686, 0, 0, 0, '2020-01-01'),
+              (6, 106, 0, 0, 0, 1310054, 0, 0, 0, '2020-01-01'),
+              (7, 107, 0, 0, 0, 715726, 0, 0, 0, '2020-01-01'),
+              (8, 108, 0, 0, 0, 715724, 0, 0, 0, '2020-01-01'),
+              (9, 109, 0, 0, 0, 715714, 0, 0, 0, '2020-01-01'),
+              (10, 110, 0, 0, 0, 1310146, 0, 0, 0, '2020-01-01'),
+              (11, 111, 0, 0, 0, 1310058, 0, 0, 0, '2020-01-01'),
+              -- not concepts to be suppressed --
+              (12, 112, 0, 0, 0, 1111111, 0, 0, 0, '2020-01-01'),
+              (13, 113, 0, 0, 0, 2222222, 0, 0, 0, '2020-01-01')
             """)
 
         insert_observation_query = observation_data_template.render(

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/explicit_identifier_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/explicit_identifier_suppression_test.py
@@ -23,7 +23,6 @@ from google.cloud.bigquery import Table
 
 # Project Imports
 from common import OBSERVATION, VOCABULARY_TABLES
-from utils import bq
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.explicit_identifier_suppression import \
     ExplicitIdentifierSuppression, EXPLICIT_IDENTIFIER_CONCEPTS
@@ -69,24 +68,9 @@ class ExplicitIdentifierSuppressionTestBase(BaseTest.CleaningRulesTestBase):
         cls.up_class = super().setUpClass()
 
         # Copy vocab tables over to the test dataset
-        cls.copy_vocab_tables(cls.vocabulary_id)
-
-    @classmethod
-    def copy_vocab_tables(cls, vocabulary_id):
-        """
-        A function for copying the vocab tables to the test dataset_id
-        :param vocabulary_id: 
-        :return: 
-        """
-        # Copy vocab tables over to the test dataset
-        vocabulary_dataset = bq.get_dataset(cls.project_id, vocabulary_id)
-        for src_table in bq.list_tables(cls.client, vocabulary_dataset):
-            schema = bq.get_table_schema(src_table.table_id)
+        for src_table in cls.client.list_tables(cls.vocabulary_id):
             destination = f'{cls.project_id}.{cls.dataset_id}.{src_table.table_id}'
-            dst_table = cls.client.create_table(Table(destination,
-                                                      schema=schema),
-                                                exists_ok=True)
-            cls.client.copy_table(src_table, dst_table)
+            cls.client.copy_table(src_table, destination)
 
     def setUp(self):
         """
@@ -97,46 +81,8 @@ class ExplicitIdentifierSuppressionTestBase(BaseTest.CleaningRulesTestBase):
 
         # Load the test data
         observation_data_template = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.observation`;
-            CREATE TABLE `{{project_id}}.{{dataset_id}}.observation`
-            AS (
-            WITH w AS (
-              SELECT ARRAY<STRUCT<
-                    observation_id int64, 
-                    person_id int64, 
-                    observation_concept_id int64, 
-                    observation_type_concept_id int64,
-                    value_as_concept_id int64,
-                    observation_source_concept_id int64,
-                    value_source_concept_id int64,
-                    qualifier_concept_id int64,
-                    unit_concept_id int64
-                    >>
-                  -- Subset of Concepts to suppress --
-                  -- 43529731: Social Security: Prefer Not To Answer --
-                  -- 43529730: Secondary Contact Info: Person Two Prefer Not To Answer --
-                  -- 3042942: First name --
-                  -- 1585907: Secondary Contact Info: Person One First Name --
-                  -- 1585246: PII Address: Street Address --
-
-                  -- Concepts to keep --
-                  -- 1384550: Insurance Type: Tricare Or Military --
-                  -- 903152: Hair style or head gear --
-                  -- 903574: Disability: Blind --
-                  -- 903155: Manual heart rate --
-                  [(1, 1, 43529731, 0, 0, 0, 0, 0, 0),
-                   (2, 1, 0, 43529730, 0, 0, 0, 0, 0),
-                   (3, 1, 0, 0, 3042942, 0, 0, 0, 0),
-                   (4, 1, 0, 0, 0, 1585907, 0, 0, 0),
-                   (5, 1, 0, 0, 0, 0, 1585246, 0, 0),
-                   (6, 1, 43529731, 43529730, 3042942, 1585907, 1585246, 0, 0),
-                   (7, 1, 1384550, 0, 0, 0, 0, 0, 0),
-                   (8, 1, 0, 903152, 0, 0, 0, 0, 0),
-                   (9, 1, 0, 0, 903574, 0, 0, 0, 0),
-                   (10, 1, 0, 0, 0, 903155, 0, 0, 0),
-                   (11, 1, 1384550, 903152, 903574, 903155, 0, 0, 0)] col
-            )
-            SELECT 
+            INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+            (
                 observation_id, 
                 person_id, 
                 observation_concept_id, 
@@ -145,8 +91,33 @@ class ExplicitIdentifierSuppressionTestBase(BaseTest.CleaningRulesTestBase):
                 observation_source_concept_id,
                 value_source_concept_id,
                 qualifier_concept_id,
-                unit_concept_id
-            FROM w, UNNEST(w.col))
+                unit_concept_id,
+                observation_date
+            )
+            VALUES
+              -- Subset of Concepts to suppress --
+              -- 43529731: Social Security: Prefer Not To Answer --
+              -- 43529730: Secondary Contact Info: Person Two Prefer Not To Answer --
+              -- 3042942: First name --
+              -- 1585907: Secondary Contact Info: Person One First Name --
+              -- 1585246: PII Address: Street Address --
+
+              -- Concepts to keep --
+              -- 1384550: Insurance Type: Tricare Or Military --
+              -- 903152: Hair style or head gear --
+              -- 903574: Disability: Blind --
+              -- 903155: Manual heart rate --
+              (1, 1, 43529731, 0, 0, 0, 0, 0, 0, '2020-01-01'),
+              (2, 1, 0, 43529730, 0, 0, 0, 0, 0, '2020-01-01'),
+              (3, 1, 0, 0, 3042942, 0, 0, 0, 0, '2020-01-01'),
+              (4, 1, 0, 0, 0, 1585907, 0, 0, 0, '2020-01-01'),
+              (5, 1, 0, 0, 0, 0, 1585246, 0, 0, '2020-01-01'),
+              (6, 1, 43529731, 43529730, 3042942, 1585907, 1585246, 0, 0, '2020-01-01'),
+              (7, 1, 1384550, 0, 0, 0, 0, 0, 0, '2020-01-01'),
+              (8, 1, 0, 903152, 0, 0, 0, 0, 0, '2020-01-01'),
+              (9, 1, 0, 0, 903574, 0, 0, 0, 0, '2020-01-01'),
+              (10, 1, 0, 0, 0, 903155, 0, 0, 0, '2020-01-01'),
+              (11, 1, 1384550, 903152, 903574, 903155, 0, 0, 0, '2020-01-01')
             """)
 
         insert_observation_query = observation_data_template.render(

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/organ_transplant_concept_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/organ_transplant_concept_suppression_test.py
@@ -61,41 +61,20 @@ class OrganTransplantConceptSuppressionTest(BaseTest.CleaningRulesTestBase):
 
         # Load the test data
         observation_tmpl = self.jinja_env.from_string("""
-        DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.observation`;
-        CREATE TABLE `{{project_id}}.{{dataset_id}}.observation`
-        AS (
-        WITH w AS (
-            SELECT ARRAY<STRUCT<
-                observation_id INT64,
-                person_id INT64,
-                observation_concept_id INT64,
-                observation_type_concept_id INT64,
-                value_as_concept_id INT64,
-                qualifier_concept_id INT64,
-                unit_concept_id INT64,
-                observation_source_concept_id INT64,
-                value_source_concept_id INT64
-                >>
-              -- Concepts to suppress --
-              -- OrganTransplantDescription_OtherOrgan - 1585807 --
-              -- OrganTransplantDescription_OtherTissue - 1585808 --
-              [(1, 1, 0, 0, 0, 0, 0, 0, 1585808),
-               (2, 1, 0, 0, 0, 0, 0, 0, 1585807),
-               (3, 1, 0, 0, 0, 0, 0, 0, 1585806),
-               (4, 1, 0, 0, 0, 0, 0, 0, 1585834),
-               (5, 1, 0, 0, 0, 0, 0, 0, 1585825)] col
-            )
-            SELECT
-                observation_id,
-                person_id,
-                observation_concept_id,
-                observation_type_concept_id,
-                value_as_concept_id,
-                qualifier_concept_id,
-                unit_concept_id,
-                observation_source_concept_id,
-                value_source_concept_id
-            FROM w, UNNEST(w.col))
+        INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+        (observation_id, person_id, observation_concept_id,
+         observation_date, observation_type_concept_id, value_as_concept_id,
+         qualifier_concept_id, unit_concept_id, observation_source_concept_id,
+         value_source_concept_id)
+         VALUES
+      -- Concepts to suppress --
+      -- 903079: PMI Prefer Not To Answer --
+         (1, 1, 0, '2017-05-02', 0, 0, 0, 0, 0, 1585808),
+         (2, 1, 0, '2017-05-02', 0, 0, 0, 0, 0, 1585807),
+         (3, 1, 0, '2017-05-02', 0, 0, 0, 0, 0, 1585806),
+         (4, 1, 0, '2017-05-02', 0, 0, 0, 0, 0, 1585834),
+         (5, 1, 0, '2017-05-02', 0, 0, 0, 0, 0, 1585825),
+         (6, 1, 0, '2017-05-02', 0, 0, 0, 0, 903079, 0)
             """)
 
         insert_observation_query = observation_tmpl.render(
@@ -112,7 +91,7 @@ class OrganTransplantConceptSuppressionTest(BaseTest.CleaningRulesTestBase):
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.'
                 f'{self.rule_instance.sandbox_table_for("observation")}',
-            'loaded_ids': [1, 2, 3, 4, 5],
+            'loaded_ids': [1, 2, 3, 4, 5, 6],
             'sandboxed_ids': [1, 2],
             'fields': [
                 'observation_id', 'person_id', 'observation_concept_id',
@@ -122,7 +101,8 @@ class OrganTransplantConceptSuppressionTest(BaseTest.CleaningRulesTestBase):
             ],
             'cleaned_values': [(3, 1, 0, 0, 0, 0, 0, 0, 1585806),
                                (4, 1, 0, 0, 0, 0, 0, 0, 1585834),
-                               (5, 1, 0, 0, 0, 0, 0, 0, 1585825)]
+                               (5, 1, 0, 0, 0, 0, 0, 0, 1585825),
+                               (6, 1, 0, 0, 0, 0, 0, 903079, 0)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
@@ -3,7 +3,7 @@ Integration test for repopulate_person_controlled_tier module
 
 Original Issues: DC-1439
 
-The intent is to repopulate the person table using the PPI responses based on the controlled tier 
+The intent is to repopulate the person table using the PPI responses based on the controlled tier
 privacy requirements """
 
 # Python Imports
@@ -99,36 +99,27 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
         """)
 
         observation_data_template = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.observation`;
-            CREATE TABLE `{{project_id}}.{{dataset_id}}.observation`
-            AS (
-            WITH w AS (
-                SELECT ARRAY<STRUCT<
-                        observation_id int64, 
-                        person_id int64, 
-                        value_as_concept_id int64,
-                        observation_source_concept_id int64,
-                        value_source_concept_id int64
-                        >>
-                      [(1, 1, 45877987, 1586140, 1586146),
-                       (2, 1, 1586143, 1586140, 1586143),
-                       (3, 2, 45879439, 1586140, 1586142),
-                       (4, 2, 1586147, 1586140, 1586147),
-                       (5, 1, 45878463, 1585838, 1585840),
-                       (6, 2, 45880669, 1585838, 1585839),
-                       (7, 2, 1585841, 1585838, 1585841),
-                       (8, 1, 45878463, 1585845, 1585847),
-                       (9, 2, 45880669, 1585845, 1585846)] col
-                )
-                SELECT 
-                    observation_id, 
-                    person_id, 
-                    observation_datetime,
-                    value_as_concept_id,
-                    observation_source_concept_id,
-                    value_source_concept_id
-                FROM w, UNNEST(w.col)
+            INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+            (
+                observation_id,
+                person_id,
+                value_as_concept_id,
+                observation_source_concept_id,
+                value_source_concept_id,
+                observation_date,
+                observation_concept_id,
+                observation_type_concept_id
             )
+            VALUES
+                (1, 1, 45877987, 1586140, 1586146, '2020-01-01', 0, 0),
+                (2, 1, 1586143, 1586140, 1586143, '2020-01-01', 0, 0),
+                (3, 2, 45879439, 1586140, 1586142, '2020-01-01', 0, 0),
+                (4, 2, 1586147, 1586140, 1586147, '2020-01-01', 0, 0),
+                (5, 1, 45878463, 1585838, 1585840, '2020-01-01', 0, 0),
+                (6, 2, 45880669, 1585838, 1585839, '2020-01-01', 0, 0),
+                (7, 2, 1585841, 1585838, 1585841, '2020-01-01', 0, 0),
+                (8, 1, 45878463, 1585845, 1585847, '2020-01-01', 0, 0),
+                (9, 2, 45880669, 1585845, 1585846, '2020-01-01', 0, 0)
         """)
         insert_person_query = person_data_template.render(
             project_id=self.project_id, dataset_id=self.dataset_id)
@@ -136,10 +127,8 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
             project_id=self.project_id, dataset_id=self.dataset_id)
 
         # Load test data
-        self.load_test_data([
-            f'''{insert_person_query};
-                {insert_observation_query};'''
-        ])
+        self.load_test_data(
+            [f'{insert_person_query}', f'{insert_observation_query}'])
 
     def test_repopulate_person_controlled_tier(self):
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
@@ -14,7 +14,6 @@ from google.cloud.bigquery import Table
 
 # Project Imports
 from common import PERSON, OBSERVATION, VOCABULARY_TABLES
-from utils import bq
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.repopulate_person_controlled_tier import \
     RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
@@ -59,24 +58,9 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
         cls.up_class = super().setUpClass()
 
         # Copy vocab tables over to the test dataset
-        cls.copy_vocab_tables(cls.vocabulary_id)
-
-    @classmethod
-    def copy_vocab_tables(cls, vocabulary_id):
-        """
-        A function for copying the vocab tables to the test dataset_id
-        :param vocabulary_id: 
-        :return: 
-        """
-        # Copy vocab tables over to the test dataset
-        vocabulary_dataset = bq.get_dataset(cls.project_id, vocabulary_id)
-        for src_table in bq.list_tables(cls.client, vocabulary_dataset):
-            schema = bq.get_table_schema(src_table.table_id)
+        for src_table in cls.client.list_tables(cls.vocabulary_id):
             destination = f'{cls.project_id}.{cls.dataset_id}.{src_table.table_id}'
-            dst_table = cls.client.create_table(Table(destination,
-                                                      schema=schema),
-                                                exists_ok=True)
-            cls.client.copy_table(src_table, dst_table)
+            cls.client.copy_table(src_table, destination)
 
     def setUp(self):
         """
@@ -88,54 +72,30 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
         # Load the test data
         # Load the test data
         person_data_template = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.person`;
-            CREATE TABLE `{{project_id}}.{{dataset_id}}.person`
-            AS (
-                WITH w AS (
-                    SELECT ARRAY<STRUCT<
-                        person_id int64,
-                        gender_concept_id int64,
-                        year_of_birth int64,
-                        month_of_birth int64,
-                        day_of_birth int64,
-                        birth_datetime datetime,
-                        race_concept_id int64,
-                        ethnicity_concept_id int64,
-                        location_id int64,
-                        provider_id int64,
-                        care_site_id int64,
-                        person_source_value string,
-                        gender_source_value string,
-                        gender_source_concept_id int64,
-                        race_source_value string,
-                        race_source_concept_id int64,
-                        ethnicity_source_value string,
-                        ethnicity_source_concept_id int64
-                        >>
-                      [(1, 0, 1990, 1, 1, DATETIME(TIMESTAMP '1990-01-01T00:00:01'), 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
-                       (2, 0, 1980, 1, 1, DATETIME(TIMESTAMP '1980-01-01T00:00:01'), 0, 0, 1, 1, 1, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0)] col
-                )
-                SELECT 
-                    person_id,
-                    gender_concept_id,
-                    year_of_birth,
-                    month_of_birth,
-                    day_of_birth,
-                    birth_datetime,
-                    race_concept_id,
-                    ethnicity_concept_id,
-                    location_id,
-                    provider_id,
-                    care_site_id,
-                    person_source_value,
-                    gender_source_value,
-                    gender_source_concept_id,
-                    race_source_value,
-                    race_source_concept_id,
-                    ethnicity_source_value,
-                    ethnicity_source_concept_id
-                FROM w, UNNEST(w.col)
+            INSERT INTO `{{project_id}}.{{dataset_id}}.person`
+            (
+                person_id,
+                gender_concept_id,
+                year_of_birth,
+                month_of_birth,
+                day_of_birth,
+                birth_datetime,
+                race_concept_id,
+                ethnicity_concept_id,
+                location_id,
+                provider_id,
+                care_site_id,
+                person_source_value,
+                gender_source_value,
+                gender_source_concept_id,
+                race_source_value,
+                race_source_concept_id,
+                ethnicity_source_value,
+                ethnicity_source_concept_id
             )
+            VALUES
+            (1, 0, 1990, 1, 1, '1990-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
+            (2, 0, 1980, 1, 1, '1980-01-01T00:00:01', 0, 0, 1, 1, 1, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0)
         """)
 
         observation_data_template = self.jinja_env.from_string("""
@@ -146,20 +106,19 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
                 SELECT ARRAY<STRUCT<
                         observation_id int64, 
                         person_id int64, 
-                        observation_datetime datetime,
                         value_as_concept_id int64,
                         observation_source_concept_id int64,
                         value_source_concept_id int64
                         >>
-                      [(1, 1, DATETIME(TIMESTAMP '2020-01-01T00:00:01'), 45877987, 1586140, 1586146),
-                       (2, 1, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 1586143, 1586140, 1586143),
-                       (3, 2, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 45879439, 1586140, 1586142),
-                       (4, 2, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 1586147, 1586140, 1586147),
-                       (5, 1, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 45878463, 1585838, 1585840),
-                       (6, 2, DATETIME(TIMESTAMP '2020-01-01T00:00:01'), 45880669, 1585838, 1585839),
-                       (7, 2, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 1585841, 1585838, 1585841),
-                       (8, 1, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 45878463, 1585845, 1585847),
-                       (9, 2, DATETIME(TIMESTAMP '2020-01-01T00:00:00'), 45880669, 1585845, 1585846)] col
+                      [(1, 1, 45877987, 1586140, 1586146),
+                       (2, 1, 1586143, 1586140, 1586143),
+                       (3, 2, 45879439, 1586140, 1586142),
+                       (4, 2, 1586147, 1586140, 1586147),
+                       (5, 1, 45878463, 1585838, 1585840),
+                       (6, 2, 45880669, 1585838, 1585839),
+                       (7, 2, 1585841, 1585838, 1585841),
+                       (8, 1, 45878463, 1585845, 1585847),
+                       (9, 2, 45880669, 1585845, 1585846)] col
                 )
                 SELECT 
                     observation_id, 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses_test.py
@@ -59,7 +59,10 @@ class DropCopeDuplicateResponsesTest(BaseTest.CleaningRulesTestBase):
             cls.fq_sandbox_table_names.append(
                 f'{project_id}.{sandbox_id}.{table_name}')
 
-        cls.fq_table_names = [f'{project_id}.{dataset_id}.observation']
+        cls.fq_table_names = [
+            f'{project_id}.{dataset_id}.observation',
+            f'{project_id}.{dataset_id}.cope_survey_semantic_version_map'
+        ]
 
         # call super to set up the client, create datasets, and create
         # empty test tables
@@ -117,28 +120,14 @@ VALUES
    'phq_9_5', 'COPE_A_161', 666666666)""")
 
         tmp2 = self.jinja_env.from_string("""
-         DROP TABLE IF EXISTS
-  `{{fq_dataset_name}}.cope_survey_semantic_version_map`;
-CREATE TABLE
-  `{{fq_dataset_name}}.cope_survey_semantic_version_map` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<participant_id INT64,
-      questionnaire_response_id INT64,
-      semantic_version INT64,
-      cope_month STRING>> [(2222222, 333333333, 4, 'jul' ),
-      (2222222, 555555555, 4, 'jul' ),
-      (2222222, 444444444, 6, 'aug' ),
-      (2222222, 666666666, 14,'dec' )] col )
-  SELECT
-    participant_id,
-    questionnaire_response_id,
-    semantic_version,
-    cope_month
-  FROM
-    w,
-    UNNEST(w.col))
+INSERT INTO `{{fq_dataset_name}}.cope_survey_semantic_version_map` (
+      participant_id, questionnaire_response_id,
+      semantic_version,
+      cope_month)
+VALUES (2222222, 333333333, '4', 'jul' ),
+      (2222222, 555555555, '4', 'jul' ),
+      (2222222, 444444444, '6', 'aug' ),
+      (2222222, 666666666, '14','dec' )
         """)
 
         query = tmpl.render(fq_dataset_name=self.fq_dataset_name)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/identifying_field_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/identifying_field_suppression_test.py
@@ -89,39 +89,21 @@ class IDFieldSuppressionTest(BaseTest.CleaningRulesTestBase):
 
         # test data for measurement table, identifying fields: provider_id
         measurement_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-              `{{project_id}}.{{dataset_id}}.measurement`;
-            CREATE TABLE
-              `{{project_id}}.{{dataset_id}}.measurement` (measurement_id INT64 NOT NULL,
-                person_id INT64 NOT NULL,
-                measurement_concept_id INT64 NOT NULL,
-                measurement_type_concept_id INT64 NOT NULL,
-                provider_id INT64);
-            INSERT INTO
-              `{{project_id}}.{{dataset_id}}.measurement` (measurement_id,
+            INSERT INTO `{{project_id}}.{{dataset_id}}.measurement` (
+                measurement_id,
                 person_id,
                 measurement_concept_id,
                 measurement_type_concept_id,
-                provider_id)
+                provider_id,
+                measurement_date)
             VALUES
-              (321, 12345, 111, 444, 789),
-              (123, 6789, 222, 555, 1011)
+              (321, 12345, 111, 444, 789, '2020-01-01'),
+              (123, 6789, 222, 555, 1011, '2020-01-01')
             """).render(project_id=self.project_id, dataset_id=self.dataset_id)
 
         # test data for person table, identifying fields:
         # month_of_birth, day_of_birth, location_id, provider_id, care_site_id
         person_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-              `{{project_id}}.{{dataset_id}}.person`;
-            CREATE TABLE
-              `{{project_id}}.{{dataset_id}}.person` (person_id INT64 NOT NULL,
-                gender_concept_id INT64 NOT NULL,
-                year_of_birth INT64 NOT NULL,
-                month_of_birth INT64,
-                day_of_birth INT64,
-                location_id INT64,
-                provider_id INT64,
-                care_site_id INT64);
             INSERT INTO
               `{{project_id}}.{{dataset_id}}.person` (person_id,
                 gender_concept_id,
@@ -130,22 +112,16 @@ class IDFieldSuppressionTest(BaseTest.CleaningRulesTestBase):
                 day_of_birth,
                 location_id,
                 provider_id,
-                care_site_id)
+                care_site_id,
+                race_concept_id,
+                ethnicity_concept_id)
             VALUES
-              (12345, 1, 1990, 12, 29, 22, 33, 44),
-              (6789, 2, 1980, 11, 20, 40, 50, 60)
+              (12345, 1, 1990, 12, 29, 22, 33, 44, 0, 0),
+              (6789, 2, 1980, 11, 20, 40, 50, 60, 0, 0)
             """).render(project_id=self.project_id, dataset_id=self.dataset_id)
 
         # test data for fact_relationship table, no identifying fields contained in table
         fact_relationship_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-              `{{project_id}}.{{dataset_id}}.fact_relationship`;
-            CREATE TABLE
-              `{{project_id}}.{{dataset_id}}.fact_relationship` (domain_concept_id_1 INT64 NOT NULL,
-                fact_id_1 INT64 NOT NULL,
-                domain_concept_id_2 INT64 NOT NULL,
-                fact_id_2 INT64 NOT NULL,
-                relationship_concept_id INT64 NOT NULL);
             INSERT INTO
               `{{project_id}}.{{dataset_id}}.fact_relationship` (domain_concept_id_1,
                 fact_id_1,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/negative_ages_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/negative_ages_test.py
@@ -40,7 +40,8 @@ class NegativeAgesTest(BaseTest.CleaningRulesTestBase):
 
         cls.rule_instance = NegativeAges(project_id, dataset_id, sandbox_id)
 
-        for table in cls.rule_instance.affected_tables:
+        # adding person table for setup/cleanup utilities
+        for table in cls.rule_instance.affected_tables + ['person']:
             cls.fq_table_names.append(
                 f'{cls.project_id}.{cls.dataset_id}.{table}')
 
@@ -65,69 +66,50 @@ class NegativeAgesTest(BaseTest.CleaningRulesTestBase):
 
         # test data for person table
         person_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-                `{{project_id}}.{{dataset_id}}.person`;
-            CREATE TABLE
-                `{{project_id}}.{{dataset_id}}.person` 
-                    (person_id INT64, birth_datetime TIMESTAMP);
             INSERT INTO
                 `{{project_id}}.{{dataset_id}}.person`
-                    (person_id, birth_datetime)
+                    (person_id, birth_datetime, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
             VALUES
-                (1, '1988-12-29 15:00:00'),
-                (2, '1980-11-20 15:00:00'),
-                (3, '2020-09-17 15:00:00'),
-                (4, '1861-09-17 15:00:00'),
-                (5, '1930-03-15 15:00:00'),
-                (5, '1940-04-09 15:00:00')
+                (1, '1988-12-29 15:00:00', 0, 1988, 0, 0),
+                (2, '1980-11-20 15:00:00', 0, 1980, 0, 0),
+                (3, '2020-09-17 15:00:00', 0, 2020, 0, 0),
+                (4, '1861-09-17 15:00:00', 0, 1861, 0, 0),
+                (5, '1930-03-15 15:00:00', 0, 1930, 0, 0),
+                (5, '1940-04-09 15:00:00', 0, 1940, 0, 0)
         """).render(project_id=self.project_id, dataset_id=self.dataset_id)
 
         # test data for negative age at recorded time in table
         measurement_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-                `{{project_id}}.{{dataset_id}}.measurement`;
-            CREATE TABLE
-                 `{{project_id}}.{{dataset_id}}.measurement` 
-                 (measurement_id INT64, person_id INT64, measurement_date DATE);
             INSERT INTO
                   `{{project_id}}.{{dataset_id}}.measurement` 
-                  (measurement_id, person_id, measurement_date)
+                  (measurement_id, person_id, measurement_date, measurement_type_concept_id, measurement_concept_id)
             VALUES
-                  (123, 1, date('2020-01-17')),
-                  (456, 2, date('2020-03-17')),
-                  (789, 3, date('2019-08-17'))
+                  (123, 1, date('2020-01-17'), 0, 0),
+                  (456, 2, date('2020-03-17'), 0, 0),
+                  (789, 3, date('2019-08-17'), 0, 0)
             """).render(project_id=self.project_id, dataset_id=self.dataset_id)
 
         # test data for age > MAX_AGE (=150) at recorded time in table
         observation_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-                `{{project_id}}.{{dataset_id}}.observation`;
-            CREATE TABLE
-                `{{project_id}}.{{dataset_id}}.observation`
-                (observation_id INT64, person_id INT64, observation_date DATE);
             INSERT INTO
                 `{{project_id}}.{{dataset_id}}.observation`
-                (observation_id, person_id, observation_date)
+                (observation_id, person_id, observation_date,
+                 observation_concept_id, observation_type_concept_id)
             VALUES
-                (111, 1, date('2019-07-04')),
-                (222, 2, date('2020-02-13')),
-                (333, 3, date('2021-02-17')),
-                (444, 4, date('2021-01-17'))
+                (111, 1, date('2019-07-04'),0 ,0),
+                (222, 2, date('2020-02-13'),0 ,0),
+                (333, 3, date('2021-02-17'),0 ,0),
+                (444, 4, date('2021-01-17'),0 ,0)
             """).render(project_id=self.project_id, dataset_id=self.dataset_id)
 
         # test data for negative age at death
         death_data_query = self.jinja_env.from_string("""
-            DROP TABLE IF EXISTS
-                `{{project_id}}.{{dataset_id}}.death`;
-            CREATE TABLE
-                `{{project_id}}.{{dataset_id}}.death`
-                (person_id INT64, death_date DATE);
             INSERT INTO
                 `{{project_id}}.{{dataset_id}}.death`
-                (person_id, death_date)
+                (person_id, death_date, death_type_concept_id)
             VALUES
-                (5, date('1915-05-05')),
-                (6, date('2020-08-15'))
+                (5, date('1915-05-05'), 0),
+                (6, date('2020-08-15'), 0)
             """).render(project_id=self.project_id, dataset_id=self.dataset_id)
 
         self.load_test_data([

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
@@ -20,9 +20,6 @@ from cdr_cleaner.cleaning_rules.no_data_30_days_after_death import (
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import \
     BaseTest
 
-# The existing person table is created and partitioned on the pseudo column _PARTITIONTIME,
-# partitioning by _PARTITIONTIME doesn't work using a query_statement for creating a table,
-# therefore CREATE OR REPLACE TABLE doesn' work and we need to DROP the table first.
 PERSON_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.person`
 (person_id, birth_datetime, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
@@ -24,57 +24,41 @@ from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_te
 # partitioning by _PARTITIONTIME doesn't work using a query_statement for creating a table,
 # therefore CREATE OR REPLACE TABLE doesn' work and we need to DROP the table first.
 PERSON_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.person`;
-CREATE TABLE `{{project_id}}.{{dataset_id}}.person`
-AS (
-WITH w AS (
-  SELECT ARRAY<STRUCT<person_id int64, birth_datetime TIMESTAMP>>
-      [(1, '1970-01-01 00:00:00 EST'),
-       (2, '1970-01-01 00:00:00 EST'),
-       (3, '1970-01-01 00:00:00 EST')] col
-)
-SELECT person_id, birth_datetime FROM w, UNNEST(w.col))
+INSERT INTO `{{project_id}}.{{dataset_id}}.person`
+(person_id, birth_datetime, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
+VALUES
+      (1, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
+      (2, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
+      (3, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0)
 """)
 
 DEATH_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.death`;
-CREATE TABLE `{{project_id}}.{{dataset_id}}.death`
-AS (
-WITH w AS (
-  SELECT ARRAY<STRUCT<person_id int64, death_date DATE>>
-      [(1, '1969-01-01'),
-       (2, '2020-01-01')] col
-)
-SELECT person_id, death_date FROM w, UNNEST(w.col))
+INSERT INTO `{{project_id}}.{{dataset_id}}.death`
+(person_id, death_date, death_type_concept_id)
+VALUES
+      (1, '1969-01-01', 0),
+      (2, '2020-01-01', 0)
 """)
 
 VISIT_OCCURRENCE_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.visit_occurrence`;
-CREATE TABLE `{{project_id}}.{{dataset_id}}.visit_occurrence`
-AS (
-WITH w AS (
-  SELECT ARRAY<STRUCT<visit_occurrence_id int64, person_id int64, visit_start_date DATE, visit_end_date DATE>>
-      [(1, 1, '2000-01-01', '2000-01-02'),
-       (2, 1, '2000-01-02', '2000-01-03'),
-       (3, 2, '2000-01-01', '2020-03-01'),
-       (4, 3, '2000-01-02', '2000-01-03')] col
-)
-SELECT visit_occurrence_id, person_id, visit_start_date, visit_end_date FROM w, UNNEST(w.col))
+INSERT INTO `{{project_id}}.{{dataset_id}}.visit_occurrence`
+      (visit_occurrence_id, person_id, visit_start_date, visit_end_date, visit_concept_id, visit_type_concept_id)
+VALUES
+      (1, 1, '2000-01-01', '2000-01-02', 0, 0),
+      (2, 1, '2000-01-02', '2000-01-03', 0, 0),
+      (3, 2, '2000-01-01', '2020-03-01', 0, 0),
+      (4, 3, '2000-01-02', '2000-01-03', 0, 0)
 """)
 
 OBSERVATION_DATA_TEMPLATE = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS `{{project_id}}.{{dataset_id}}.observation`;
-CREATE TABLE `{{project_id}}.{{dataset_id}}.observation`
-AS (
-WITH w AS (
-  SELECT ARRAY<STRUCT<observation_id int64, person_id int64, observation_date DATE>>
-      [(1, 1, '2000-01-01'),
-       (2, 1, '2000-01-02'),
-       (3, 2, '2020-03-01'),
-       (4, 2, '2020-01-05'),
-       (5, 3, '2020-05-05')] col
-)
-SELECT observation_id, person_id, observation_date FROM w, UNNEST(w.col))
+INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+(observation_id, person_id, observation_date, observation_concept_id, observation_type_concept_id)
+VALUES
+      (1, 1, '2000-01-01', 0, 0),
+      (2, 1, '2000-01-02', 0, 0),
+      (3, 2, '2020-03-01', 0, 0),
+      (4, 2, '2020-01-05', 0, 0),
+      (5, 3, '2020-05-05', 0, 0)
 """)
 
 
@@ -99,7 +83,8 @@ class NoDataAfterDeathTest(BaseTest.CleaningRulesTestBase):
                                              cls.sandbox_id)
 
         # Generates list of fully qualified table names and their corresponding sandbox table names
-        for table_name in get_affected_tables():
+        # adding death table name for setup/cleanup operations
+        for table_name in get_affected_tables() + ['death']:
             cls.fq_table_names.append(
                 f'{cls.project_id}.{cls.dataset_id}.{table_name}')
             sandbox_table_name = cls.rule_instance.sandbox_table_for(table_name)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
@@ -7,9 +7,9 @@ Original Issue: DC-414
 import os
 
 # Third party imports
+from google.cloud import bigquery
 
 # Project Imports
-from utils import bq
 import tests.test_util as test_util
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.unit_normalization import UnitNormalization, UNIT_MAPPING_TABLE
@@ -20,32 +20,27 @@ from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_te
 test_query = JINJA_ENV.from_string("""select * from `{{intermediary_table}}`""")
 
 INSERT_UNITS_RAW_DATA = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{project_id}}.{{dataset_id}}.measurement`;
-CREATE TABLE
-  `{{project_id}}.{{dataset_id}}.measurement` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<measurement_id INT64,
-      person_id INT64,
-      measurement_concept_id INT64,
-      value_as_number FLOAT64,
-      unit_concept_id INT64,
-      range_low FLOAT64,
-      range_high FLOAT64,
-      measurement_date INT64,
-      measurement_datetime INT64,
-      measurement_type_concept_id INT64,
-      operator_concept_id INT64,
-      value_as_concept_id INT64,
-      provider_id INT64,
-      visit_occurrence_id INT64,
-      measurement_source_value INT64,
-      measurement_source_concept_id INT64,
-      unit_source_value INT64,
-      value_source_value INT64
-      >>
+  INSERT INTO `{{project_id}}.{{dataset_id}}.measurement` (
+      measurement_id,
+      person_id,
+      measurement_concept_id,
+      value_as_number,
+      unit_concept_id,
+      range_low,
+      range_high,
+      measurement_date,
+      measurement_datetime,
+      measurement_type_concept_id,
+      operator_concept_id,
+      value_as_concept_id,
+      provider_id,
+      visit_occurrence_id,
+      measurement_source_value,
+      measurement_source_concept_id,
+      unit_source_value,
+      value_source_value
+      )
+    VALUES
     -- 3020509 Albumin/Globulin [Mass Ratio] in Serum or Plasma https://athena.ohdsi.org/search-terms/terms/3020509 --
     -- 3020891 Body temperature https://athena.ohdsi.org/search-terms/terms/3020891 --
     -- 3016293 Bicarbonate [Moles/volume] in Serum or Plasma https://athena.ohdsi.org/search-terms/terms/3016293 --
@@ -54,40 +49,16 @@ CREATE TABLE
     -- 000905 Leukocytes [#/volume] in Blood by Automated count https://athena.ohdsi.org/search-terms/terms/3000905 --
     -- 3020630 Protein [Mass/volume] in Serum or Plasma https://athena.ohdsi.org/search-terms/terms/3020630 --
     -- 3020416 Erythrocytes [#/volume] in Blood by Automated count https://athena.ohdsi.org/search-terms/terms/3020416 --
-      [
-      (1,1,3020509,0.4,8523,1.0,2.4,0,0,0,0,0,0,0,0,0,0,0),
-      (2,1,3020891,97.7,9289,0.0,150.0,0,0,0,0,0,0,0,0,0,0,0),
-      (3,1,3016293,25.0,8753,21.0,31.0,0,0,0,0,0,0,0,0,0,0,0),
-      (4,1,3027970,2.3,8713,1.5,4.5,0,0,0,0,0,0,0,0,0,0,0),
-      (5,1,3027970,2.6,4121395,1.9,3.7,0,0,0,0,0,0,0,0,0,0,0),
-      (6,1,3000963,15.8,4121395,13.2,17.1,0,0,0,0,0,0,0,0,0,0,0),
-      (7,1,3000905,10.1,8647,4.5,11.0,0,0,0,0,0,0,0,0,0,0,0),
-      (8,1,3020630,6.2,8840,6.4,8.2,0,0,0,0,0,0,0,0,0,0,0),
-      (9,1,3020416,5.06,8816,4.2,5.8,0,0,0,0,0,0,0,0,0,0,0),
-      (10,1,3000963,3.4,8554,0.5,5.0,0,0,0,0,0,0,0,0,0,0,0)] col
-)
-SELECT
-    measurement_id,
-    person_id,
-    measurement_concept_id,
-    value_as_number,
-    unit_concept_id,
-    range_low,
-    range_high,
-    measurement_date,
-    measurement_datetime,
-    measurement_type_concept_id,
-    operator_concept_id,
-    value_as_concept_id,
-    provider_id,
-    visit_occurrence_id,
-    measurement_source_value,
-    measurement_source_concept_id,
-    unit_source_value,
-    value_source_value
-  FROM
-    w,
-    UNNEST(w.col))
+      (1,1,3020509,0.4,8523,1.0,2.4,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (2,1,3020891,97.7,9289,0.0,150.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (3,1,3016293,25.0,8753,21.0,31.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (4,1,3027970,2.3,8713,1.5,4.5,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (5,1,3027970,2.6,4121395,1.9,3.7,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (6,1,3000963,15.8,4121395,13.2,17.1,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (7,1,3000905,10.1,8647,4.5,11.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (8,1,3020630,6.2,8840,6.4,8.2,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (9,1,3020416,5.06,8816,4.2,5.8,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      (10,1,3000963,3.4,8554,0.5,5.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null)
 """)
 
 
@@ -132,30 +103,30 @@ class UnitNormalizationTest(BaseTest.CleaningRulesTestBase):
             project_id=self.project_id, dataset_id=self.dataset_id)
 
         # Load test data
-        self.load_test_data([f'''{raw_units_load_query}'''])
+        self.load_test_data([f'{raw_units_load_query}'])
 
     def test_setup_rule(self):
 
         # test if intermediary table exists before running the cleaning rule
         intermediary_table = f'{self.project_id}.{self.sandbox_id}.{UNIT_MAPPING_TABLE}'
 
-        client = bq.get_client(self.project_id)
         # run setup_rule and see if the table is created
-        self.rule_instance.setup_rule(client)
+        self.rule_instance.setup_rule(self.client)
 
-        actual_table = client.get_table(intermediary_table)
+        actual_table = self.client.get_table(intermediary_table)
         self.assertIsNotNone(actual_table.created)
 
         # test if exception is raised if table already exists
         with self.assertRaises(RuntimeError) as c:
-            self.rule_instance.setup_rule(client)
+            self.rule_instance.setup_rule(self.client)
 
         self.assertEqual(str(c.exception),
                          f"Unable to create tables: ['{intermediary_table}']")
 
         query = test_query.render(intermediary_table=intermediary_table)
-        query_job_config = bq.bigquery.job.QueryJobConfig(use_query_cache=False)
-        result = client.query(query, job_config=query_job_config).to_dataframe()
+        query_job_config = bigquery.job.QueryJobConfig(use_query_cache=False)
+        result = self.client.query(query,
+                                   job_config=query_job_config).to_dataframe()
         self.assertEqual(result.empty, False)
 
     def test_unit_normalization(self):
@@ -188,7 +159,3 @@ class UnitNormalizationTest(BaseTest.CleaningRulesTestBase):
         }]
 
         self.default_test(tables_and_counts)
-
-    def tearDown(self):
-        for table in self.fq_table_names + self.fq_sandbox_table_names:
-            self.client.delete_table(table, not_found_ok=True)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -23,34 +23,24 @@ from cdr_cleaner.cleaning_rules.valid_death_dates import ValidDeathDates, progra
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
 DEATH_DATA_QUERY = JINJA_ENV.from_string("""
-DROP TABLE IF EXISTS
-  `{{fq_dataset_name}}.death`;
-CREATE TABLE
-  `{{fq_dataset_name}}.death` AS (
-  WITH
-    w AS (
-    SELECT
-      ARRAY<STRUCT<person_id INT64,
-      death_date DATE,
-      death_type_concept_id INT64>>
+  INSERT INTO `{{fq_dataset_name}}.death`
+    (
+        person_id,
+        death_date,
+        death_type_concept_id
+    )
+    VALUES
       -- records will be dropped because death_date is before AoU start date (Jan 1, 2017) --
-      [(101, DATE('2015-01-01'), 1),
-      (102, DATE('2016-01-01'), 2),
+      (101, '2015-01-01', 1),
+      (102, '2016-01-01', 2),
       -- records will be dropped because death_date is in the future --
       (103, DATE_ADD(CURRENT_DATE(), INTERVAL 1 DAY), 3),
       -- death_date will be one day in the future --
       (104, DATE_ADD(CURRENT_DATE(), INTERVAL 5 DAY), 4),
       -- death_date will be five days in the future --
       -- records won't be dropped because death_date is between AoU program start date and current date --
-      (105, DATE('2017-01-01'), 5),
-      (106, DATE('2020-01-01'), 6)] col )
-  SELECT
-    person_id,
-    death_date,
-    death_type_concept_id
-  FROM
-    w,
-    UNNEST(w.col))
+      (105, '2017-01-01', 5),
+      (106, '2020-01-01', 6)
 """)
 
 


### PR DESCRIPTION
* removes unnecessary table drops and recreations.  all tables are created with defined schemas by base class.
* utilizes `cls.fq_table_names` as intended to create/delete tables from base class.
* removes superfluous copy function in favor of existing client object copy function.
* removes creating new client objects in tests when the base client object is already available.
* removes redundant test teardowns that are overwriting the same definition in the base class.