### PR TITLE
[DC-1967] Updated write_to_result_table to incorperate gcloud.gcs.StorageClient()

### DIFF
--- a/data_steward/validation/participants/writers.py
+++ b/data_steward/validation/participants/writers.py
@@ -16,6 +16,7 @@ import oauth2client
 import bq_utils
 import constants.validation.participants.writers as consts
 import gcs_utils
+from gcloud.gcs import StorageClient
 from resources import fields_path
 
 LOGGER = logging.getLogger(__name__)
@@ -68,7 +69,10 @@ def write_to_result_table(project, dataset, site, match_values):
 
     # write results
     results.seek(0)
-    gcs_utils.upload_object(bucket, path, results)
+    sc = StorageClient()
+    sc_bucket = sc.get_bucket(bucket)
+    bucket_blob = sc_bucket.blob(path)
+    bucket_blob.upload_from_file(results)
     results.close()
 
     LOGGER.info(

--- a/tests/unit_tests/data_steward/validation/participants/writers_test.py
+++ b/tests/unit_tests/data_steward/validation/participants/writers_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 # Third party imports
-from mock import ANY, call, patch
+from mock import ANY, call, patch, MagicMock
 import oauth2client
 
 # Project imports
@@ -23,16 +23,21 @@ class WritersTest(unittest.TestCase):
         self.dataset = 'bar'
         self.site = 'rho'
 
+    @patch('validation.participants.writers.StorageClient')
     @patch('validation.participants.writers.gcs_utils.get_drc_bucket')
     @patch('validation.participants.writers.bq_utils.wait_on_jobs')
-    @patch('validation.participants.writers.gcs_utils.upload_object')
     @patch('validation.participants.writers.bq_utils.load_csv')
-    def test_write_to_result_table(self, mock_load_csv, mock_upload, mock_wait,
-                                   mock_bucket):
+    def test_write_to_result_table(self, mock_load_csv, mock_wait, mock_bucket,
+                                   mock_storage_client):
         # pre-conditions
         bucket_name = 'mock_bucket'
         mock_wait.return_value = []
         mock_bucket.return_value = bucket_name
+        mock_client_bucket = MagicMock()
+        mock_client_blob = MagicMock()
+        mock_storage_client.return_value = mock_storage_client
+        mock_storage_client.get_bucket.return_value = mock_client_bucket
+        mock_client_bucket.blob.return_value = mock_client_blob
 
         match = {}
         for field in consts.VALIDATION_FIELDS:
@@ -45,13 +50,20 @@ class WritersTest(unittest.TestCase):
                                      matches)
 
         # post conditions
-        self.assertEqual(mock_upload.call_count, 1)
         self.assertEqual(mock_load_csv.call_count, 1)
         self.assertEqual(mock_wait.call_count, 1)
