### PR TITLE
[DC-2017] Migrate gcs_utils.get_hpo_bucket(hpo_id) to StorageClient()

### DIFF
--- a/data_steward/gcs_utils.py
+++ b/data_steward/gcs_utils.py
@@ -25,6 +25,7 @@ def get_drc_bucket():
     return result
 
 
+@deprecated(reason='use StorageClient().get_hpo_bucket(str) instead')
 def get_hpo_bucket(hpo_id):
     """
     Get the name of an HPO site's private bucket


### PR DESCRIPTION
This function may best be served as a method in StorageClient().  In every case, it relates to a bucket, and bucket functionality is now in StorageClient().  Having this method defined in that class may prove to increase readability and other human factors.  The change is also subtle.  This task does not include removing gcs_utils.get_hpo_bucket(...) but instead helps the GCS migration.  If accepted, a new ticket will target replacing existing calls with this new method.