### PR TITLE
[DC-2006] `ehr_union_test.py` helper function `_load_datasets()` does not load from RDR_PATH

### DIFF
--- a/tests/integration_tests/data_steward/validation/ehr_union_test.py
+++ b/tests/integration_tests/data_steward/validation/ehr_union_test.py
@@ -101,9 +101,7 @@ class EhrUnionTest(unittest.TestCase):
                     cdm_filepath: str = os.path.join(
                         test_util.PITT_FIVE_PERSONS_PATH, cdm_filename)
                 elif hpo_id == EXCLUDED_HPO_ID:
-
-                    #TODO use cdm_table ?
-                    if cdm_filepath in [
+                    if cdm_table in [
                             'observation', 'person', 'visit_occurrence'
                     ]:
                         cdm_filepath: str = os.path.join(


### PR DESCRIPTION
Bug fix for ehr_union integration test.