### PR TITLE
[DC-2070] Replace gcs_utils.get_drc_bucket(hpo_id) calls in query_reports.py

### DIFF
--- a/data_steward/tools/consolidated_reports/get_all_achilles_reports.py
+++ b/data_steward/tools/consolidated_reports/get_all_achilles_reports.py
@@ -3,10 +3,13 @@ import os
 
 import common
 import gcs_utils
+from gcloud.gcs import StorageClient
 from tools.consolidated_reports import query_reports as query_reports
 from io import open
 
-DRC_BUCKET_PATH = 'gs://%s/' % gcs_utils.get_drc_bucket()
+storage_client = StorageClient()
+drc_bucket = storage_client.get_drc_bucket()
+DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
 DATASOURCES_PATH = 'curation_report/data/datasources.json'
 
 

--- a/data_steward/tools/consolidated_reports/get_all_achilles_reports.py
+++ b/data_steward/tools/consolidated_reports/get_all_achilles_reports.py
@@ -4,10 +4,12 @@ import os
 import common
 import gcs_utils
 from gcloud.gcs import StorageClient
+import app_identity
 from tools.consolidated_reports import query_reports as query_reports
 from io import open
 
-storage_client = StorageClient()
+project_id = app_identity.get_application_id()
+storage_client = StorageClient(project_id)
 drc_bucket = storage_client.get_drc_bucket()
 DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
 DATASOURCES_PATH = 'curation_report/data/datasources.json'

--- a/data_steward/tools/consolidated_reports/get_all_achilles_reports.py
+++ b/data_steward/tools/consolidated_reports/get_all_achilles_reports.py
@@ -3,15 +3,10 @@ import os
 
 import common
 import gcs_utils
-from gcloud.gcs import StorageClient
-import app_identity
 from tools.consolidated_reports import query_reports as query_reports
 from io import open
 
-project_id = app_identity.get_application_id()
-storage_client = StorageClient(project_id)
-drc_bucket = storage_client.get_drc_bucket()
-DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
+DRC_BUCKET_PATH = 'gs://%s/' % gcs_utils.get_drc_bucket()
 DATASOURCES_PATH = 'curation_report/data/datasources.json'
 
 

--- a/data_steward/tools/consolidated_reports/get_all_results_html.py
+++ b/data_steward/tools/consolidated_reports/get_all_results_html.py
@@ -5,9 +5,11 @@ import os
 
 import gcs_utils
 from gcloud.gcs import StorageClient
+import app_identity
 from tools.consolidated_reports import query_reports
 
-storage_client = StorageClient()
+project_id = app_identity.get_application_id()
+storage_client = StorageClient(project_id)
 drc_bucket = storage_client.get_drc_bucket()
 DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
 

--- a/data_steward/tools/consolidated_reports/get_all_results_html.py
+++ b/data_steward/tools/consolidated_reports/get_all_results_html.py
@@ -4,9 +4,12 @@ import json
 import os
 
 import gcs_utils
+from gcloud.gcs import StorageClient
 from tools.consolidated_reports import query_reports
 
-DRC_BUCKET_PATH = 'gs://%s/' % gcs_utils.get_drc_bucket()
+storage_client = StorageClient()
+drc_bucket = storage_client.get_drc_bucket()
+DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
 
 
 def get_hpo_id(p):

--- a/data_steward/tools/consolidated_reports/get_all_results_html.py
+++ b/data_steward/tools/consolidated_reports/get_all_results_html.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import json
 import os
 
-import gcs_utils
 from gcloud.gcs import StorageClient
 import app_identity
 from tools.consolidated_reports import query_reports

--- a/data_steward/tools/consolidated_reports/get_all_results_html.py
+++ b/data_steward/tools/consolidated_reports/get_all_results_html.py
@@ -3,14 +3,9 @@ from __future__ import print_function
 import json
 import os
 
-from gcloud.gcs import StorageClient
-import app_identity
 from tools.consolidated_reports import query_reports
 
