### PR TITLE
[DRAFT!] [DC-2037] Implement gcs_utils.list_bucket(...) functionality in gcloud.gcs.StorageClient

### DIFF
--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -22,7 +22,7 @@ class StorageClient(Client):
     See https://googleapis.dev/python/storage/latest/client.html
     """
 
-    def get_items_metadata(self, bucket: Bucket) -> list[dict]:
+    def get_items_metadata(self, bucket: Bucket) -> list:
         """
         Get metadata for each object within a bucket
         :param bucket: Bucket to inspect

--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -29,14 +29,14 @@ class StorageClient(Client):
         :return: list of dicts with storage objects' metadata
         """
 
-        bucket_name = bucket.name
-        scopes = ['https://www.googleapis.com/auth/devstorage.read_only']
-        url = f'https://storage.googleapis.com/storage/v1/b/{bucket_name}/o'
+        bucket_name: str = bucket.name
+        scopes: list = ['https://www.googleapis.com/auth/devstorage.read_only']
+        url: str = f'https://storage.googleapis.com/storage/v1/b/{bucket_name}/o'
 
         credentials, _ = google.auth.default(scopes=scopes)
         authed_session = AuthorizedSession(credentials)
         response = authed_session.request('GET', url)
-        result = json.loads(response.content)
+        result: dict = json.loads(response.content)
         return result['items']
 
     def get_drc_bucket(self) -> str:

--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -26,7 +26,7 @@ class StorageClient(Client):
         """
         Get metadata for each object within a bucket
         :param bucket: Bucket to inspect
-        :return: list of metadata objects
+        :return: list of dicts with storage objects' metadata
         """
 
         bucket_name = bucket.name

--- a/data_steward/gcloud/gcs/__init__.py
+++ b/data_steward/gcloud/gcs/__init__.py
@@ -22,7 +22,7 @@ class StorageClient(Client):
     See https://googleapis.dev/python/storage/latest/client.html
     """
 
-    def get_items_metadata(self, bucket: Bucket):
+    def get_items_metadata(self, bucket: Bucket) -> list[dict]:
         """
         Get metadata for each object within a bucket
         :param bucket: Bucket to inspect

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -36,9 +36,6 @@ class GCSTest(TestCase):
         self.prefix = 'foo_prefix/'
         self.file_name = 'foo_file.csv'
 
-    def side_effect(self, init_arg):
-        return init_arg
-
     @patch('google.auth.default')
     @patch('gcloud.gcs.AuthorizedSession')
     def test_get_items_metadata(self, mock_authed_session, mock_auth_default):

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -1,10 +1,13 @@
 # Python imports
+import json
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest import mock
+from unittest.mock import patch, MagicMock, PropertyMock
 from typing import Callable
 
-# Third party imports
+from google.auth import credentials
 
+# Third party imports
 # Project imports
 from gcloud.gcs import StorageClient
 
@@ -32,6 +35,33 @@ class GCSTest(TestCase):
         self.bucket = 'foo_bucket'
         self.prefix = 'foo_prefix/'
         self.file_name = 'foo_file.csv'
+
+    def side_effect(self, init_arg):
+        return init_arg
+
+    @patch('google.auth.default')
+    @patch('gcloud.gcs.AuthorizedSession')
+    def test_get_items_metadata(self, mock_authed_session, mock_auth_default):
+
+        mock_bucket = MagicMock()
+        mock_bucket.name = 'mock_bucket_name'
+
+        mock_credentials, _ = 'mock_credentials', None
+        mock_auth_default.return_value = (mock_credentials, None)
+
+        expected: dict = {'items': [{'metakey': 'metavalue'}]}
+        return_value: str = json.dumps(expected)
+
+        mock_response = MagicMock()
+        type(mock_response).content = PropertyMock(return_value=return_value)
+
+        mocked_session = mock_authed_session(mock_credentials)
+        mocked_session.request.return_value = mock_response
+
+        actual = self.client.get_items_metadata(mock_bucket)
+
+        mock_authed_session.assert_called_with(mock_credentials)
+        self.assertEqual(actual, expected['items'])
 
     @patch.object(DummyClient, 'list_blobs')
     def test_empty_bucket(self, mock_list_blobs):

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -1,11 +1,8 @@
 # Python imports
 import json
 from unittest import TestCase
-from unittest import mock
 from unittest.mock import patch, MagicMock, PropertyMock
 from typing import Callable
-
-from google.auth import credentials
 
 # Third party imports
 # Project imports


### PR DESCRIPTION
Implement DC-2036 in gcloud.gcs.StorageClient and write a test.  Name this method get_items_metadata(...) instead.  get_items_metadata(…) should take a google.cloud.storage.bucket.Bucket as one of its arguments.