### PR TITLE
[DC-2038] Remove gcs_utils.get_object(...) and test_utils.read_cloud_file(...)

### DIFF
--- a/data_steward/gcs_utils.py
+++ b/data_steward/gcs_utils.py
@@ -161,31 +161,6 @@ def list_bucket_prefixes(gcs_path):
 
 
 @deprecated(reason=(
-    'See https://googleapis.dev/python/storage/latest/buckets.html#google.cloud.storage.bucket.Bucket.get_blob '
-    'and use gcloud.gcs.StorageClient() instead'))
-def get_object(bucket, name, as_text=True):
-    """
-    Download object from a bucket
-    :param bucket: the bucket containing the file
-    :param name: name of the file to download
-    :param as_text: True if result should be decoded as text (default) otherwise bytes are returned
-    :return: file contents
-    """
-    service = create_service()
-    req = service.objects().get_media(bucket=bucket, object=name)
-    out_file = BytesIO()
-    downloader = googleapiclient.http.MediaIoBaseDownload(out_file, req)
-    done = False
-    while not done:
-        status, done = downloader.next_chunk()
-    result_bytes = out_file.getvalue()
-    out_file.close()
-    if as_text:
-        return result_bytes.decode()
-    return result_bytes
-
-
-@deprecated(reason=(
     'See https://googleapis.dev/python/storage/latest/blobs.html#google.cloud.storage.blob.Blob.upload_from_string '
     'and use gcloud.gcs.StorageClient() instead'))
 def upload_object(bucket, name, fp):

--- a/tests/integration_tests/data_steward/gcs_utils_test.py
+++ b/tests/integration_tests/data_steward/gcs_utils_test.py
@@ -37,14 +37,6 @@ class GcsUtilsTest(unittest.TestCase):
         bucket_item = bucket_items[0]
         self.assertEqual(bucket_item['name'], 'person.csv')
 
-    def test_get_object(self):
-        with open(FIVE_PERSONS_PERSON_CSV, 'r') as fp:
-            expected = fp.read()
-        with open(FIVE_PERSONS_PERSON_CSV, 'rb') as fp:
-            gcs_utils.upload_object(self.hpo_bucket, 'person.csv', fp)
-        result = gcs_utils.get_object(self.hpo_bucket, 'person.csv')
-        self.assertEqual(expected, result)
-
     def test_get_metadata_on_existing_file(self):
         expected_file_name = 'person.csv'
         with open(FIVE_PERSONS_PERSON_CSV, 'rb') as fp:

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -311,8 +311,9 @@ class ValidationMainTest(unittest.TestCase):
         main.app.testing = True
         with main.app.test_client() as c:
             c.get(test_util.VALIDATE_HPO_FILES_URL)
-            actual_result = test_util.read_cloud_file(
-                self.hpo_bucket, self.folder_prefix + common.RESULTS_HTML)
+            actual_result = self.storage_bucket.get_blob(
+                f'{self.folder_prefix}{common.RESULTS_HTML}').download_as_text(
+                )
 
         # ensure emails are not sent
         bucket_items = gcs_utils.list_bucket(self.hpo_bucket)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -214,13 +214,13 @@ class ValidationMainTest(unittest.TestCase):
         main.app.testing = True
         with main.app.test_client() as c:
             c.get(test_util.COPY_HPO_FILES_URL)
-            prefix = test_util.FAKE_HPO_ID + '/' + self.hpo_bucket + '/' + self.folder_prefix
+            prefix: str = f'{test_util.FAKE_HPO_ID}/{self.hpo_bucket}/{self.folder_prefix}'
             expected_bucket_items = [
-                prefix + item.split(os.sep)[-1]
+                f'{prefix}{item.split(os.sep)[-1]}'
                 for item in test_util.FIVE_PERSONS_FILES
             ]
             expected_bucket_items.extend([
-                prefix + self.folder_prefix + item.split(os.sep)[-1]
+                f'{prefix}{self.folder_prefix}{item.split(os.sep)[-1]}'
                 for item in test_util.FIVE_PERSONS_FILES
             ])
 
@@ -241,7 +241,7 @@ class ValidationMainTest(unittest.TestCase):
         actual_bucket_files = set(
             [item['name'] for item in gcs_utils.list_bucket(bucket_nyc)])
         expected_bucket_files = set([
-            'test-folder-fake/' + item
+            f'test-folder-fake/{item}'
             for item in resources.ALL_ACHILLES_INDEX_FILES
         ])
         self.assertSetEqual(expected_bucket_files, actual_bucket_files)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -213,10 +213,6 @@ def delete_all_tables(dataset_id):
     return deleted
 
 
-def read_cloud_file(bucket, name):
-    return gcs_utils.get_object(bucket, name)
-
-
 def populate_achilles(hpo_id=FAKE_HPO_ID, include_heel=True):
     from validation import achilles, achilles_heel
     import app_identity

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -10,7 +10,6 @@ import bq_utils
 import common
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 from constants.validation import main
-import gcs_utils
 import resources
 
 RESOURCES_BUCKET_FMT = '{project_id}-resources'


### PR DESCRIPTION
- Replaces test_util.read_cloud_file(bucket, name) call with get_blob(blob_name).download_as_text() from StorageClient() in tests/integration_tests/data_steward/validation/main_test.py.
- Removes read_cloud_file(bucket, name) function in tests/test_util.py. No longer needed or used.
- Removes get_object(bucket, name,as_text=True) function in data_steward/gcs_utils.py. No longer needed or used.
- Removes test_get_object() method in tests/integration_tests/data_steward/gcs_utils_test.py. No longer needed.
- Removes gcs_utils import in tests/test_utils.py. No longer needed or used.