### PR TITLE
[DC-1643] ValidDeathDates should remove death_dates occurring before any PPI response

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -39,18 +39,18 @@ SELECT d.*
 FROM `{{project_id}}.{{dataset_id}}.{{table}}` d
 LEFT JOIN (
         SELECT
-            person_id, MIN(o.observation_date) first_ppi_date
+            person_id, MAX(o.observation_date) last_ppi_date
         FROM `{{project_id}}.{{dataset_id}}.observation` o
         JOIN `{{project_id}}.{{dataset_id}}.concept` c
             ON c.concept_id =  o.observation_source_concept_id
         WHERE c.vocabulary_id = 'PPI'
         GROUP BY person_id
-) first_ppi_date
-    ON first_ppi_date.person_id = d.person_id
+) last_ppi_date
+    ON last_ppi_date.person_id = d.person_id
 WHERE {{table}}_date < '{{program_start_date}}' OR {{table}}_date > {{current_date}}
     OR (
-        first_ppi_date.person_id IS NULL 
-        OR DATE_DIFF(first_ppi_date.first_ppi_date, d.{{table}}_date, DAY) >= 1
+        last_ppi_date.person_id IS NULL 
+        OR DATE_DIFF(last_ppi_date.last_ppi_date, d.{{table}}_date, DAY) >= 1
     ) 
 )
 """)

--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -37,6 +37,7 @@ SANDBOX_INVALID_DEATH_DATE_ROWS = common.JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}` AS (
 SELECT d.*
 FROM `{{project_id}}.{{dataset_id}}.{{table}}` d
+-- Find the latest PPI observation for each person --
 LEFT JOIN (
         SELECT
             person_id, MAX(o.observation_date) last_ppi_date
@@ -48,6 +49,7 @@ LEFT JOIN (
 ) last_ppi_date
     ON last_ppi_date.person_id = d.person_id
 WHERE {{table}}_date < '{{program_start_date}}' OR {{table}}_date > {{current_date}}
+    -- Sandbox death record if it is >=1 day before latest PPI observation or no PPI observation exists --
     OR (
         last_ppi_date.person_id IS NULL 
         OR DATE_DIFF(last_ppi_date.last_ppi_date, d.{{table}}_date, DAY) >= 1

--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -35,9 +35,24 @@ SELECT person_id FROM `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}`)
 # or after the current date.
 SANDBOX_INVALID_DEATH_DATE_ROWS = common.JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}` AS (
-SELECT *
-FROM `{{project_id}}.{{dataset_id}}.{{table}}`
-WHERE {{table}}_date < '{{program_start_date}}' OR {{table}}_date > {{current_date}})
+SELECT d.*
+FROM `{{project_id}}.{{dataset_id}}.{{table}}` d
+LEFT JOIN (
+        SELECT
+            person_id, MIN(o.observation_date) first_ppi_date
+        FROM `{{project_id}}.{{dataset_id}}.observation` o
+        JOIN `{{project_id}}.{{dataset_id}}.concept` c
+            ON c.concept_id =  o.observation_source_concept_id
+        WHERE c.vocabulary_id = 'PPI'
+        GROUP BY person_id
+) first_ppi_date
+    ON first_ppi_date.person_id = d.person_id
+WHERE {{table}}_date < '{{program_start_date}}' OR {{table}}_date > {{current_date}}
+    OR (
+        first_ppi_date.person_id IS NULL 
+        OR DATE_DIFF(first_ppi_date.first_ppi_date, d.{{table}}_date, DAY) >= 1
+    ) 
+)
 """)
 
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -119,15 +119,13 @@ class ValidDeathDatesTest(BaseTest.CleaningRulesTestBase):
         fq_dataset_name = self.fq_table_names[0].split('.')
         self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
 
-        self.copy_vocab_tables()
-
-        super().setUp()
-
-    def copy_vocab_tables(self):
+        #Copy all needed vocab tables to the dataset
         for table in self.vocab_tables:
             self.client.copy_table(
                 f'{self.project_id}.{self.vocabulary_id}.{table}',
                 f'{self.project_id}.{self.dataset_id}.{table}')
+
+        super().setUp()
 
     def test_valid_death_dates(self):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -44,7 +44,9 @@ DEATH_DATA_QUERY = JINJA_ENV.from_string("""
       (106, '2020-01-01', 6),
       -- records will be dropped because death date is before first ppi date --
       (107, '2019-01-01', 7),
-      (108, '2019-01-01', 8)
+      (108, '2019-01-01', 8),
+      -- record should be dropped because a PPI record exists after this date --
+      (109, '2020-08-01', 0)
 """)
 
 INSERT_OBSERVATIONS_QUERY = JINJA_ENV.from_string("""
@@ -59,7 +61,9 @@ INSERT_OBSERVATIONS_QUERY = JINJA_ENV.from_string("""
         (5, 105, 1585250, 1585250, date('2016-05-05'), 5),
         (6, 106, 1585250, 1585250, date('2019-05-05'), 6),
         (7, 107, 1585250, 1585250, date('2019-01-03'), 7),
-        (8, 108, 1585250, 1585250, date('2019-01-02'), 8)
+        (8, 108, 1585250, 1585250, date('2019-01-02'), 8),
+        (9, 109, 1585250, 1585250, '2020-01-01', 0),
+        (10, 109, 1585250, 1585250, '2021-01-01', 0)
 """)
 
 
@@ -146,8 +150,8 @@ class ValidDeathDatesTest(BaseTest.CleaningRulesTestBase):
                 '.'.join([self.fq_dataset_name, DEATH]),
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'loaded_ids': [101, 102, 103, 104, 105, 106, 107, 108],
-            'sandboxed_ids': [101, 102, 103, 104, 107, 108],
+            'loaded_ids': [101, 102, 103, 104, 105, 106, 107, 108, 109],
+            'sandboxed_ids': [101, 102, 103, 104, 107, 108, 109],
             'fields': ['person_id', 'death_date', 'death_type_concept_id'],
             'cleaned_values': [(105, parse('2017-01-01').date(), 5),
                                (106, parse('2020-01-01').date(), 6)]


### PR DESCRIPTION
excluded records that have death before any ppi records.