-project_id = app_identity.get_application_id()
-storage_client = StorageClient(project_id)
-drc_bucket = storage_client.get_drc_bucket()
-DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
+DRC_BUCKET_PATH = query_reports.get_drc_bucket_path()
 
 
 def get_hpo_id(p):

--- a/data_steward/tools/consolidated_reports/main.py
+++ b/data_steward/tools/consolidated_reports/main.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-import gcs_utils
 from gcloud.gcs import StorageClient
 import app_identity
 from tools.consolidated_reports import query_reports

--- a/data_steward/tools/consolidated_reports/main.py
+++ b/data_steward/tools/consolidated_reports/main.py
@@ -3,10 +3,12 @@ import os
 
 import gcs_utils
 from gcloud.gcs import StorageClient
+import app_identity
 from tools.consolidated_reports import query_reports
 from io import open
 
-storage_client = StorageClient()
+project_id = app_identity.get_application_id()
+storage_client = StorageClient(project_id)
 drc_bucket = storage_client.get_drc_bucket()
 DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
 DATASOURCES_PATH = 'curation_report/data/datasources.json'

--- a/data_steward/tools/consolidated_reports/main.py
+++ b/data_steward/tools/consolidated_reports/main.py
@@ -2,10 +2,13 @@ import json
 import os
 
 import gcs_utils
+from gcloud.gcs import StorageClient
 from tools.consolidated_reports import query_reports
 from io import open
 
-DRC_BUCKET_PATH = 'gs://%s/' % gcs_utils.get_drc_bucket()
+storage_client = StorageClient()
+drc_bucket = storage_client.get_drc_bucket()
+DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
 DATASOURCES_PATH = 'curation_report/data/datasources.json'
 
 

--- a/data_steward/tools/consolidated_reports/main.py
+++ b/data_steward/tools/consolidated_reports/main.py
@@ -1,15 +1,10 @@
 import json
 import os
 
-from gcloud.gcs import StorageClient
-import app_identity
 from tools.consolidated_reports import query_reports
 from io import open
 
-project_id = app_identity.get_application_id()
-storage_client = StorageClient(project_id)
-drc_bucket = storage_client.get_drc_bucket()
-DRC_BUCKET_PATH = f'gs://{drc_bucket.name}/'
+DRC_BUCKET_PATH = query_reports.get_drc_bucket_path()
 DATASOURCES_PATH = 'curation_report/data/datasources.json'
 
 

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -61,7 +61,7 @@ def get_most_recent(report_for=None):
     :return: list of dict with keys `file_path`, `upload_timestamp`
     """
     app_id = app_identity.get_application_id()
-    storage_client = StorageClient()
+    storage_client = StorageClient(app_id)
     drc_bucket = storage_client.get_drc_bucket()
     if report_for == common.REPORT_FOR_ACHILLES:
         if not os.path.exists(common.LATEST_REPORTS_JSON):

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -50,7 +50,7 @@ LATEST_RESULTS_QUERY = (
     '  rank_order = 1')
 
 
-def get_most_recent(report_for=None):
+def get_most_recent(app_id=None, drc_bucket=None, report_for=None):
     """
     Query audit logs for paths to the most recent datasources.json files in the DRC bucket.
 
