### PR TITLE
[DC-1747] removing suppression of cope concepts in registered tier

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/deid/registered_cope_survey_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/registered_cope_survey_suppression.py
@@ -22,8 +22,6 @@ to be suppressed from the registered tier CDR
 | 596889                        | https://athena.ohdsi.org/search-terms/terms/596889            |
 | 1310137                       | https://athena.ohdsi.org/search-terms/terms/1310137           |
 | 1310146                       | https://athena.ohdsi.org/search-terms/terms/1310146           |
-| 1333015                       | https://athena.ohdsi.org/search-terms/terms/1333015           |
-| 1333023                       | https://athena.ohdsi.org/search-terms/terms/1333023           |
 | 1333016                       | https://athena.ohdsi.org/search-terms/terms/1333016           |
 | 715714                        | https://athena.ohdsi.org/search-terms/terms/715714            |
 | 1310147                       | https://athena.ohdsi.org/search-terms/terms/1310147           |
@@ -53,7 +51,7 @@ LOGGER = logging.getLogger(__name__)
 REGISTERED_COPE_SURVEY_SUPPRESS_CONCEPT_LIST = [
     1310058, 1310065, 1333012, 1333234, 702686, 1333327, 1333118, 1310054,
     1333326, 1310066, 596884, 596885, 596886, 596887, 596888, 596889, 1310137,
-    1310146, 1333015, 1333023, 1333016, 715714, 1310147, 715726
+    1310146, 1333016, 715714, 1310147, 715726
 ]
 
 
@@ -70,7 +68,7 @@ class RegisteredCopeSurveyQuestionsSuppression(
         """
         desc = f'Any record with an observation_source_concept_id equal to any concept_id in ' \
                f'{REGISTERED_COPE_SURVEY_SUPPRESS_CONCEPT_LIST} will be sandboxed and dropped from observation table.'
-        super().__init__(issue_numbers=['DC1666', 'DC1740'],
+        super().__init__(issue_numbers=['DC1666', 'DC1740', 'DC1747'],
                          description=desc,
                          affected_datasets=[cdr_consts.REGISTERED_TIER_DEID],
                          project_id=project_id,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/registered_cope_survey_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/registered_cope_survey_suppression_test.py
@@ -3,7 +3,7 @@ Integration test to ensure records are properly sandboxed and dropped in the reg
 
 Removes any records that have an observation_source_concept_id as any of these values: 1310058, 1310065, 1333012,
  1333234, 702686, 1333327, 1333118, 1310054, 1333326, 1310066, 596884, 596885, 596886, 596887, 596888, 596889, 1310137,
- 1310146, 1333015, 1333023, 1333016, 715714, 1310147, 715726.
+ 1310146, 1333016, 715714, 1310147, 715726.
 
 Original Issue: DC-1666, DC-1740
 
@@ -103,7 +103,9 @@ class RegisteredCopeSurveyQuestionsSuppressionTest(
               (11, 111, 0, 0, 0, 713888, 0, 0, 0, '2020-01-01'),
               (12, 112, 0, 0, 0, 1111111, 0, 0, 0, '2020-01-01'),
               (13, 113, 0, 0, 0, 2222222, 0, 0, 0, '2020-01-01'),
-              (14, 114, 0, 0, 0, null, 0, 0, 0, '2020-01-01')
+              (14, 114, 0, 0, 0, null, 0, 0, 0, '2020-01-01'),
+              (15, 115, 0, 0, 0, 1333023, 0, 0, 0, '2020-01-01'),
+              (16, 116, 0, 0, 0, 1333015, 0, 0, 0, '2020-01-01')
             """)
 
         insert_observation_query = observation_data_template.render(
@@ -120,7 +122,9 @@ class RegisteredCopeSurveyQuestionsSuppressionTest(
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.'
                 f'{self.rule_instance.sandbox_table_for("observation")}',
-            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+            'loaded_ids': [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+            ],
             'sandboxed_ids': [1, 2, 3, 4, 5, 6],
             'fields': [
                 'observation_id', 'person_id', 'observation_concept_id',
@@ -135,7 +139,9 @@ class RegisteredCopeSurveyQuestionsSuppressionTest(
                                (11, 111, 0, 0, 0, 713888, 0, 0, 0),
                                (12, 112, 0, 0, 0, 1111111, 0, 0, 0),
                                (13, 113, 0, 0, 0, 2222222, 0, 0, 0),
-                               (14, 114, 0, 0, 0, None, 0, 0, 0)]
+                               (14, 114, 0, 0, 0, None, 0, 0, 0),
+                               (15, 115, 0, 0, 0, 1333023, 0, 0, 0),
+                               (16, 116, 0, 0, 0, 1333015, 0, 0, 0)]
         }]
 
         self.default_test(tables_and_counts)


### PR DESCRIPTION
* removes the concepts from the list of suppressions
* updates the integration test to make sure the removal worked