### PR TITLE
[DC-1748] fix state generalization by population rule

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/generalize_state_by_population.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/generalize_state_by_population.py
@@ -30,6 +30,7 @@ STATE_GENERALIZATION_QUERY = JINJA_ENV.from_string("""
         GROUP BY value_source_concept_id
         HAVING COUNT(*) < {{threshold}}
     )
+    and observation_source_concept_id = 1585249
 """)
 
 

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generalize_state_by_population_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generalize_state_by_population_test.py
@@ -31,6 +31,7 @@ STATE_GENERALIZATION_QUERY = JINJA_ENV.from_string("""
         GROUP BY value_source_concept_id
         HAVING COUNT(*) < {{threshold}}
     )
+    and observation_source_concept_id = 1585249
 """)
 
 


### PR DESCRIPTION
* limit the update statement to only impact state participant survey records
* update unit test to validate it only updates records where observation_source_concept_id = 1585249