### PR TITLE
[DC-2053] Remove last remaing empty_bucket() calls found in tests

### DIFF
--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -77,12 +77,8 @@ class BqUtilsTest(unittest.TestCase):
             }
         ]
         self.DT_FORMAT = '%Y-%m-%d %H:%M:%S'
-        self._empty_bucket()
-
-    def _empty_bucket(self):
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        for bucket_item in bucket_items:
-            gcs_utils.delete_object(self.hpo_bucket, bucket_item['name'])
+        self.client = StorageClient()
+        self.client.empty_bucket(self.hpo_bucket)
 
     def _drop_tables(self):
         tables = bq_utils.list_tables()
@@ -378,4 +374,4 @@ class BqUtilsTest(unittest.TestCase):
 
     def tearDown(self):
         test_util.delete_all_tables(self.dataset_id)
-        self._empty_bucket()
+        self.client.empty_bucket(self.hpo_bucket)

--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -103,8 +103,7 @@ class BqUtilsTest(unittest.TestCase):
         csv_file_name = table_name + '.csv'
         local_csv_path = os.path.join(test_util.TEST_DATA_EXPORT_PATH,
                                       csv_file_name)
-        sc = StorageClient()
-        sc_bucket = sc.get_bucket(self.hpo_bucket)
+        sc_bucket = self.client.get_bucket(self.hpo_bucket)
         bucket_blob = sc_bucket.blob(csv_file_name)
         with open(local_csv_path, 'rb') as fp:
             bucket_blob.upload_from_file(fp)
@@ -123,8 +122,7 @@ class BqUtilsTest(unittest.TestCase):
         self.assertEqual(query_response['kind'], 'bigquery#queryResponse')
 
     def test_load_cdm_csv(self):
-        sc = StorageClient()
-        sc_bucket = sc.get_bucket(self.hpo_bucket)
+        sc_bucket = self.client.get_bucket(self.hpo_bucket)
         bucket_blob = sc_bucket.blob('person.csv')
         with open(FIVE_PERSONS_PERSON_CSV, 'rb') as fp:
             bucket_blob.upload_from_file(fp)
@@ -141,8 +139,7 @@ class BqUtilsTest(unittest.TestCase):
         self.assertEqual(num_rows, '5')
 
     def test_query_result(self):
-        sc = StorageClient()
-        sc_bucket = sc.get_bucket(self.hpo_bucket)
+        sc_bucket = self.client.get_bucket(self.hpo_bucket)
         bucket_blob = sc_bucket.blob('person.csv')
         with open(FIVE_PERSONS_PERSON_CSV, 'rb') as fp:
             bucket_blob.upload_from_file(fp)
@@ -213,8 +210,7 @@ class BqUtilsTest(unittest.TestCase):
             int(row['observation_id'])
             for row in resources.csv_to_list(PITT_FIVE_PERSONS_OBSERVATION_CSV)
         ]
-        sc = StorageClient()
-        sc_bucket = sc.get_bucket(gcs_utils.get_hpo_bucket(hpo_id))
+        sc_bucket = self.client.get_bucket(gcs_utils.get_hpo_bucket(hpo_id))
         bucket_blob = sc_bucket.blob('observation.csv')
         with open(PITT_FIVE_PERSONS_OBSERVATION_CSV, 'rb') as fp:
             bucket_blob.upload_from_file(fp)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
@@ -10,7 +10,6 @@ import os
 from google.cloud import bigquery
 
 # Project Imports
-import tests.test_util as test_util
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.unit_normalization import UnitNormalization, UNIT_MAPPING_TABLE
 from common import JINJA_ENV, MEASUREMENT

--- a/tests/integration_tests/data_steward/gcs_utils_test.py
+++ b/tests/integration_tests/data_steward/gcs_utils_test.py
@@ -2,6 +2,7 @@ import unittest
 from io import open
 
 from googleapiclient.errors import HttpError
+from gcloud.gcs import StorageClient
 
 import gcs_utils
 from tests.test_util import FIVE_PERSONS_PERSON_CSV, FAKE_HPO_ID
