### PR TITLE
[DC-1811] circleci limited update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ orbs:
   # Send notifications for failed builds on master, develop branches using Slack orb (https://circleci.com/orbs/registry/orb/circleci/slack). Refer to the
   # For channels to notify and webhook URL refer to the CircleCI Slack App page (https://slack.com/apps/A0F7VRE7N-circleci).
   slack: circleci/slack@3.4.2
+  # Invoke python orb
+  python: circleci/python@1.4.0
 
 job_defaults: &job_defaults
     working_directory: ~/curation/data_steward
@@ -13,8 +15,9 @@ job_defaults: &job_defaults
     # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
     environment:
       - CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      - PYTHONPATH: ~/curation/data_steward:~/curation/tests:$PYTHONPATH
     docker:
-      - image: circleci/python:3.7.4
+      - image: cimg/python:3.7
 
 commands:
   # Define reusable sets of steps to be run within the testing jobs.
@@ -22,11 +25,6 @@ commands:
     steps:
       - checkout:
           path: ~/curation
-      # Dependencies
-      - restore_cache:
-          keys:
-            - pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
-            - pip-cache-
       - run:
           name: Add virtual environment activation to bash startup
           command: python3 -m venv ~/curation_venv && echo "source ~/curation_venv/bin/activate" >> $BASH_ENV
@@ -43,10 +41,6 @@ commands:
           command: cat ${BASH_ENV}
   lint_teardown:
     steps:
-      - save_cache:
-          paths:
-            ~/curation_venv
-          key: pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
       - slack/status:
           fail_only: true
           only_for_branches: master,develop
@@ -54,54 +48,29 @@ commands:
     steps:
       - checkout:
           path: ~/curation
-      - run:
-          name: Allow google cloud to be added as apt repo
-          command: |
-            sudo apt-get update
-            sudo apt install software-properties-common
       # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
       - run: mkdir -p $CIRCLE_ARTIFACTS
       - run:
-          name: Add google-cloud-sdk repo to apt
-          command: echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-      - run:
-          name: Add google key to apt
-          command: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      - run:
           name: Install google-cloud-sdk
-          command: |
-            sudo apt-get update
-            sudo apt-get install dpkg
-            sudo apt-get install google-cloud-sdk
-      # Dependencies
-      - restore_cache:
-          keys:
-          - pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
-          - pip-cache-
-      - run:
-          name: Add virtual environment activation to bash startup
-          command: python3 -m venv ~/curation_venv && echo "source ~/curation_venv/bin/activate" >> $BASH_ENV
-      - run:
-          name: Upgrade pip and install requirements
-          command: |
-            pip install --upgrade pip setuptools
-            pip install -r requirements.txt
-            pip install -r dev_requirements.txt
-            pip install -r deid/requirements.txt
+          working_directory: ~/curation
+          command: source tools/install_google_cloud_sdk.sh  # need to get the other code for this
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/curation
+          include-branch-in-cache-key: false
+          include-python-in-cache-key: true
+          pip-dependency-file: data_steward/requirements.txt
+          pip-dependency-file: data_steward/dev_requirements.txt
+          pypi-cache: true
       - run:
           name: Show bashrc file
           command: cat ${BASH_ENV}
   test_teardown:
     steps:
-      - save_cache:
-          paths:
-            ~/curation_venv
-          key: pip-cache-{{ checksum "requirements.txt" }}-{{ checksum "dev_requirements.txt" }}-{{ checksum "deid/requirements.txt" }}
       - run:
           name: Combine Coverage Results
           working_directory: ~/curation
-          command: |
-              . tests/combine_coverage.sh
+          command: . tests/combine_coverage.sh
           no_output_timeout: 30s
       # Save test results
       - store_test_results:
@@ -117,8 +86,18 @@ commands:
 jobs:
   linting_checks:
     <<: *job_defaults
+    executor: python/default
     steps:
-      - lint_setup
+      - checkout:
+          path: ~/curation
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/curation
+          include-branch-in-cache-key: false
+          include-python-in-cache-key: true
+          pip-dependency-file: data_steward/requirements.txt
+          pip-dependency-file: data_steward/dev_requirements.txt
+          pypi-cache: true
       - run:
           name: Checking commit messages for Jira tag
           working_directory: ~/curation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,6 @@ commands:
             pip install -r requirements.txt
             pip install -r dev_requirements.txt
             pip install -r deid/requirements.txt
-      - run:
-          name: Show bashrc file
-          command: cat ${BASH_ENV}
   lint_teardown:
     steps:
       - slack/status:
@@ -91,9 +88,6 @@ commands:
           include-python-in-cache-key: true
           pip-dependency-file: data_steward/dev_requirements.txt
           pypi-cache: true
-      - run:
-          name: Show bashrc file
-          command: cat ${BASH_ENV}
   test_teardown:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,30 @@ commands:
       - run:
           name: Install google-cloud-sdk
           working_directory: ~/curation
