### PR TITLE
[DC-2019] Migrate gcs_utils.get_drc_bucket() to StorageClient()

### DIFF
--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -18,6 +18,10 @@ class StorageClient(Client):
     See https://googleapis.dev/python/storage/latest/client.html
     """
 
+    def get_drc_bucket(self) -> str:
+        result = os.environ.get('DRC_BUCKET_NAME')
+        return result
+
     def get_hpo_bucket(self, hpo_id: str) -> str:
         """
         Get the name of an HPO site's private bucket
@@ -38,10 +42,6 @@ class StorageClient(Client):
                 f"Failed to fetch bucket '{hpo_bucket_name}' for hpo_id '{hpo_id}'",
                 hpo_bucket_name)
         return hpo_bucket_name
-
-    def get_drc_bucket(self) -> str:
-        result = os.environ.get('DRC_BUCKET_NAME')
-        return result
 
     def empty_bucket(self, bucket: str, **kwargs) -> None:
         """

--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -39,6 +39,10 @@ class StorageClient(Client):
                 hpo_bucket_name)
         return hpo_bucket_name
 
+    def get_drc_bucket(self) -> str:
+        result = os.environ.get('DRC_BUCKET_NAME')
+        return result
+
     def empty_bucket(self, bucket: str, **kwargs) -> None:
         """
         Delete all blobs in a bucket.

--- a/data_steward/gcs_utils.py
+++ b/data_steward/gcs_utils.py
@@ -20,6 +20,7 @@ MIMETYPES = {
 GCS_DEFAULT_RETRY_COUNT = 5
 
 
+@deprecated(reason='use StorageClient().get_drc_bucket() instead')
 def get_drc_bucket():
     result = os.environ.get('DRC_BUCKET_NAME')
     return result


### PR DESCRIPTION
This function may best be served as a method in StorageClient().  In every case, it relates to a bucket, and bucket functionality is now in StorageClient().  Having this method defined in that class may prove to increase readability and other human factors.  The change is also subtle.  This task does not include removing gcs_utils.get_drc_bucket(...) but instead helps the GCS migration.  If accepted, a new ticket will target replacing existing calls with this new method.