### PR TITLE
[DC-1742] Remove Duplicate rule instances in RT clean list

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -299,14 +299,13 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     ####################################
     (
         GeneralizeStateByPopulation,),
+    (GeneralizeCopeInsuranceAnswers,),
 
     # Data suppressions
     ####################################
     (
         CovidEHRVaccineConceptSuppression,),  # should run after QRIDtoRID
     (StringFieldsSuppression,),
-    (GeneralizeStateByPopulation,),
-    (GeneralizeCopeInsuranceAnswers,),
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),
 ]


### PR DESCRIPTION
Remove repeated cleaning rules and reorder the cleaning rules to follow the classification

Signed-off-by: ksdkalluri <krishnasaikalluri@gmail.com>