### PR TITLE
[DC-1698] observation_source_value Values Not Nulled In R2021q2r1_deid

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -274,6 +274,7 @@ CONTROLLED_TIER_DEID_CLEAN_CLEANING_CLASSES = [
 
 REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     (QRIDtoRID,),  # Should run before any row suppression rules
+    (FillSourceValueTextFields,),
     (GenerateSiteMappingsAndExtTables,),
     (GeneralizeStateByPopulation,),
     (SectionParticipationConceptSuppression,),

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression.py
@@ -10,6 +10,7 @@ from constants import bq_utils as bq_consts
 import constants.cdr_cleaner.clean_cdr as cdr_consts
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
 from cdr_cleaner.clean_cdr_utils import get_tables_in_dataset
+from utils import pipeline_logging
 
 LOGGER = logging.getLogger(__name__)
 
@@ -112,7 +113,10 @@ class StringFieldsSuppression(BaseCleaningRule):
 
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
-                         affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.CONTROLLED_TIER_DEID],
+                         affected_datasets=[
+                             cdr_consts.CONTROLLED_TIER_DEID,
+                             cdr_consts.CONTROLLED_TIER_DEID
+                         ],
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id,
@@ -269,6 +273,7 @@ if __name__ == '__main__':
     import cdr_cleaner.clean_cdr_engine as clean_engine
 
     ARGS = parser.default_parse_args()
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
 
     if ARGS.list_queries:
         clean_engine.add_console_logging()

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/string_fields_suppression.py
@@ -112,7 +112,7 @@ class StringFieldsSuppression(BaseCleaningRule):
 
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
-                         affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID],
+                         affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.CONTROLLED_TIER_DEID],
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id,


### PR DESCRIPTION
* Add cleaning rule to `REGISTERED_TIER_DEID_CLEANING_CLASSES` list
* Updated affected datasets in cleaning rule module