### PR TITLE
[DC-2057] Replace gcs_utils.get_metadata() calls with StorageClient.get_blob_metadata()

### DIFF
--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -696,8 +696,10 @@ def perform_validation_on_file(file_name, found_file_names, hpo_id,
 
 
 def _validation_done(bucket, folder):
-    if gcs_utils.get_metadata(bucket=bucket,
-                              name=folder + common.PROCESSED_TXT) is not None:
+    storage_client = StorageClient()
+    sc_bucket = storage_client.get_bucket(bucket)
+    bucket_blob = sc_bucket.blob(f'{folder}{common.PROCESSED_TXT}')
+    if storage_client.get_blob_metadata(bucket_blob):
         return True
     return False
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -17,6 +17,7 @@ from io import StringIO, open
 import dateutil
 from flask import Flask
 from googleapiclient.errors import HttpError
+from google.cloud.storage import Blob
 
 # Project imports
 import api_util
@@ -698,11 +699,9 @@ def perform_validation_on_file(file_name, found_file_names, hpo_id,
 
 def _validation_done(bucket, folder):
     storage_client = StorageClient()
-    sc_bucket = storage_client.get_bucket(bucket)
-    bucket_blob = sc_bucket.blob(f'{folder}{common.PROCESSED_TXT}')
-    if storage_client.get_blob_metadata(bucket_blob):
-        return True
-    return False
+    bucket = storage_client.get_bucket(bucket)
+    return Blob(bucket=bucket,
+                name=f'{folder}{common.PROCESSED_TXT}').exists(storage_client)
 
 
 def basename(gcs_object_metadata):

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -25,6 +25,7 @@ import bq_utils
 import cdm
 import common
 import gcs_utils
+from gcloud.gcs import StorageClient
 import resources
 from common import ACHILLES_EXPORT_PREFIX_STRING, ACHILLES_EXPORT_DATASOURCES_JSON, AOU_REQUIRED_FILES
 from constants.validation import hpo_report as report_consts


### PR DESCRIPTION
gcs_utils.get_metadata() call in validation/main.py was replaced with StorageClient.get_blob_metadata(). gcs_utils.get_metadata() is used only once in the curation project. 