-          command: source tools/install_google_cloud_sdk.sh  # need to get the other code for this
+          command: |
+            # install google-cloud-sdk since it is not yet available via apt-get on ubuntu 20.0.4
+
+            # don't suppress errors.
+            set -e
+            # TODO: this is done as there is currently (as of 2021.08.19) no 20.04 release in the google repo for...reasons
+            # TODO: parameterize gsdk version and sha
+            wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-353.0.0-linux-x86_64.tar.gz
+            # verify integrity
+            echo 94fcb77632fed5b6fa61d1bf6c619cbfceb63f3d95911bfe15e7caa401df81c0 \
+              google-cloud-sdk-353.0.0-linux-x86_64.tar.gz | sha256sum --check --status && if [[ "$?" -ne 0 ]]; then exit 1; fi
+            # if we get here, assume things are ok and do the following:
+            # 1. untar source
+            # 2. execute installer
+            # 3. cd back to home
+            # 4. update components (should help us not have to manually manage sha and wget version)
+            tar -xzvf google-cloud-sdk-353.0.0-linux-x86_64.tar.gz \
+              && cd ./google-cloud-sdk \
+              && ./install.sh --quiet \
+              && echo "source $(pwd)/path.bash.inc" >> /home/circleci/.profile \
+              && cd .. \
+              && ./google-cloud-sdk/bin/gcloud components update --quiet
+            # finally, add to path
+            set +e
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/curation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,21 +21,24 @@ job_defaults: &job_defaults
 
 commands:
   # Define reusable sets of steps to be run within the testing jobs.
-  lint_setup:
+  virtual_env_setup:
     steps:
       - checkout:
           path: ~/curation
-      - run:
-          name: Add virtual environment activation to bash startup
-          command: python3 -m venv ~/curation_venv && echo "source ~/curation_venv/bin/activate" >> $BASH_ENV
-      - run:
-          working_directory: ~/curation/data_steward
-          name: Upgrade pip and install requirements
-          command: |
-            pip install --upgrade pip setuptools
-            pip install -r requirements.txt
-            pip install -r dev_requirements.txt
-            pip install -r deid/requirements.txt
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/curation
+          include-branch-in-cache-key: false
+          include-python-in-cache-key: true
+          pip-dependency-file: data_steward/requirements.txt
+          pypi-cache: true
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/curation
+          include-branch-in-cache-key: false
+          include-python-in-cache-key: true
+          pip-dependency-file: data_steward/dev_requirements.txt
+          pypi-cache: true
   lint_teardown:
     steps:
       - slack/status:
@@ -74,20 +77,7 @@ commands:
               && ./google-cloud-sdk/bin/gcloud components update --quiet
             # finally, add to path
             set +e
-      - python/install-packages:
-          pkg-manager: pip
-          app-dir: ~/curation
-          include-branch-in-cache-key: false
-          include-python-in-cache-key: true
-          pip-dependency-file: data_steward/requirements.txt
-          pypi-cache: true
-      - python/install-packages:
-          pkg-manager: pip
-          app-dir: ~/curation
-          include-branch-in-cache-key: false
-          include-python-in-cache-key: true
-          pip-dependency-file: data_steward/dev_requirements.txt
-          pypi-cache: true
+      - virtual_env_setup
   test_teardown:
     steps:
       - run:
@@ -113,20 +103,7 @@ jobs:
     steps:
       - checkout:
           path: ~/curation
-      - python/install-packages:
-          pkg-manager: pip
-          app-dir: ~/curation
-          include-branch-in-cache-key: false
-          include-python-in-cache-key: true
-          pip-dependency-file: data_steward/requirements.txt
-          pypi-cache: true
-      - python/install-packages:
-          pkg-manager: pip
-          app-dir: ~/curation
-          include-branch-in-cache-key: false
-          include-python-in-cache-key: true
-          pip-dependency-file: data_steward/dev_requirements.txt
-          pypi-cache: true
+      - virtual_env_setup
       - run:
           name: Checking commit messages for Jira tag
           working_directory: ~/curation
@@ -177,16 +154,10 @@ jobs:
           command: ./ci/activate_creds.sh ${HOME}/gcloud-credentials-key.json
       - run:
           name: Set up environment variables
-          working_directory: ~/curation/data_steward
-          command: |
-            echo $CIRCLE_WORKING_DIRECTORY
-            ./init_env.sh
+          command: ./init_env.sh
       - run:
           name: Create buckets and datasets
-          command: |
-            echo $CIRCLE_WORKING_DIRECTORY
-            echo $PYTHONPATH
-            PYTHONPATH=./:$PYTHONPATH python ./ci/test_setup.py
+          command: PYTHONPATH=./:$PYTHONPATH python ./ci/test_setup.py
       - run:
           name: Run integration tests
           working_directory: ~/curation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           command: tools/yapf_lint.sh
       - run:
           name: Checking Python lint with Pylint
