### PR TITLE
[DC-2075] Replace gcs_utils.get_hpo_bucket(hpo_id) calls with StorageClient().get_hpo_bucket(hpo_id)

### DIFF
--- a/data_steward/validation/app_errors.py
+++ b/data_steward/validation/app_errors.py
@@ -56,6 +56,7 @@ class BucketNotSet(RuntimeError):
 
     def __init__(self, msg):
         super(BucketNotSet, self).__init__(self, msg)
+        self.message = msg
 
 
 #TODO: refactor code that has BDNE error to NotFound -- all of it w/ticket

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -177,8 +177,9 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
         bucket_file_name = filename.split(resources.resource_files_path +
                                           os.sep)[1].strip().replace('\\', '/')
         with open(filename, 'rb') as fp:
-            upload_result = gcs_utils.upload_object(
-                bucket.name, folder_prefix + bucket_file_name, fp)
+            blob = bucket.blob(f'{folder_prefix}{bucket_file_name}')
+            blob.upload_from_file(fp)
+            upload_result = storage_client.get_blob_metadata(blob)
             results.append(upload_result)
     return results
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -18,6 +18,7 @@ import dateutil
 from flask import Flask
 from googleapiclient.errors import HttpError
 from google.cloud.storage import Blob
+from google.cloud.storage.bucket import Bucket
 
 # Project imports
 import api_util

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -159,9 +159,10 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     :returns:
     """
     results = []
-    storage_client = StorageClient()
+    project_id = app_identity.get_application_id()
+    storage_client = StorageClient(project_id)
     if target_bucket is not None:
-        bucket: Bucket = storage_client.get_bucket(target_bucket)
+        bucket: Bucket = storage_client.bucket(target_bucket)
     else:
         if hpo_id is None:
             raise RuntimeError(
@@ -508,7 +509,8 @@ def process_hpo(hpo_id, force_run=False):
     """
     try:
         logging.info(f"Processing hpo_id {hpo_id}")
-        storage_client = StorageClient()
+        project_id = app_identity.get_application_id()
+        storage_client = StorageClient(project_id)
         bucket: Bucket = storage_client.get_hpo_bucket(hpo_id)
         bucket_items = list_bucket(bucket.name)
         folder_prefix = _get_submission_folder(bucket.name, bucket_items,

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -159,22 +159,25 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     :returns:
     """
     results = []
+    storage_client = StorageClient()
     if target_bucket is not None:
-        bucket = target_bucket
+        bucket: Bucket = storage_client.get_bucket(target_bucket)
     else:
         if hpo_id is None:
             raise RuntimeError(
                 f"Either hpo_id or target_bucket must be specified")
-        bucket = gcs_utils.get_hpo_bucket(hpo_id)
+        bucket: Bucket = storage_client.get_hpo_bucket(hpo_id)
     logging.info(
-        f"Uploading achilles index files to 'gs://{bucket}/{folder_prefix}'")
+        f"Uploading achilles index files to 'gs://{bucket.name}/{folder_prefix}'"
+    )
     for filename in resources.ACHILLES_INDEX_FILES:
-        logging.info(f"Uploading achilles file '{filename}' to bucket {bucket}")
+        logging.info(
+            f"Uploading achilles file '{filename}' to bucket {bucket.name}")
         bucket_file_name = filename.split(resources.resource_files_path +
                                           os.sep)[1].strip().replace('\\', '/')
         with open(filename, 'rb') as fp:
             upload_result = gcs_utils.upload_object(
-                bucket, folder_prefix + bucket_file_name, fp)
+                bucket.name, folder_prefix + bucket_file_name, fp)
             results.append(upload_result)
     return results
 
@@ -505,25 +508,27 @@ def process_hpo(hpo_id, force_run=False):
     """
     try:
         logging.info(f"Processing hpo_id {hpo_id}")
-        bucket = gcs_utils.get_hpo_bucket(hpo_id)
-        bucket_items = list_bucket(bucket)
-        folder_prefix = _get_submission_folder(bucket, bucket_items, force_run)
+        storage_client = StorageClient()
+        bucket: Bucket = storage_client.get_hpo_bucket(hpo_id)
+        bucket_items = list_bucket(bucket.name)
+        folder_prefix = _get_submission_folder(bucket.name, bucket_items,
+                                               force_run)
         if folder_prefix is None:
             logging.info(
-                f"No submissions to process in {hpo_id} bucket {bucket}")
+                f"No submissions to process in {hpo_id} bucket {bucket.name}")
         else:
             folder_items = []
             if is_valid_folder_prefix_name(folder_prefix):
                 # perform validation
                 folder_items = get_folder_items(bucket_items, folder_prefix)