+        self.assertEqual(mock_storage_client.get_bucket.call_count, 1)
+        self.assertEqual(mock_client_bucket.blob.call_count, 1)
+        self.assertEqual(mock_client_blob.upload_from_file.call_count, 1)
 
         upload_path = self.dataset + '/intermediate_results/' + self.site + '.csv'
         self.assertEqual(
-            mock_upload.assert_called_with(bucket_name, upload_path, ANY), None)
+            mock_storage_client.get_bucket.assert_called_with(bucket_name),
+            None)
+        self.assertEqual(
+            mock_client_bucket.blob.assert_called_with(upload_path), None)
+        self.assertEqual(
+            mock_client_blob.upload_from_file.assert_called_with(ANY), None)
 
         self.assertEqual(
             mock_load_csv.assert_called_with(

--- a/tests/unit_tests/data_steward/validation/participants/writers_test.py
+++ b/tests/unit_tests/data_steward/validation/participants/writers_test.py
@@ -64,7 +64,7 @@ class WritersTest(unittest.TestCase):
 
         mock_load_csv.assert_called_with(
             ANY,
-            'gs://' + bucket_name + '/' + upload_path,
+            f'gs://{bucket_name}/{upload_path}',
             self.project,
             self.dataset,
             self.site + consts.VALIDATION_TABLE_SUFFIX,
@@ -112,7 +112,7 @@ class WritersTest(unittest.TestCase):
 
         mock_load_csv.assert_called_with(
             ANY,
-            'gs://' + bucket_name + '/' + upload_path,
+            f'gs://{bucket_name}/{upload_path}',
             self.project,
             self.dataset,
             self.site + consts.VALIDATION_TABLE_SUFFIX,

--- a/tests/unit_tests/data_steward/validation/participants/writers_test.py
+++ b/tests/unit_tests/data_steward/validation/participants/writers_test.py
@@ -35,8 +35,9 @@ class WritersTest(unittest.TestCase):
         mock_bucket.return_value = bucket_name
         mock_client_bucket = MagicMock()
         mock_client_blob = MagicMock()
-        mock_storage_client.return_value = mock_storage_client
-        mock_storage_client.get_bucket.return_value = mock_client_bucket
+        mock_client = MagicMock()
+        mock_storage_client.return_value = mock_client
+        mock_client.get_bucket.return_value = mock_client_bucket
         mock_client_bucket.blob.return_value = mock_client_blob
 
         match = {}
@@ -52,27 +53,22 @@ class WritersTest(unittest.TestCase):
         # post conditions
         self.assertEqual(mock_load_csv.call_count, 1)
         self.assertEqual(mock_wait.call_count, 1)
-        self.assertEqual(mock_storage_client.get_bucket.call_count, 1)
+        self.assertEqual(mock_client.get_bucket.call_count, 1)
         self.assertEqual(mock_client_bucket.blob.call_count, 1)
         self.assertEqual(mock_client_blob.upload_from_file.call_count, 1)
 
-        upload_path = self.dataset + '/intermediate_results/' + self.site + '.csv'
-        self.assertEqual(
-            mock_storage_client.get_bucket.assert_called_with(bucket_name),
-            None)
-        self.assertEqual(
-            mock_client_bucket.blob.assert_called_with(upload_path), None)
-        self.assertEqual(
-            mock_client_blob.upload_from_file.assert_called_with(ANY), None)
+        upload_path = f'{self.dataset}/intermediate_results/{self.site}.csv'
+        mock_client.get_bucket.assert_called_with(bucket_name)
+        mock_client_bucket.blob.assert_called_with(upload_path)
+        mock_client_blob.upload_from_file.assert_called_with(ANY)
 
-        self.assertEqual(
-            mock_load_csv.assert_called_with(
-                ANY,
-                'gs://' + bucket_name + '/' + upload_path,
-                self.project,
-                self.dataset,
-                self.site + consts.VALIDATION_TABLE_SUFFIX,
-                write_disposition=consts.WRITE_TRUNCATE), None)
+        mock_load_csv.assert_called_with(
+            ANY,
+            'gs://' + bucket_name + '/' + upload_path,
+            self.project,
+            self.dataset,
+            self.site + consts.VALIDATION_TABLE_SUFFIX,
+            write_disposition=consts.WRITE_TRUNCATE)
 
     @patch('validation.participants.writers.StorageClient')
     @patch('validation.participants.writers.gcs_utils.get_drc_bucket')
@@ -86,8 +82,9 @@ class WritersTest(unittest.TestCase):
         )
         mock_client_bucket = MagicMock()
         mock_client_blob = MagicMock()
-        mock_storage_client.return_value = mock_storage_client
-        mock_storage_client.get_bucket.return_value = mock_client_bucket
+        mock_client = MagicMock()
+        mock_storage_client.return_value = mock_client
+        mock_client.get_bucket.return_value = mock_client_bucket
         mock_client_bucket.blob.return_value = mock_client_blob
 
         match = {}
@@ -104,27 +101,22 @@ class WritersTest(unittest.TestCase):
         # post conditions
         self.assertEqual(mock_load_csv.call_count, 1)
         self.assertEqual(mock_bucket.call_count, 1)
-        self.assertEqual(mock_storage_client.get_bucket.call_count, 1)
+        self.assertEqual(mock_client.get_bucket.call_count, 1)
         self.assertEqual(mock_client_bucket.blob.call_count, 1)
         self.assertEqual(mock_client_blob.upload_from_file.call_count, 1)
 
-        upload_path = self.dataset + '/intermediate_results/' + self.site + '.csv'
-        self.assertEqual(
-            mock_storage_client.get_bucket.assert_called_with(bucket_name),
-            None)
-        self.assertEqual(
-            mock_client_bucket.blob.assert_called_with(upload_path), None)
-        self.assertEqual(
-            mock_client_blob.upload_from_file.assert_called_with(ANY), None)
+        upload_path = f'{self.dataset}/intermediate_results/{self.site}.csv'
+        mock_client.get_bucket.assert_called_with(bucket_name)
+        mock_client_bucket.blob.assert_called_with(upload_path)
+        mock_client_blob.upload_from_file.assert_called_with(ANY)
 
-        self.assertEqual(
-            mock_load_csv.assert_called_with(
-                ANY,
-                'gs://' + bucket_name + '/' + upload_path,
-                self.project,
-                self.dataset,
-                self.site + consts.VALIDATION_TABLE_SUFFIX,
-                write_disposition=consts.WRITE_TRUNCATE), None)
+        mock_load_csv.assert_called_with(
+            ANY,
+            'gs://' + bucket_name + '/' + upload_path,
+            self.project,
+            self.dataset,
+            self.site + consts.VALIDATION_TABLE_SUFFIX,
+            write_disposition=consts.WRITE_TRUNCATE)
 
     def test_get_address_match(self):
         # pre conditions


### PR DESCRIPTION
1. Updated write_to_result_table(project, dataset, site, match_values) found in    data_steward/validation/participants/writers.py to incorperate gcloud.gcs.StorageClient()
2. Updated test_write_to_result_table_error and test_write_to_result_table to reflect the changes made to write_to_result_table(project, dataset, site, match_values). 