### PR TITLE
[DC-2054] remove slack notifications from admin api

### DIFF
--- a/data_steward/admin/admin_api.py
+++ b/data_steward/admin/admin_api.py
@@ -16,10 +16,8 @@ from admin import key_rotation
 
 PREFIX = '/admin/v1/'
 REMOVE_EXPIRED_KEYS_RULE = f'{PREFIX}RemoveExpiredServiceAccountKeys'
-
 """Used as part of GCP monitoring and alerting.  String is part of the metric."""
 BODY_HEADER_EXPIRED_KEY_TEMPLATE = '# Expired keys deleted\n'
-
 """Used as part of GCP monitoring and alerting.  String is part of the metric."""
 BODY_HEADER_EXPIRING_KEY_TEMPLATE = '\n# Keys expiring soon\n'
 

--- a/data_steward/admin/admin_api.py
+++ b/data_steward/admin/admin_api.py
@@ -13,13 +13,14 @@ from flask import Flask
 import api_util
 import app_identity
 from admin import key_rotation
-from utils.slack_alerts import post_message
 
 PREFIX = '/admin/v1/'
-REMOVE_EXPIRED_KEYS_RULE = PREFIX + 'RemoveExpiredServiceAccountKeys'
+REMOVE_EXPIRED_KEYS_RULE = f'{PREFIX}RemoveExpiredServiceAccountKeys'
 
+"""Used as part of GCP monitoring and alerting.  String is part of the metric."""
 BODY_HEADER_EXPIRED_KEY_TEMPLATE = '# Expired keys deleted\n'
 
+"""Used as part of GCP monitoring and alerting.  String is part of the metric."""
 BODY_HEADER_EXPIRING_KEY_TEMPLATE = '\n# Keys expiring soon\n'
 
 BODY_TEMPLATE = ('service_account_email={service_account_email}\n'
@@ -61,22 +62,23 @@ def text_body(expired_keys, expiring_keys):
 def remove_expired_keys():
     project_id = app_identity.get_application_id()
 
-    logging.info('Started removal of expired service account keys for %s' %
-                 project_id)
+    logging.info(
+        f'Started removal of expired service account keys for {project_id}')
 
     expired_keys = key_rotation.delete_expired_keys(project_id)
-    logging.info('Completed removal of expired service account keys for %s' %
-                 project_id)
+    logging.info(
+        f'Completed removal of expired service account keys for {project_id}')
 
-    logging.info('Started listing expiring service account keys for %s' %
-                 project_id)
+    logging.info(
+        f'Started listing expiring service account keys for {project_id}')
     expiring_keys = key_rotation.get_expiring_keys(project_id)
-    logging.info('Completed listing expiring service account keys for %s' %
-                 project_id)
+    logging.info(
+        f'Completed listing expiring service account keys for {project_id}')
 
     if len(expiring_keys) != 0 or len(expired_keys) != 0:
         text = text_body(expired_keys, expiring_keys)
-        post_message(text)
+        # message text will trigger a GCP metric and alert
+        logging.info(text)
     return 'remove-expired-keys-complete'
 
 

--- a/data_steward/admin/key_rotation.py
+++ b/data_steward/admin/key_rotation.py
@@ -25,7 +25,7 @@ def list_service_accounts(project_id):
     """
 
     service_accounts_per_project_id = get_iam_service().projects(
-    ).serviceAccounts().list(name='projects/' + project_id).execute()
+    ).serviceAccounts().list(name=f'projects/{project_id}').execute()
 
     return service_accounts_per_project_id['accounts']
 
@@ -38,8 +38,8 @@ def list_keys_for_service_account(service_account_email):
     """
 
     service_keys_per_account = get_iam_service().projects().serviceAccounts(
-    ).keys().list(name='projects/-/serviceAccounts/' +
-                  service_account_email).execute()
+    ).keys().list(
+        name=f'projects/-/serviceAccounts/{service_account_email}').execute()
 
     return service_keys_per_account['keys']
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -12,7 +12,8 @@ export PYTHONPATH=:"${BASE_DIR}":"${BASE_DIR}/data_steward":"${BASE_DIR}/tests":
 function usage() {
   echo "Usage: run_test.sh " \
     "[unit|integration]" \
-    "[Set env CURATION_TESTS_FILEPATH for specific tests, usage in runner.py]" >&2
+    "[Set env CURATION_TESTS_FILEPATH for specific tests, usage in runner.py]" \
+    "[Set env TEST_PATTERN to run tests whose file names match the pattern, usage in runner.py]" >&2
   exit 1
 }
 
@@ -56,6 +57,7 @@ for i in "${run_args[@]}"; do
     echo "Unknown option ${i}"
     echo "run_args=${run_args[*]}"
     exit 1
+    ;;
   esac
 done
 
@@ -77,6 +79,13 @@ if [[ -n "${CURATION_TESTS_FILEPATH}" ]]; then
   script_args+=(
     "--test-paths-filepath"
     "${CURATION_TESTS_FILEPATH}")
+fi
+
+if [[ -n "${TEST_PATTERN}" ]]; then
+  script_args+=(
+    "--test-pattern"
+    "${TEST_PATTERN}"
+  )
 fi
 
 python "${script_args[@]}"


### PR DESCRIPTION
* remove ability to send messages from admin api to slack channel
* use f-strings to match rest of code base conventions
* update the unit test to expect log messages instead of slack post messages
* update the test runner script to run a test(s) based on a test filename pattern instead of a filepath.  (adds back a functionality that was removed by a previous commit.)