@@ -18,12 +19,8 @@ class GcsUtilsTest(unittest.TestCase):
     def setUp(self):
         self.hpo_bucket = gcs_utils.get_hpo_bucket(FAKE_HPO_ID)
         self.gcs_path = '/'.join([self.hpo_bucket, 'dummy'])
-        self._empty_bucket()
-
-    def _empty_bucket(self):
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        for bucket_item in bucket_items:
-            gcs_utils.delete_object(self.hpo_bucket, bucket_item['name'])
+        self.storage_client = StorageClient()
+        self.storage_client.empty_bucket(self.hpo_bucket)
 
     def test_upload_object(self):
         bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
@@ -63,4 +60,4 @@ class GcsUtilsTest(unittest.TestCase):
         self.assertEqual(cm.exception.resp.status, 404)
 
     def tearDown(self):
-        self._empty_bucket()
+        self.storage_client.empty_bucket(self.hpo_bucket)

--- a/tests/integration_tests/data_steward/metrics/required_labs_test.py
+++ b/tests/integration_tests/data_steward/metrics/required_labs_test.py
@@ -9,6 +9,7 @@ import mock
 import app_identity
 import bq_utils
 import common
+from gcloud.gcs import StorageClient
 import gcs_utils
 import resources
 import validation.sql_wrangle as sql_wrangle
@@ -35,7 +36,9 @@ class RequiredLabsTest(unittest.TestCase):
         self.rdr_dataset_id = bq_utils.get_rdr_dataset_id()
         self.folder_prefix = '2019-01-01/'
         test_util.delete_all_tables(self.dataset_id)
-        test_util.empty_bucket(self.hpo_bucket)
+
+        self.storage_client = StorageClient()
+        self.storage_client.empty_bucket(self.hpo_bucket)
 
         self.client = bq.get_client(self.project_id)
 
@@ -49,7 +52,7 @@ class RequiredLabsTest(unittest.TestCase):
 
     def tearDown(self):
         test_util.delete_all_tables(bq_utils.get_dataset_id())
-        test_util.empty_bucket(self.hpo_bucket)
+        self.storage_client.empty_bucket(self.hpo_bucket)
 
     def _load_data(self):
 

--- a/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
+++ b/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
@@ -66,7 +66,7 @@ class TopHeelErrorsTest(TestCase):
         self.bucket: str = gcs_utils.get_drc_bucket()
         self.storage_client = StorageClient()
 
-        test_util.empty_bucket(self.bucket)
+        self.storage_client.empty_bucket(self.bucket)
         test_util.delete_all_tables(self.dataset_id)
         self.load_test_data(hpo_id=HPO_NYC)
 
@@ -126,5 +126,5 @@ class TopHeelErrorsTest(TestCase):
         self.assertCountEqual(actual_results, expected_results)
 
     def tearDown(self):
-        test_util.empty_bucket(self.bucket)
+        self.storage_client.empty_bucket(self.bucket)
         test_util.delete_all_tables(self.dataset_id)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -195,12 +195,6 @@ def _export_query_responses():
         _export_query_response_by_path(p, FAKE_HPO_ID)
 
 
-def empty_bucket(bucket):
-    bucket_items = gcs_utils.list_bucket(bucket)
-    for bucket_item in bucket_items:
-        gcs_utils.delete_object(bucket, bucket_item['name'])
-
-
 def delete_all_tables(dataset_id):
     """
     Remove all non-vocabulary tables from a dataset


### PR DESCRIPTION
DC-2053 targets the last remaining "empty_bucket(...)" calls outside of `gcs_utils`.  In fact, before this PR, there were no calls to gcs_utils at all -- the function was already deleted.  However,`test_util.empty_bucket(...)` remained, and some hidden functions still existed.  This PR removes the last of empty_bucket(...) calls outside of `StorageClient.empty_bucket(...)`.  Hooray 🎉.

Diligence is required here because testing their replacements is tricky at best; they were used in tests themselves.  So care was taken to ensure their replacement matched the existing call.  The `StorageClient.empty_bucket(...)` (the replacement) is already used in tests, and has been thoroughly unit- and integration-test tested.   