### PR TITLE
[DC-1935] Add the list of sandbox table names to the `GeneralizeCopeInsuranceAnswers` cleaning rule

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/deid/generalize_cope_insurance_answers.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/generalize_cope_insurance_answers.py
@@ -19,6 +19,15 @@ from utils import pipeline_logging
 
 LOGGER = logging.getLogger(__name__)
 
+SANDBOX_RECORDS_QUERY = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}` AS (
+SELECT * FROM `{{project_id}}.{{dataset_id}}.observation`
+WHERE
+  observation_source_concept_id = 1332737
+  AND value_source_concept_id IN (1332904, 1333140)
+)
+""")
+
 ANSWER_GENERALIZATION_QUERY = JINJA_ENV.from_string("""
 UPDATE
   `{{project_id}}.{{dataset_id}}.observation`
@@ -76,7 +85,10 @@ class GeneralizeCopeInsuranceAnswers(BaseCleaningRule):
                          sandbox_dataset_id=sandbox_dataset_id)
 
     def get_sandbox_tablenames(self):
-        raise NotImplementedError("Please fix me.")
+        """
+        Returns a list of sandbox table names.
+        """
+        return [self.sandbox_table_for(OBSERVATION)]
 
     def get_query_specs(self, *args, **keyword_args):
         """
@@ -87,6 +99,14 @@ class GeneralizeCopeInsuranceAnswers(BaseCleaningRule):
             stored in list order and returned in list order to maintain
             an ordering.
         """
+
+        sandbox_records_query = dict()
+        sandbox_records_query[cdr_consts.QUERY] = SANDBOX_RECORDS_QUERY.render(
+            project_id=self.project_id,
+            sandbox_id=self.sandbox_dataset_id,
+            sandbox_table=self.sandbox_table_for(OBSERVATION),
+            dataset_id=self.dataset_id)
+
         insurance_answers_generalization_query = dict()
         insurance_answers_generalization_query[
             cdr_consts.QUERY] = ANSWER_GENERALIZATION_QUERY.render(
@@ -98,7 +118,7 @@ class GeneralizeCopeInsuranceAnswers(BaseCleaningRule):
                 project_id=self.project_id, dataset_id=self.dataset_id)
 
         return [
-            insurance_answers_generalization_query,
+            sandbox_records_query, insurance_answers_generalization_query,
             generalized_answers_deduplication_query
         ]
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/generalize_cope_insurance_answers_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/generalize_cope_insurance_answers_test.py
@@ -45,6 +45,11 @@ class GeneralizeCopeInsuranceAnswersTest(BaseTest.CleaningRulesTestBase):
         cls.rule_instance = GeneralizeCopeInsuranceAnswers(
             project_id, dataset_id, sandbox_id)
 
+        sandbox_table_names = cls.rule_instance.get_sandbox_tablenames()
+        for table in sandbox_table_names:
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{table}')
+
         cls.fq_table_names = [
             f'{project_id}.{dataset_id}.{OBSERVATION}',
         ]
@@ -92,9 +97,9 @@ class GeneralizeCopeInsuranceAnswersTest(BaseTest.CleaningRulesTestBase):
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, 'observation']),
             'fq_sandbox_table_name':
-                '',
+                self.fq_sandbox_table_names[0],
             'loaded_ids': [1, 2, 3, 4, 5, 6, 7],
-            'sandboxed_ids': [],
+            'sandboxed_ids': [3, 4],
             'fields': [
                 'observation_id', 'person_id', 'observation_concept_id',
                 'observation_date', 'observation_source_concept_id',

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/generalize_cope_insurance_answers_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/generalize_cope_insurance_answers_test.py
@@ -99,7 +99,7 @@ class GeneralizeCopeInsuranceAnswersTest(BaseTest.CleaningRulesTestBase):
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
             'loaded_ids': [1, 2, 3, 4, 5, 6, 7],
-            'sandboxed_ids': [3, 4],
+            'sandboxed_ids': [1, 2, 3],
             'fields': [
                 'observation_id', 'person_id', 'observation_concept_id',
                 'observation_date', 'observation_source_concept_id',


### PR DESCRIPTION
In addition to what the title says, I added sandbox creation SQL and test for `GeneralizeCopeInsuranceAnswers`, as discussed in the ticket comments: https://precisionmedicineinitiative.atlassian.net/browse/DC-1935?focusedCommentId=106158