### PR TITLE
[DC-2051] removing slack messaging for exceptions

### DIFF
--- a/data_steward/validation/app_errors.py
+++ b/data_steward/validation/app_errors.py
@@ -13,7 +13,6 @@ import flask
 from googleapiclient.errors import HttpError
 
 # Project imports
-from utils.slack_alerts import post_message, SlackConfigurationError
 
 errors_blueprint = flask.Blueprint('app_errors', __name__)
 
@@ -41,12 +40,6 @@ def log_traceback(func):
         except Exception as e:
             alert_message = format_alert_message(e.__class__.__name__, str(e))
             logging.exception(alert_message, exc_info=True, stack_info=True)
-            try:
-                post_message(alert_message)
-            except SlackConfigurationError:
-                logging.exception(
-                    'Slack is not configured for posting messages, refer to playbook.'
-                )
             raise e
 
     return wrapper

--- a/tests/unit_tests/data_steward/validation/app_errors_test.py
+++ b/tests/unit_tests/data_steward/validation/app_errors_test.py
@@ -39,8 +39,7 @@ class AppErrorHandlersTest(TestCase):
             app_errors.handle_internal_validation_error
         ]
 
-    @mock.patch('validation.app_errors.post_message')
-    def test_log_traceback(self, mock_post):
+    def test_log_traceback(self):
         message = f"This is a test Exception"
         exception = ValueError(message)
         alert_msg = app_errors.format_alert_message(
@@ -51,10 +50,8 @@ class AppErrorHandlersTest(TestCase):
             raise exception
 
         self.assertRaises(ValueError, fake_function)
-        mock_post.assert_called_once_with(alert_msg)
 
-    @mock.patch('validation.app_errors.post_message')
-    def test_handler_functions(self, mock_alert_message):
+    def test_handler_functions(self):
         """
         Test that all the handlers behave as expected.
         """
@@ -81,10 +78,8 @@ class AppErrorHandlersTest(TestCase):
             self.assertTrue(code, app_errors.DEFAULT_ERROR_STATUS)
 
     @mock.patch('gcs_utils.list_bucket')
-    @mock.patch('validation.app_errors.post_message')
     @mock.patch('api_util.check_cron')
-    def test_handlers_fire(self, mock_check_cron, mock_alert_message,
-                           mock_list_bucket):
+    def test_handlers_fire(self, mock_check_cron, mock_list_bucket):
         """
         Test the os handler method fires as expected when an OSError is raised.
         """


### PR DESCRIPTION
* GCP monitoring is configured to monitor for warnings or higher in the application
* should remove redundant messaging from the application now.
* update the unit tests to expect alert removal