-                summary = validate_submission(hpo_id, bucket, folder_items,
+                summary = validate_submission(hpo_id, bucket.name, folder_items,
                                               folder_prefix)
-                report_data = generate_metrics(hpo_id, bucket, folder_prefix,
-                                               summary)
+                report_data = generate_metrics(hpo_id, bucket.name,
+                                               folder_prefix, summary)
             else:
                 # do not perform validation
                 report_data = generate_empty_report(hpo_id, folder_prefix)
-            perform_reporting(hpo_id, report_data, folder_items, bucket,
+            perform_reporting(hpo_id, report_data, folder_items, bucket.name,
                               folder_prefix)
     except BucketDoesNotExistError as bucket_error:
         bucket = bucket_error.bucket

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -45,13 +45,11 @@ class GCSTest(TestCase):
         with self.assertRaises(BucketNotSet) as e:
             self.client.get_hpo_bucket(self.hpo_id)
         self.assertEqual(e.exception.message, expected_message(None))
-
         # run after setting env var to empty string
         os.environ[bucket_env_var] = ""
         with self.assertRaises(BucketNotSet) as e:
             self.client.get_hpo_bucket(self.hpo_id)
         self.assertEqual(e.exception.message, expected_message(""))
-
         # run after setting env var to 'None'
         os.environ[bucket_env_var] = "None"
         with self.assertRaises(BucketNotSet) as e:

--- a/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
+++ b/tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py
@@ -36,7 +36,7 @@ class GCSTest(TestCase):
         self.file_name: str = 'foo_file.csv'
         self.hpo_id = 'fake_hpo_id'
 
-    def test_unset_bucket(self):
+    def test_get_hpo_bucket_not_set(self):
         bucket_env_var = f'BUCKET_NAME_{self.hpo_id.upper()}'
         expected_message = lambda bucket: f"Bucket '{bucket}' for hpo '{self.hpo_id}' is unset/empty"
 

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -52,26 +52,6 @@ class ValidationMainTest(TestCase):
 
         return bucket_items
 
-    @mock.patch('validation.main.StorageClient')
-    def test_unset_bucket(self, mock_storage_client):
-        mock_client = mock.MagicMock()
-        mock_storage_client.return_value = mock_client
-
-        bucket_env_var = f'BUCKET_NAME_{self.hpo_id.upper()}'
-        # run without setting env var (unset env_var)
-        os.environ.pop(f"BUCKET_NAME_{self.hpo_id.upper()}", None)
-        main.process_hpo(self.hpo_id)
-        # post conditions
-        mock_storage_client.assert_called()
-        mock_client.get_hpo_bucket.assert_called()
-
-        # run after setting env var to empty string
-        os.environ[bucket_env_var] = ""
-        main.process_hpo(self.hpo_id)
-        # post conditions
-        mock_storage_client.assert_called()
-        mock_client.get_hpo_bucket.assert_called()
-
     def test_retention_checks_list_submitted_bucket_items(self):
         #Define times to use
         within_retention = datetime.datetime.today() - datetime.timedelta(

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -350,14 +350,15 @@ class ValidationMainTest(TestCase):
         mock_blob = mock.MagicMock()
         mock_storage_client.return_value = mock_client
         mock_client.get_hpo_bucket.return_value = mock_bucket
-        type(mock_bucket).name = mock.PropertyMock(return_value='noob')
+        type(mock_bucket).name = mock.PropertyMock(
+            return_value='fake_bucket_name')
         mock_bucket.blob.return_value = mock_blob
         mock_all_required_files_loaded.return_value = True
         mock_has_all_required_files.return_value = True
         mock_query.return_value = {}
         mock_query_rows.return_value = []
         mock_get_duplicate_counts_query.return_value = ''
-        mock_get_hpo_name.return_value = 'noob'
+        mock_get_hpo_name.return_value = 'fake_hpo_name'
         mock_upload_string_to_gcs.return_value = ''
         mock_valid_rdr.return_value = True
         mock_first_validation.return_value = False
@@ -405,19 +406,20 @@ class ValidationMainTest(TestCase):
         mock_folder_items.return_value = ['measurement.csv']
 
         # test
-        main.process_hpo('noob', force_run=True)
+        main.process_hpo('fake_hpo_id', force_run=True)
 
         # post conditions
         mock_folder_items.assert_called()
         mock_folder_items.assert_called_once_with(mock_bucket_list.return_value,
                                                   'SUBMISSION/')
         mock_validation.assert_called()
-        mock_validation.assert_called_once_with('noob', 'noob',
+        mock_validation.assert_called_once_with('fake_hpo_id',
+                                                'fake_bucket_name',
                                                 mock_folder_items.return_value,
                                                 'SUBMISSION/')
         mock_run_achilles.assert_called()
         mock_export.assert_called()
-        mock_export.assert_called_once_with(datasource_id='noob',
+        mock_export.assert_called_once_with(datasource_id='fake_hpo_id',
                                             folder_prefix='SUBMISSION/')
         # make sure upload is called for only the most recent
         # non-participant directory
@@ -425,7 +427,7 @@ class ValidationMainTest(TestCase):
         mock_bucket.blob.assert_called()
         mock_blob.upload_from_file.assert_called()
         for filepath in mock_bucket.blob.call_args_list:
-            self.assertEqual('noob', type(mock_bucket).name)
+            self.assertEqual('fake_bucket_name', mock_bucket.name)
             self.assertTrue(filepath.startswith('SUBMISSION/'))
         mock_client.get_blob_metadata.assert_called()
 

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -52,14 +52,25 @@ class ValidationMainTest(TestCase):
 
         return bucket_items
 
-    def test_unset_bucket(self):
+    @mock.patch('validation.main.StorageClient')
+    def test_unset_bucket(self, mock_storage_client):
+        mock_client = mock.MagicMock()
+        mock_storage_client.return_value = mock_client
+
         bucket_env_var = f'BUCKET_NAME_{self.hpo_id.upper()}'
         # run without setting env var (unset env_var)
         os.environ.pop(f"BUCKET_NAME_{self.hpo_id.upper()}", None)
         main.process_hpo(self.hpo_id)
+        # post conditions
+        mock_storage_client.assert_called()
+        mock_client.get_hpo_bucket.assert_called()
+
         # run after setting env var to empty string
         os.environ[bucket_env_var] = ""
         main.process_hpo(self.hpo_id)
+        # post conditions
+        mock_storage_client.assert_called()
+        mock_client.get_hpo_bucket.assert_called()
 
     def test_retention_checks_list_submitted_bucket_items(self):
         #Define times to use


### PR DESCRIPTION
- Replaces `gcs_utils.get_hpo_bucket(hpo_id)` method calls in ` _upload_achilles_files(…)` and `process_hpo(...)` with `StorageClient().get_hpo_bucket(hpo_id)` in data_steward/validation/main.py.
- Replaces `gcs_utils.upload_object(...)` in `_upload_achilles_files(...)` from data_steward/validation/main.py.'
- Updates` test_unset_bucket(...) `and relocates it from tests/unit_tests/data_steward/validation/main_test.py to tests/unit_tests/data_steward/gcloud/gcs/gcs_test.py.
- Updates `test_validate_all_hpos_exception(...)` and `test_process_hpo_ignore_dirs(...)` in tests/unit_tests/data_steward/validation/main_test.py.
- Adds `self.message = msg` in `class BucketNotSet(RuntimeError)` from data_steward/validation/app_errors.py.
