### PR TITLE
[DC-1661] Exclude death table from cleaning rule to drop zero concept ids

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/drop_zero_concept_ids.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_zero_concept_ids.py
@@ -26,12 +26,13 @@ observation
 measurement
     - measurement_source_concept_id
     - measurement_concept_id
-death
-    - cause_source_concept_id
-    - cause_concept_id
 
 Remove those rows from the clean dataset
 Archive/sandbox those rows
+
+As of DC-1661, the death table has been removed.
+This allows the death table with suppressed cause_concept_id and
+cause_source_concept_id to persist without being deleted.9
 """
 
 # Python imports
@@ -40,14 +41,13 @@ import logging
 # Project imports
 import constants.cdr_cleaner.clean_cdr as cdr_consts
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
-from constants.bq_utils import WRITE_TRUNCATE
 from common import JINJA_ENV
 
 LOGGER = logging.getLogger(__name__)
 
 tables = [
     'condition_occurrence', 'procedure_occurrence', 'visit_occurrence',
-    'drug_exposure', 'device_exposure', 'observation', 'measurement', 'death'
+    'drug_exposure', 'device_exposure', 'observation', 'measurement'
 ]
 unique_identifier = {
     'condition_occurrence': 'condition_occurrence_id',
@@ -57,7 +57,6 @@ unique_identifier = {
     'device_exposure': 'device_exposure_id',
     'observation': 'observation_id',
     'measurement': 'measurement_id',
-    'death': 'person_id'
 }
 
 source_concept_id_columns = {
@@ -67,8 +66,7 @@ source_concept_id_columns = {
     'drug_exposure': 'drug_source_concept_id',
     'device_exposure': 'device_source_concept_id',
     'observation': 'observation_source_concept_id',
-    'measurement': 'measurement_source_concept_id',
-    'death': 'cause_source_concept_id'
+    'measurement': 'measurement_source_concept_id'
 }
 concept_id_columns = {
     'condition_occurrence': 'condition_concept_id',
@@ -77,8 +75,7 @@ concept_id_columns = {
     'drug_exposure': 'drug_concept_id',
     'device_exposure': 'device_concept_id',
     'observation': 'observation_concept_id',
-    'measurement': 'measurement_concept_id',
-    'death': 'cause_concept_id'
+    'measurement': 'measurement_concept_id'
 }
 
 # Query to create tables in sandbox with the rows that will be removed per cleaning rule

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_zero_concept_ids.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_zero_concept_ids.py
@@ -32,7 +32,7 @@ Archive/sandbox those rows
 
 As of DC-1661, the death table has been removed.
 This allows the death table with suppressed cause_concept_id and
-cause_source_concept_id to persist without being deleted.9
+cause_source_concept_id to persist without being deleted.
 """
 
 # Python imports

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_zero_concept_ids_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_zero_concept_ids_test.py
@@ -28,12 +28,13 @@ observation
 measurement
     - measurement_source_concept_id
     - measurement_concept_id
-death
-    - cause_source_concept_id
-    - cause_concept_id
 
 Remove those rows from the clean dataset
 Archive/sandbox those rows
+
+As of DC-1661, the death table has been removed.
+This allows the death table with suppressed cause_concept_id and
+cause_source_concept_id to persist without being deleted.
 """
 
 # Python imports
@@ -42,9 +43,7 @@ import unittest
 # Project imports
 from cdr_cleaner.cleaning_rules.drop_zero_concept_ids import DropZeroConceptIDs, SANDBOX_ZERO_CONCEPT_IDS_QUERY, \
     DROP_ZERO_CONCEPT_IDS_QUERY, tables, unique_identifier, concept_id_columns, source_concept_id_columns
-from constants.bq_utils import WRITE_TRUNCATE
 from constants.cdr_cleaner import clean_cdr as clean_consts
-import constants.cdr_cleaner.clean_cdr as cdr_consts
 
 
 class DropZeroConceptIDsTest(unittest.TestCase):


### PR DESCRIPTION
* [DC-1661] Exclude death table

[DC-1661]: https://precisionmedicineinitiative.atlassian.net/browse/DC-1661