### PR TITLE
[DC-1969] Update tests.integration_tests.bq_utils_tests to use gcloud.gcs.StorageClient()

### DIFF
--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -134,7 +134,6 @@ class BqUtilsTest(unittest.TestCase):
             bucket_blob.upload_from_file(fp)
         result = bq_utils.load_cdm_csv(FAKE_HPO_ID, common.PERSON)
         self.assertEqual(result['status']['state'], 'RUNNING')
-
         load_job_id = result['jobReference']['jobId']
         table_id = result['configuration']['load']['destinationTable'][
             'tableId']
@@ -152,12 +151,10 @@ class BqUtilsTest(unittest.TestCase):
             bucket_blob = sc_bucket.blob('person.csv')
             bucket_blob.upload_from_file(fp)
         result = bq_utils.load_cdm_csv(FAKE_HPO_ID, common.PERSON)
-
         load_job_id = result['jobReference']['jobId']
         incomplete_jobs = bq_utils.wait_on_jobs([load_job_id])
         self.assertEqual(len(incomplete_jobs), 0,
                          'loading table {} timed out'.format(common.PERSON))
-
         table_id = bq_utils.get_table_id(FAKE_HPO_ID, common.PERSON)
         q = 'SELECT person_id FROM %s' % table_id
         result = bq_utils.query(q)
@@ -203,7 +200,7 @@ class BqUtilsTest(unittest.TestCase):
     def test_create_standard_table(self):
         standard_tables = list(resources.CDM_TABLES) + ACHILLES_TABLES
         for standard_table in standard_tables:
-            table_id = 'prefix_for_test_' + standard_table
+            table_id = f'prefix_for_test_{standard_table}'
             result = bq_utils.create_standard_table(standard_table, table_id)
             self.assertTrue('kind' in result)
             self.assertEqual(result['kind'], 'bigquery#table')

--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -107,10 +107,10 @@ class BqUtilsTest(unittest.TestCase):
         csv_file_name = table_name + '.csv'
         local_csv_path = os.path.join(test_util.TEST_DATA_EXPORT_PATH,
                                       csv_file_name)
+        sc = StorageClient()
+        sc_bucket = sc.get_bucket(self.hpo_bucket)
+        bucket_blob = sc_bucket.blob(csv_file_name)
         with open(local_csv_path, 'rb') as fp:
-            sc = StorageClient()
-            sc_bucket = sc.get_bucket(self.hpo_bucket)
-            bucket_blob = sc_bucket.blob(csv_file_name)
             bucket_blob.upload_from_file(fp)
         hpo_bucket = self.hpo_bucket
         gcs_object_path = 'gs://%(hpo_bucket)s/%(csv_file_name)s' % locals()
@@ -127,10 +127,10 @@ class BqUtilsTest(unittest.TestCase):
         self.assertEqual(query_response['kind'], 'bigquery#queryResponse')
 
     def test_load_cdm_csv(self):
+        sc = StorageClient()
+        sc_bucket = sc.get_bucket(self.hpo_bucket)
+        bucket_blob = sc_bucket.blob('person.csv')
         with open(FIVE_PERSONS_PERSON_CSV, 'rb') as fp:
-            sc = StorageClient()
-            sc_bucket = sc.get_bucket(self.hpo_bucket)
-            bucket_blob = sc_bucket.blob('person.csv')
             bucket_blob.upload_from_file(fp)
         result = bq_utils.load_cdm_csv(FAKE_HPO_ID, common.PERSON)
         self.assertEqual(result['status']['state'], 'RUNNING')
@@ -145,10 +145,10 @@ class BqUtilsTest(unittest.TestCase):
         self.assertEqual(num_rows, '5')
 
     def test_query_result(self):
+        sc = StorageClient()
+        sc_bucket = sc.get_bucket(self.hpo_bucket)
+        bucket_blob = sc_bucket.blob('person.csv')
         with open(FIVE_PERSONS_PERSON_CSV, 'rb') as fp:
-            sc = StorageClient()
-            sc_bucket = sc.get_bucket(self.hpo_bucket)
-            bucket_blob = sc_bucket.blob('person.csv')
             bucket_blob.upload_from_file(fp)
         result = bq_utils.load_cdm_csv(FAKE_HPO_ID, common.PERSON)
         load_job_id = result['jobReference']['jobId']
@@ -217,10 +217,10 @@ class BqUtilsTest(unittest.TestCase):
             int(row['observation_id'])
             for row in resources.csv_to_list(PITT_FIVE_PERSONS_OBSERVATION_CSV)
         ]
+        sc = StorageClient()
+        sc_bucket = sc.get_bucket(gcs_utils.get_hpo_bucket(hpo_id))
+        bucket_blob = sc_bucket.blob('observation.csv')
         with open(PITT_FIVE_PERSONS_OBSERVATION_CSV, 'rb') as fp:
-            sc = StorageClient()
-            sc_bucket = sc.get_bucket(gcs_utils.get_hpo_bucket(hpo_id))
-            bucket_blob = sc_bucket.blob('observation.csv')
             bucket_blob.upload_from_file(fp)
         result = bq_utils.load_cdm_csv(hpo_id, 'observation')
         job_id = result['jobReference']['jobId']


### PR DESCRIPTION
The following functions have been updated to utilize the new StorageClient and its functionality.
test_load_csv()
test_load_cdm_csv()
test_query_result()
test_load_ehr_observation()