### PR TITLE
[DC-2069] Replace gcs_utils in main.save_datasources_json()

### DIFF
--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -117,7 +117,7 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         f"Exporting {datasource_id} report to bucket {target_bucket.name}")
 
     # Run export queries and store json payloads in specified folder in the target bucket
-    reports_prefix = f'{folder_prefix}{ACHILLES_EXPORT_PREFIX_STRING}{datasource_id}/'
+    reports_prefix: str = f'{folder_prefix}{ACHILLES_EXPORT_PREFIX_STRING}{datasource_id}/'
     for export_name in common.ALL_REPORTS:
         sql_path = os.path.join(export.EXPORT_PATH, export_name)
         result = export.export_from_path(sql_path, datasource_id)

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -70,6 +70,9 @@ def save_datasources_json(datasource_id=None,
         bucket assigned to hpo_id.
     :return:
     """
+    if storage_client is None:
+        project_id = app_identity.get_application_id()
+        storage_client = StorageClient(project_id)
     if datasource_id is None:
         if target_bucket is None:
             raise RuntimeError(

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -57,10 +57,10 @@ def all_required_files_loaded(result_items):
     return True
 
 
-def save_datasources_json(datasource_id=None,
+def save_datasources_json(storage_client,
+                          datasource_id=None,
                           folder_prefix="",
-                          target_bucket=None,
-                          storage_client=None):
+                          target_bucket=None):
     """
     Generate and save datasources.json (from curation report) in a GCS bucket
 
@@ -70,9 +70,6 @@ def save_datasources_json(datasource_id=None,
         bucket assigned to hpo_id.
     :return:
     """
-    if storage_client is None:
-        project_id = app_identity.get_application_id()
-        storage_client = StorageClient(project_id)
     if datasource_id is None:
         if target_bucket is None:
             raise RuntimeError(
@@ -129,10 +126,10 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         blob.upload_from_file(fp)
         result: dict = storage_client.get_blob_metadata(blob)
         results.append(result)
-    result = save_datasources_json(datasource_id=datasource_id,
+    result = save_datasources_json(storage_client=storage_client,
+                                   datasource_id=datasource_id,
                                    folder_prefix=folder_prefix,
-                                   target_bucket=target_bucket.name,
-                                   storage_client=storage_client)
+                                   target_bucket=target_bucket.name)
     results.append(result)
     return results
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -59,7 +59,8 @@ def all_required_files_loaded(result_items):
 
 def save_datasources_json(datasource_id=None,
                           folder_prefix="",
-                          target_bucket=None):
+                          target_bucket=None,
+                          storage_client=None):
     """
     Generate and save datasources.json (from curation report) in a GCS bucket
 
@@ -69,8 +70,6 @@ def save_datasources_json(datasource_id=None,
         bucket assigned to hpo_id.
     :return:
     """
-    project_id = app_identity.get_application_id()
-    storage_client = StorageClient(project_id)
     if datasource_id is None:
         if target_bucket is None:
             raise RuntimeError(
@@ -129,7 +128,8 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         results.append(result)
     result = save_datasources_json(datasource_id=datasource_id,
                                    folder_prefix=folder_prefix,
-                                   target_bucket=target_bucket.name)
+                                   target_bucket=target_bucket.name,
+                                   storage_client=storage_client)
     results.append(result)
     return results
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -105,17 +105,16 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         raise RuntimeError(
             f"Cannot export if neither hpo_id nor target_bucket is specified.")
     else:
-        datasource_name = datasource_id
         if target_bucket is None:
             target_bucket: Bucket = storage_client.get_hpo_bucket(datasource_id)
         else:
             target_bucket: Bucket = storage_client.get_bucket(target_bucket)
 
     logging.info(
-        f"Exporting {datasource_name} report to bucket {target_bucket.name}")
+        f"Exporting {datasource_id} report to bucket {target_bucket.name}")
 
     # Run export queries and store json payloads in specified folder in the target bucket
-    reports_prefix = folder_prefix + ACHILLES_EXPORT_PREFIX_STRING + datasource_name + '/'
+    reports_prefix = f'{folder_prefix}{ACHILLES_EXPORT_PREFIX_STRING}{datasource_id}/'
     for export_name in common.ALL_REPORTS:
         sql_path = os.path.join(export.EXPORT_PATH, export_name)
         result = export.export_from_path(sql_path, datasource_id)

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -80,7 +80,7 @@ def save_datasources_json(datasource_id=None,
         if target_bucket is None:
             target_bucket: Bucket = storage_client.get_hpo_bucket(datasource_id)
         else:
-            target_bucket: Bucket = storage_client.get_bucket(target_bucket)
+            target_bucket: Bucket = storage_client.bucket(target_bucket)
 
     datasource = dict(name=datasource_id, folder=datasource_id, cdmVersion=5)
     datasources = dict(datasources=[datasource])
@@ -111,7 +111,7 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         if target_bucket is None:
             target_bucket: Bucket = storage_client.get_hpo_bucket(datasource_id)
         else:
-            target_bucket: Bucket = storage_client.get_bucket(target_bucket)
+            target_bucket: Bucket = storage_client.bucket(target_bucket)
 
     logging.info(
         f"Exporting {datasource_id} report to bucket {target_bucket.name}")

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -85,10 +85,10 @@ def save_datasources_json(datasource_id=None,
     datasource = dict(name=datasource_id, folder=datasource_id, cdmVersion=5)
     datasources = dict(datasources=[datasource])
     datasources_fp = StringIO(json.dumps(datasources))
-    blob = target_bucket.blob(
+    blob: Blob = target_bucket.blob(
         f'{folder_prefix}{ACHILLES_EXPORT_DATASOURCES_JSON}')
     blob.upload_from_file(datasources_fp)
-    result = storage_client.get_blob_metadata(blob)
+    result: dict = storage_client.get_blob_metadata(blob)
     return result
 
 
@@ -123,9 +123,9 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         result = export.export_from_path(sql_path, datasource_id)
         content = json.dumps(result)
         fp = StringIO(content)
-        blob = target_bucket.blob(f'{reports_prefix}{export_name}.json')
+        blob: Blob = target_bucket.blob(f'{reports_prefix}{export_name}.json')
         blob.upload_from_file(fp)
-        result = storage_client.get_blob_metadata(blob)
+        result: dict = storage_client.get_blob_metadata(blob)
         results.append(result)
     result = save_datasources_json(datasource_id=datasource_id,
                                    folder_prefix=folder_prefix,

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -84,9 +84,10 @@ def save_datasources_json(datasource_id=None,
     datasource = dict(name=datasource_id, folder=datasource_id, cdmVersion=5)
     datasources = dict(datasources=[datasource])
     datasources_fp = StringIO(json.dumps(datasources))
-    result = gcs_utils.upload_object(
-        target_bucket.name, folder_prefix + ACHILLES_EXPORT_DATASOURCES_JSON,
-        datasources_fp)
+    blob = target_bucket.blob(
+        f'{folder_prefix}{ACHILLES_EXPORT_DATASOURCES_JSON}')
+    blob.upload_from_file(datasources_fp)
+    result = storage_client.get_blob_metadata(blob)
     return result
 
 
@@ -120,9 +121,9 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
         result = export.export_from_path(sql_path, datasource_id)
         content = json.dumps(result)
         fp = StringIO(content)
-        result = gcs_utils.upload_object(target_bucket.name,
-                                         reports_prefix + export_name + '.json',
-                                         fp)
+        blob = target_bucket.blob(f'{reports_prefix}{export_name}.json')
+        blob.upload_from_file(fp)
+        result = storage_client.get_blob_metadata(blob)
         results.append(result)
     result = save_datasources_json(datasource_id=datasource_id,
                                    folder_prefix=folder_prefix,

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -69,7 +69,8 @@ def save_datasources_json(datasource_id=None,
         bucket assigned to hpo_id.
     :return:
     """
-    storage_client = StorageClient()
+    project_id = app_identity.get_application_id()
+    storage_client = StorageClient(project_id)
     if datasource_id is None:
         if target_bucket is None:
             raise RuntimeError(
@@ -100,7 +101,8 @@ def run_export(datasource_id=None, folder_prefix="", target_bucket=None):
     :param target_bucket: Bucket to save report. If None, use bucket associated with hpo_id.
     """
     results = []
-    storage_client = StorageClient()
+    project_id = app_identity.get_application_id()
+    storage_client = StorageClient(project_id)
     # Using separate var rather than hpo_id here because hpo_id None needed in calls below
     if datasource_id is None and target_bucket is None:
         raise RuntimeError(

--- a/tests/integration_tests/data_steward/validation/export_test.py
+++ b/tests/integration_tests/data_steward/validation/export_test.py
@@ -9,6 +9,7 @@ import app_identity
 import bq_utils
 import common
 from gcloud.gcs import StorageClient
+from google.cloud.storage.bucket import Bucket
 from tests import test_util
 from tests.test_util import FAKE_HPO_ID
 from validation import export, main
@@ -31,7 +32,6 @@ class ExportTest(unittest.TestCase):
     def setUp(self):
         self.project_id = app_identity.get_application_id()
         self.storage_client = StorageClient(self.project_id)
-
         self.hpo_bucket = self.storage_client.get_hpo_bucket(FAKE_HPO_ID)
 
     def _test_report_export(self, report):
@@ -125,13 +125,11 @@ class ExportTest(unittest.TestCase):
         # validation/main.py INTEGRATION TEST
         mock_is_hpo_id.return_value = True
         folder_prefix: str = 'dummy-prefix-2018-03-24/'
-
-        target_bucket = self.storage_client.get_hpo_bucket('nyc')
+        target_bucket: Bucket = self.storage_client.get_hpo_bucket('nyc')
         objects: Iterable = target_bucket.list_blobs()
         main.run_export(datasource_id=FAKE_HPO_ID,
                         folder_prefix=folder_prefix,
                         target_bucket=target_bucket.name)
-
         actual_names: list = [obj.name for obj in objects]
         for report in common.ALL_REPORT_FILES:
             prefix: str = f'{folder_prefix}{common.ACHILLES_EXPORT_PREFIX_STRING}{FAKE_HPO_ID}/'

--- a/tests/integration_tests/data_steward/validation/export_test.py
+++ b/tests/integration_tests/data_steward/validation/export_test.py
@@ -9,7 +9,6 @@ import app_identity
 import bq_utils
 import common
 from gcloud.gcs import StorageClient
-from google.cloud.storage.bucket import Bucket
 from tests import test_util
 from tests.test_util import FAKE_HPO_ID
 from validation import export, main
@@ -125,7 +124,7 @@ class ExportTest(unittest.TestCase):
         # validation/main.py INTEGRATION TEST
         mock_is_hpo_id.return_value = True
         folder_prefix: str = 'dummy-prefix-2018-03-24/'
-        target_bucket: Bucket = self.storage_client.get_hpo_bucket('nyc')
+        target_bucket = self.storage_client.get_hpo_bucket('nyc')
         objects: Iterable = target_bucket.list_blobs()
         main.run_export(datasource_id=FAKE_HPO_ID,
                         folder_prefix=folder_prefix,
@@ -137,7 +136,6 @@ class ExportTest(unittest.TestCase):
             self.assertIn(expected_name, actual_names)
         export_path: str = f'{folder_prefix}{common.ACHILLES_EXPORT_DATASOURCES_JSON}'
         self.assertIn(export_path, actual_names)
-
         actual_data = target_bucket.blob(export_path)
         actual_json_data: str = actual_data.download_as_bytes().decode()
         actual_datasources: dict = json.loads(actual_json_data)

--- a/tests/integration_tests/data_steward/validation/export_test.py
+++ b/tests/integration_tests/data_steward/validation/export_test.py
@@ -31,6 +31,7 @@ class ExportTest(unittest.TestCase):
     def setUp(self):
         self.project_id = app_identity.get_application_id()
         self.storage_client = StorageClient(self.project_id)
+
         self.hpo_bucket = self.storage_client.get_hpo_bucket(FAKE_HPO_ID)
 
     def _test_report_export(self, report):
@@ -124,11 +125,13 @@ class ExportTest(unittest.TestCase):
         # validation/main.py INTEGRATION TEST
         mock_is_hpo_id.return_value = True
         folder_prefix: str = 'dummy-prefix-2018-03-24/'
+
         target_bucket = self.storage_client.get_hpo_bucket('nyc')
         objects: Iterable = target_bucket.list_blobs()
         main.run_export(datasource_id=FAKE_HPO_ID,
                         folder_prefix=folder_prefix,
                         target_bucket=target_bucket.name)
+
         actual_names: list = [obj.name for obj in objects]
         for report in common.ALL_REPORT_FILES:
             prefix: str = f'{folder_prefix}{common.ACHILLES_EXPORT_PREFIX_STRING}{FAKE_HPO_ID}/'
@@ -136,6 +139,7 @@ class ExportTest(unittest.TestCase):
             self.assertIn(expected_name, actual_names)
         export_path: str = f'{folder_prefix}{common.ACHILLES_EXPORT_DATASOURCES_JSON}'
         self.assertIn(export_path, actual_names)
+
         actual_data = target_bucket.blob(export_path)
         actual_json_data: str = actual_data.download_as_bytes().decode()
         actual_datasources: dict = json.loads(actual_json_data)


### PR DESCRIPTION
- Replaces `gcs_utils.get_hpo_bucket(hpo_id)` method calls in save_datasources_json(…), upload_string_to_gcs(…), and run_export(…) with `StorageClient().get_hpo_bucket(hpo_id)` in data_steward/validation/main.py.
- Replaces `gcs_utils.upload_object()` calls with StorageClient.Blob.upload_from_file() in the same functions mentioned above.
- Replaces `gcs_utils.get_hpo_bucket(hpo_id)` method calls in test_run_export_with_target_bucket_and_datasource_id(...) with `StorageClient().get_hpo_bucket(hpo_id)` in tests/integration_tests/data_steward/validation/export_test.py.