@@ -60,28 +60,30 @@ def get_most_recent(report_for=None):
     :param report_for: denotes which query to use b/w achilles and results
     :return: list of dict with keys `file_path`, `upload_timestamp`
     """
-    app_id = app_identity.get_application_id()
-    storage_client = StorageClient(app_id)
-    drc_bucket = storage_client.get_drc_bucket()
-    if report_for == common.REPORT_FOR_ACHILLES:
-        if not os.path.exists(common.LATEST_REPORTS_JSON):
-            query = LATEST_REPORTS_QUERY.format(app_id=app_id,
-                                                drc_bucket=drc_bucket.name,
-                                                year=common.LOG_YEAR)
-            query_job = bq_utils.query(query)
-            result = bq_utils.response2rows(query_job)
-            with open(common.LATEST_REPORTS_JSON, 'w') as fp:
-                json.dump(result, fp, sort_keys=True, indent=4)
-        with open(common.LATEST_REPORTS_JSON, 'r') as fp:
-            return json.load(fp)
-    elif report_for == common.REPORT_FOR_RESULTS:
-        if not os.path.exists(common.LATEST_RESULTS_JSON):
-            query = LATEST_RESULTS_QUERY.format(app_id=app_id,
-                                                drc_bucket=drc_bucket.name,
-                                                year=common.LOG_YEAR)
-            query_job = bq_utils.query(query)
-            result = bq_utils.response2rows(query_job)
-            with open(common.LATEST_RESULTS_JSON, 'w') as fp:
-                json.dump(result, fp, sort_keys=True, indent=4)
-        with open(common.LATEST_RESULTS_JSON, 'r') as fp:
-            return json.load(fp)
+    if app_id is None:
+        app_id = app_identity.get_application_id()
+    if drc_bucket is None:
+        storage_client = StorageClient(app_id)
+        drc_bucket = storage_client.get_drc_bucket()
+        if report_for == common.REPORT_FOR_ACHILLES:
+            if not os.path.exists(common.LATEST_REPORTS_JSON):
+                query = LATEST_REPORTS_QUERY.format(app_id=app_id,
+                                                    drc_bucket=drc_bucket.name,
+                                                    year=common.LOG_YEAR)
+                query_job = bq_utils.query(query)
+                result = bq_utils.response2rows(query_job)
+                with open(common.LATEST_REPORTS_JSON, 'w') as fp:
+                    json.dump(result, fp, sort_keys=True, indent=4)
+            with open(common.LATEST_REPORTS_JSON, 'r') as fp:
+                return json.load(fp)
+        elif report_for == common.REPORT_FOR_RESULTS:
+            if not os.path.exists(common.LATEST_RESULTS_JSON):
+                query = LATEST_RESULTS_QUERY.format(app_id=app_id,
+                                                    drc_bucket=drc_bucket.name,
+                                                    year=common.LOG_YEAR)
+                query_job = bq_utils.query(query)
+                result = bq_utils.response2rows(query_job)
+                with open(common.LATEST_RESULTS_JSON, 'w') as fp:
+                    json.dump(result, fp, sort_keys=True, indent=4)
+            with open(common.LATEST_RESULTS_JSON, 'r') as fp:
+                return json.load(fp)

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -86,3 +86,10 @@ def get_most_recent(app_id=None, drc_bucket=None, report_for=None):
                     json.dump(result, fp, sort_keys=True, indent=4)
             with open(common.LATEST_RESULTS_JSON, 'r') as fp:
                 return json.load(fp)
+
+
+def get_drc_bucket_path():
+    project_id = app_identity.get_application_id()
+    storage_client = StorageClient(project_id)
+    drc_bucket = storage_client.get_drc_bucket()
+    return f'gs://{drc_bucket.name}/'

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -60,9 +60,7 @@ def get_most_recent(report_for=None):
     :param report_for: denotes which query to use b/w achilles and results
     :return: list of dict with keys `file_path`, `upload_timestamp`
     """
-    # if app_id is None:
     app_id = app_identity.get_application_id()
-    # if drc_bucket is None:
     storage_client = StorageClient()
     drc_bucket = storage_client.get_drc_bucket()
     if report_for == common.REPORT_FOR_ACHILLES:

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -6,6 +6,7 @@ import app_identity
 import bq_utils
 import common
 import gcs_utils
