### PR TITLE
[DC-1738] Comments in `clean_ppi_numeric_fields_using_parameters.py` SQL are backward

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -43,10 +43,10 @@ OR
 OR
     (observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99))
 OR
-    -- from dc1058: sandbox any participant data who have a household size greater than 11 --
+    -- from dc1061: sandbox any participant data who have a household size greater than 11 --
     (observation_concept_id IN (1333015, 1585889) AND (value_as_number < 0 OR value_as_number > 10))
 OR
-    -- from dc1061: sandbox any participant data who have 6 or more members under 18 in their household --
+    -- from dc1058: sandbox any participant data who have 6 or more members under 18 in their household --
     (observation_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5)))
 """)
 


### PR DESCRIPTION
* [DC-1738] Update jinja comments with correct tickets

[DC-1738]: https://precisionmedicineinitiative.atlassian.net/browse/DC-1738