### PR TITLE
[DC-1982] Remove and update calls to test_utils.empty_bucket() in tests

### DIFF
--- a/tests/integration_tests/data_steward/validation/achilles_heel_test.py
+++ b/tests/integration_tests/data_steward/validation/achilles_heel_test.py
@@ -32,13 +32,12 @@ class AchillesHeelTest(unittest.TestCase):
         self.hpo_bucket = gcs_utils.get_hpo_bucket(FAKE_HPO_ID)
         self.dataset = bq_utils.get_dataset_id()
         self.storage_client = StorageClient()
-
-        test_util.empty_bucket(self.hpo_bucket)
+        self.storage_client.empty_bucket(self.hpo_bucket)
         test_util.delete_all_tables(self.dataset)
 
     def tearDown(self):
         test_util.delete_all_tables(bq_utils.get_dataset_id())
-        test_util.empty_bucket(self.hpo_bucket)
+        self.storage_client.empty_bucket(self.hpo_bucket)
 
     def _load_dataset(self, hpo_id):
         for cdm_table in resources.CDM_TABLES:

--- a/tests/integration_tests/data_steward/validation/achilles_test.py
+++ b/tests/integration_tests/data_steward/validation/achilles_test.py
@@ -26,13 +26,12 @@ class AchillesTest(unittest.TestCase):
     def setUp(self):
         self.hpo_bucket = gcs_utils.get_hpo_bucket(test_util.FAKE_HPO_ID)
         self.storage_client = StorageClient()
-
-        test_util.empty_bucket(self.hpo_bucket)
+        self.storage_client.empty_bucket(self.hpo_bucket)
         test_util.delete_all_tables(bq_utils.get_dataset_id())
 
     def tearDown(self):
         test_util.delete_all_tables(bq_utils.get_dataset_id())
-        test_util.empty_bucket(self.hpo_bucket)
+        self.storage_client.empty_bucket(self.hpo_bucket)
 
     def _load_dataset(self):
         for cdm_table in resources.CDM_TABLES:

--- a/tests/integration_tests/data_steward/validation/ehr_union_test.py
+++ b/tests/integration_tests/data_steward/validation/ehr_union_test.py
@@ -43,18 +43,12 @@ class EhrUnionTest(unittest.TestCase):
         print('**************************************************************')
 
     def setUp(self):
-
         self.project_id = bq_utils.app_identity.get_application_id()
         self.hpo_ids = [PITT_HPO_ID, NYC_HPO_ID, EXCLUDED_HPO_ID]
         self.input_dataset_id = bq_utils.get_dataset_id()
         self.output_dataset_id = bq_utils.get_unioned_dataset_id()
-
         self.storage_client = StorageClient()
-
-        # Done in tearDown().  this is redundant.
-        self._empty_hpo_buckets()
-        test_util.delete_all_tables(self.input_dataset_id)
-        test_util.delete_all_tables(self.output_dataset_id)
+        self.tearDown()
 
         # TODO Generalize to work for all foreign key references
         # Collect all primary key fields in CDM tables
@@ -71,7 +65,7 @@ class EhrUnionTest(unittest.TestCase):
     def _empty_hpo_buckets(self):
         for hpo_id in self.hpo_ids:
             bucket = gcs_utils.get_hpo_bucket(hpo_id)
-            test_util.empty_bucket(bucket)
+            self.storage_client.empty_bucket(bucket)
 
     def _create_hpo_table(self, hpo_id, table, dataset_id):
         table_id = bq_utils.get_table_id(hpo_id, table)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -47,15 +47,10 @@ class ValidationMainTest(unittest.TestCase):
 
         self.storage_client = StorageClient()
         self.storage_bucket = self.storage_client.get_bucket(self.hpo_bucket)
+        self.storage_client.empty_bucket(self.hpo_bucket)
 
-        self._empty_bucket()
         test_util.delete_all_tables(self.bigquery_dataset_id)
         self._create_drug_class_table(self.bigquery_dataset_id)
-
-    def _empty_bucket(self):
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        for bucket_item in bucket_items:
-            gcs_utils.delete_object(self.hpo_bucket, bucket_item['name'])
 
     @staticmethod
     def _create_drug_class_table(bigquery_dataset_id):
@@ -238,7 +233,7 @@ class ValidationMainTest(unittest.TestCase):
     def test_target_bucket_upload(self):
         bucket_nyc = gcs_utils.get_hpo_bucket('nyc')
         folder_prefix = 'test-folder-fake/'
-        test_util.empty_bucket(bucket_nyc)
+        self.storage_client.empty_bucket(bucket_nyc)
 
         main._upload_achilles_files(hpo_id=None,
                                     folder_prefix=folder_prefix,
@@ -371,8 +366,8 @@ class ValidationMainTest(unittest.TestCase):
         self.assertTrue(len(missing_labs) > 0)
 
     def tearDown(self):
-        self._empty_bucket()
+        self.storage_client.empty_bucket(self.hpo_bucket)
         bucket_nyc = gcs_utils.get_hpo_bucket('nyc')
-        test_util.empty_bucket(bucket_nyc)
-        test_util.empty_bucket(gcs_utils.get_drc_bucket())
+        self.storage_client.empty_bucket(bucket_nyc)
+        self.storage_client.empty_bucket(gcs_utils.get_drc_bucket())
         test_util.delete_all_tables(self.bigquery_dataset_id)


### PR DESCRIPTION
Currently, integration test files achilles_heel_test.py, achilles_test.py, ehr_union_test.py, and main_test.py include calls to test_utils.py to empty buckets or have self/re-defined helpers.  Remove and replace calls using test_util.py and helpers with ones to the new StorageClient() instead.