-          working _directory: ~/curation
+          working_directory: ~/curation
           command: pylint -E data_steward tests
       - lint_teardown
 
@@ -178,10 +178,15 @@ jobs:
       - run:
           name: Set up environment variables
           working_directory: ~/curation/data_steward
-          command: ./init_env.sh
+          command: |
+            echo $CIRCLE_WORKING_DIRECTORY
+            ./init_env.sh
       - run:
           name: Create buckets and datasets
-          command: PYTHONPATH=./:$PYTHONPATH python ./ci/test_setup.py
+          command: |
+            echo $CIRCLE_WORKING_DIRECTORY
+            echo $PYTHONPATH
+            PYTHONPATH=./:$PYTHONPATH python ./ci/test_setup.py
       - run:
           name: Run integration tests
           working_directory: ~/curation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,12 @@ commands:
           include-branch-in-cache-key: false
           include-python-in-cache-key: true
           pip-dependency-file: data_steward/requirements.txt
+          pypi-cache: true
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/curation
+          include-branch-in-cache-key: false
+          include-python-in-cache-key: true
           pip-dependency-file: data_steward/dev_requirements.txt
           pypi-cache: true
       - run:
@@ -96,6 +102,12 @@ jobs:
           include-branch-in-cache-key: false
           include-python-in-cache-key: true
           pip-dependency-file: data_steward/requirements.txt
+          pypi-cache: true
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/curation
+          include-branch-in-cache-key: false
+          include-python-in-cache-key: true
           pip-dependency-file: data_steward/dev_requirements.txt
           pypi-cache: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ jobs:
           command: ./ci/activate_creds.sh ${HOME}/gcloud-credentials-key.json
       - run:
           name: Set up environment variables
+          working_directory: ~/curation/data_steward
           command: ./init_env.sh
       - run:
           name: Create buckets and datasets

--- a/data_steward/init_env.sh
+++ b/data_steward/init_env.sh
@@ -78,5 +78,5 @@ if [ -n "${CIRCLECI}" ]; then
   echo "export UNIONED_DATASET_ID=${UNIONED_DATASET_ID}" >>"${BASH_ENV}"
   echo "export BUCKET_NAME_UNIONED_EHR=${BUCKET_NAME_UNIONED_EHR}" >>"${BASH_ENV}"
   echo "export VOCABULARY_DATASET=${VOCABULARY_DATASET}" >>"${BASH_ENV}"
-  echo 'export PATH=${PATH}:${CIRCLE_WORKING_DIRECTORY}/ci' >>"${BASH_ENV}"
+  echo "export PATH=${PATH}:${CIRCLE_WORKING_DIRECTORY}/ci" >>"${BASH_ENV}"
 fi

--- a/data_steward/init_env.sh
+++ b/data_steward/init_env.sh
@@ -78,5 +78,5 @@ if [ -n "${CIRCLECI}" ]; then
   echo "export UNIONED_DATASET_ID=${UNIONED_DATASET_ID}" >>"${BASH_ENV}"
   echo "export BUCKET_NAME_UNIONED_EHR=${BUCKET_NAME_UNIONED_EHR}" >>"${BASH_ENV}"
   echo "export VOCABULARY_DATASET=${VOCABULARY_DATASET}" >>"${BASH_ENV}"
-  echo "export PATH=${PATH}:${CIRCLE_WORKING_DIRECTORY}/ci" >>"${BASH_ENV}"
+  echo 'export PATH=${PATH}:${CIRCLE_WORKING_DIRECTORY}/ci' >>"${BASH_ENV}"
 fi

--- a/data_steward/init_env.sh
+++ b/data_steward/init_env.sh
@@ -78,5 +78,5 @@ if [ -n "${CIRCLECI}" ]; then
   echo "export UNIONED_DATASET_ID=${UNIONED_DATASET_ID}" >>"${BASH_ENV}"
   echo "export BUCKET_NAME_UNIONED_EHR=${BUCKET_NAME_UNIONED_EHR}" >>"${BASH_ENV}"
   echo "export VOCABULARY_DATASET=${VOCABULARY_DATASET}" >>"${BASH_ENV}"
-  echo 'export PATH=${PATH}:${CIRCLE_WORKING_DIRECTORY}/ci' >>"${BASH_ENV}"
+  echo PATH=\"\${PATH}:\${CIRCLE_WORKING_DIRECTORY}/ci\" >> "${BASH_ENV}"
 fi


### PR DESCRIPTION
* is not the optimal update, but just trying to get circleci back up before the dockerized version is ready.
* changes to a new image
* uses the python orb to set up the virtual environment
* installs google-cloud-sdk directly
* uses the orb to set up caching and removes the current environment caching mechanism
* is intended to be overriden by DC-1820 PR
* will still fail due to linting errors to be resolved in DC-1839 PR