### PR TITLE
[DC-1970] Define empty_bucket(name: str) helper method for gcloud.gcs.StorageClient()

### DIFF
--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -26,9 +26,10 @@ class StorageClient(Client):
         (i.e gsutil rm -r gs://bucket/prefix/)
         """
 
-        blobs = self.list_blobs(bucket, **kwargs)
-        for blob in blobs:
-            blob.delete()
+        pages = self.list_blobs(bucket, **kwargs).pages
+        for page in pages:
+            for blob in page:
+                blob.delete()
 
     def list_sub_prefixes(self, bucket: str, prefix: str) -> None:
         """

--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -18,15 +18,15 @@ class StorageClient(Client):
 
     def empty_bucket(self, bucket: str, **kwargs) -> None:
         """
-        Delete all/partial blobs in a bucket.
+        Delete all blobs in a bucket.
         :param name: A GCS bucket name.
 
         Some common keyword arguments:
         :param prefix: (Optional) Prefix used to filter blobs.
-        (i.e gsutil rm -r gs://bucket/prefix)
+        (i.e gsutil rm -r gs://bucket/prefix/)
         """
-        bucket = self.get_bucket(bucket)
-        blobs = bucket.list_blobs(**kwargs)
+
+        blobs = self.list_blobs(bucket, **kwargs)
         for blob in blobs:
             blob.delete()
 

--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -16,7 +16,21 @@ class StorageClient(Client):
     See https://googleapis.dev/python/storage/latest/client.html
     """
 
-    def list_sub_prefixes(self, bucket: str, prefix: str):
+    def empty_bucket(self, bucket: str, **kwargs) -> None:
+        """
+        Delete all/partial blobs in a bucket.
+        :param name: A GCS bucket name.
+
+        Some common keyword arguments:
+        :param prefix: (Optional) Prefix used to filter blobs.
+        (i.e gsutil rm -r gs://bucket/prefix)
+        """
+        bucket = self.get_bucket(bucket)
+        blobs = bucket.list_blobs(**kwargs)
+        for blob in blobs:
+            blob.delete()
+
+    def list_sub_prefixes(self, bucket: str, prefix: str) -> None:
         """
         List sub folders in folder specified by prefix
 

--- a/tests/integration_tests/data_steward/gcloud/gcs_client_test.py
+++ b/tests/integration_tests/data_steward/gcloud/gcs_client_test.py
@@ -28,8 +28,19 @@ class GcsClientTest(unittest.TestCase):
         self.sub_prefixes: tuple = (f'{self.prefix}/a', f'{self.prefix}/b',
                                     f'{self.prefix}/c', f'{self.prefix}/d')
 
+    def test_empty_bucket(self):
+
+        self.client.empty_bucket(self.bucket_name)
+        self._stage_bucket()
+        self.client.empty_bucket(self.bucket_name)
+
+        actual = self.client.list_blobs(self.bucket_name)
+        expected: list = []
+
+        self.assertCountEqual(actual, expected)
+
     def test_list_sub_prefixes(self):
-        self._empty_bucket()
+        self.client.empty_bucket(self.bucket_name)
         self._stage_bucket()
 
         items = self.client.list_sub_prefixes(self.bucket_name, self.prefix)
@@ -38,13 +49,7 @@ class GcsClientTest(unittest.TestCase):
         for item in items:
             self.assertIn(item[:-1], self.sub_prefixes)
 
-        self._empty_bucket()
-
-    def _empty_bucket(self):
-        bucket = self.client.get_bucket(self.bucket_name)
-        blobs = bucket.list_blobs(prefix=self.prefix)
-        for blob in blobs:
-            blob.delete()
+        self.client.empty_bucket(self.bucket_name)
 
     def _stage_bucket(self):
         bucket = self.client.bucket(self.bucket_name)
@@ -52,4 +57,4 @@ class GcsClientTest(unittest.TestCase):
             bucket.blob(f'{sub_prefix}/obj.txt').upload_from_string(self.data)
 
     def tearDown(self):
-        self._empty_bucket()
+        self.client.empty_bucket(self.bucket_name)

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -35,12 +35,16 @@ class GCSTest(TestCase):
 
     @patch.object(DummyClient, 'list_blobs')
     def test_empty_bucket(self, mock_list_blobs):
+        # Mock up blobs
         mock_blob = MagicMock()
         mock_blob.delete.return_value = None
-
-        self.client.list_blobs.return_value = [mock_blob]
+        # Mock up pages
+        mock_pages = MagicMock()
+        mock_pages.pages = [[mock_blob]]
+        # Mock page returning list funciton
+        self.client.list_blobs.return_value = mock_pages
+        # Test
         self.client.empty_bucket(self.bucket)
-
         mock_blob.delete.assert_called_once()
 
     @patch('gcloud.gcs.page_iterator')

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -1,5 +1,4 @@
 # Python imports
-from io import BytesIO
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from typing import Callable
@@ -8,6 +7,16 @@ from typing import Callable
 
 # Project imports
 from gcloud.gcs import StorageClient
+
+
+class DummyClient(StorageClient):
+    """
+    A class which inherits all of StorageClient but doesn't authenticate
+    """
+
+    # pylint: disable=super-init-not-called
+    def __init__(self):
+        pass
 
 
 class GCSTest(TestCase):
@@ -19,31 +28,50 @@ class GCSTest(TestCase):
         print('**************************************************************')
 
     def setUp(self):
-        self.client = StorageClient.create_anonymous_client()
+
+        # mock_default_auth = patch('google.auth.default')
+        # self.mock_auth = mock_default_auth.start()
+        # self.mock_auth.return_value = (sentinel.credentials, 'test-project')
+        # self.client = StorageClient().create_anonymous_client()
+
+        self.client = DummyClient()
         self.bucket = 'foo_bucket'
-        self.folder_prefix = 'folder/'
-        self.file_name = 'fake_file.csv'
-        self.fake_file_obj = BytesIO()
+        self.prefix = 'foo_prefix/'
+        self.file_name = 'foo_file.csv'
+
+        # self.addCleanup(mock_default_auth.stop)
+
+    @patch.object(DummyClient, 'list_blobs')
+    def test_empty_bucket(self, mock_list_blobs):
+        mock_blob = MagicMock()
+        mock_blob.delete.return_value = None
+
+        self.client.list_blobs.return_value = [mock_blob]
+        self.client.empty_bucket(self.bucket)
+
+        mock_blob.delete.assert_called_once()
 
     @patch('gcloud.gcs.page_iterator')
-    def test_list_sub_prefixes(self, mock_iterator):
+    @patch.object(DummyClient, '_connection')
+    def test_list_sub_prefixes(self, mock_connection, mock_iterator):
 
-        mock_iterator.HTTPIterator = MagicMock()
-
-        fake_request = 'fake_api_request'
-        self.client._connection.api_request = fake_request
-        path = f"/b/{self.bucket}/o"
-        extra_params = {
+        foo_request: str = 'fake_api_request'
+        path: str = f"/b/{self.bucket}/o"
+        extra_params: dict = {
             "projection": "noAcl",
-            "prefix": self.folder_prefix,
+            "prefix": self.prefix,
             "delimiter": '/'
         }
 
-        self.client.list_sub_prefixes(self.bucket, self.folder_prefix)
+        mock_iterator.HTTPIterator = MagicMock()
+        self.client._connection.return_value = MagicMock()
+        self.client._connection.api_request = foo_request
+
+        self.client.list_sub_prefixes(self.bucket, self.prefix)
         self.assertEqual(mock_iterator.HTTPIterator.call_count, 1)
         args = mock_iterator.HTTPIterator.call_args[1]
         self.assertEqual(args['client'], self.client)
-        self.assertEqual(args['api_request'], fake_request)
+        self.assertEqual(args['api_request'], foo_request)
         self.assertEqual(args['path'], path)
         self.assertEqual(args['items_key'], 'prefixes')
         self.assertIsInstance(args['item_to_value'], Callable)

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -28,18 +28,10 @@ class GCSTest(TestCase):
         print('**************************************************************')
 
     def setUp(self):
-
-        # mock_default_auth = patch('google.auth.default')
-        # self.mock_auth = mock_default_auth.start()
-        # self.mock_auth.return_value = (sentinel.credentials, 'test-project')
-        # self.client = StorageClient().create_anonymous_client()
-
         self.client = DummyClient()
         self.bucket = 'foo_bucket'
         self.prefix = 'foo_prefix/'
         self.file_name = 'foo_file.csv'
-
-        # self.addCleanup(mock_default_auth.stop)
 
     @patch.object(DummyClient, 'list_blobs')
     def test_empty_bucket(self, mock_list_blobs):


### PR DESCRIPTION
A helper function called empty_bucket() has been created.  Any additional kwargs that may be supplied list_blob() are passed along for deletion as well (e.g.  To empty the bucket starting at a given prefix: `StorageClient.empty_bucket('bucket', prefix='prefix')`).

This work includes integration and unit tests.