+from gcloud.gcs import StorageClient
 from io import open
 
 LATEST_REPORTS_QUERY = (

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -50,7 +50,7 @@ LATEST_RESULTS_QUERY = (
     '  rank_order = 1')
 
 
-def get_most_recent(app_id=None, drc_bucket=None, report_for=None):
+def get_most_recent(report_for=None):
     """
     Query audit logs for paths to the most recent datasources.json files in the DRC bucket.
 
@@ -60,29 +60,30 @@ def get_most_recent(app_id=None, drc_bucket=None, report_for=None):
     :param report_for: denotes which query to use b/w achilles and results
     :return: list of dict with keys `file_path`, `upload_timestamp`
     """
-    if app_id is None:
-        app_id = app_identity.get_application_id()
-    if drc_bucket is None:
-        drc_bucket = gcs_utils.get_drc_bucket()
-        if report_for == common.REPORT_FOR_ACHILLES:
-            if not os.path.exists(common.LATEST_REPORTS_JSON):
-                query = LATEST_REPORTS_QUERY.format(app_id=app_id,
-                                                    drc_bucket=drc_bucket,
-                                                    year=common.LOG_YEAR)
-                query_job = bq_utils.query(query)
-                result = bq_utils.response2rows(query_job)
-                with open(common.LATEST_REPORTS_JSON, 'w') as fp:
-                    json.dump(result, fp, sort_keys=True, indent=4)
-            with open(common.LATEST_REPORTS_JSON, 'r') as fp:
-                return json.load(fp)
-        elif report_for == common.REPORT_FOR_RESULTS:
-            if not os.path.exists(common.LATEST_RESULTS_JSON):
-                query = LATEST_RESULTS_QUERY.format(app_id=app_id,
-                                                    drc_bucket=drc_bucket,
-                                                    year=common.LOG_YEAR)
-                query_job = bq_utils.query(query)
-                result = bq_utils.response2rows(query_job)
-                with open(common.LATEST_RESULTS_JSON, 'w') as fp:
-                    json.dump(result, fp, sort_keys=True, indent=4)
-            with open(common.LATEST_RESULTS_JSON, 'r') as fp:
-                return json.load(fp)
+    # if app_id is None:
+    app_id = app_identity.get_application_id()
+    # if drc_bucket is None:
+    storage_client = StorageClient()
+    drc_bucket = storage_client.get_drc_bucket()
+    if report_for == common.REPORT_FOR_ACHILLES:
+        if not os.path.exists(common.LATEST_REPORTS_JSON):
+            query = LATEST_REPORTS_QUERY.format(app_id=app_id,
+                                                drc_bucket=drc_bucket.name,
+                                                year=common.LOG_YEAR)
+            query_job = bq_utils.query(query)
+            result = bq_utils.response2rows(query_job)
+            with open(common.LATEST_REPORTS_JSON, 'w') as fp:
+                json.dump(result, fp, sort_keys=True, indent=4)
+        with open(common.LATEST_REPORTS_JSON, 'r') as fp:
+            return json.load(fp)
+    elif report_for == common.REPORT_FOR_RESULTS:
+        if not os.path.exists(common.LATEST_RESULTS_JSON):
+            query = LATEST_RESULTS_QUERY.format(app_id=app_id,
+                                                drc_bucket=drc_bucket.name,
+                                                year=common.LOG_YEAR)
+            query_job = bq_utils.query(query)
+            result = bq_utils.response2rows(query_job)
+            with open(common.LATEST_RESULTS_JSON, 'w') as fp:
+                json.dump(result, fp, sort_keys=True, indent=4)
+        with open(common.LATEST_RESULTS_JSON, 'r') as fp:
+            return json.load(fp)

--- a/data_steward/tools/consolidated_reports/query_reports.py
+++ b/data_steward/tools/consolidated_reports/query_reports.py
@@ -5,7 +5,6 @@ import app_identity
 
 import bq_utils
 import common
-import gcs_utils
 from gcloud.gcs import StorageClient
 from io import open
 


### PR DESCRIPTION
Replaces `gcs_utils.get_hpo_bucket(hpo_id)` calls in data_steward/tools/consolidated_reports/query_reports.py, data_steward/tools/consolidated_reports/get_all_results_html.py, and data_steward/tools/consolidated_reports/main.py with `StorageClient().get_hpo_bucket(hpo_id)`.