### PR TITLE
[DC-2084] Refactor test to use buckets directly and phase out gcs_utils

### DIFF
--- a/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
+++ b/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
@@ -7,7 +7,6 @@ import app_identity
 import bq_utils
 import common
 from gcloud.gcs import StorageClient
-import gcs_utils
 import resources
 from tests import test_util
 from tools.top_heel_errors import top_heel_errors, RESULT_LIMIT, FIELD_ANALYSIS_ID, FIELD_RECORD_COUNT, \
@@ -63,10 +62,10 @@ class TopHeelErrorsTest(TestCase):
     def setUp(self):
         self.project_id = app_identity.get_application_id()
         self.dataset_id = bq_utils.get_dataset_id()
-        self.bucket: str = gcs_utils.get_drc_bucket()
         self.storage_client = StorageClient(self.project_id)
+        self.drc_bucket = self.storage_client.get_drc_bucket()
 
-        self.storage_client.empty_bucket(self.bucket)
+        self.storage_client.empty_bucket(self.drc_bucket)
         test_util.delete_all_tables(self.dataset_id)
         self.load_test_data(hpo_id=HPO_NYC)
 
@@ -87,11 +86,10 @@ class TopHeelErrorsTest(TestCase):
         test_file_path: str = os.path.join(test_util.TEST_DATA_PATH,
                                            test_file_name)
 
-        target_bucket = self.storage_client.get_bucket(self.bucket)
-        test_blob = target_bucket.blob(test_file_name)
+        test_blob = self.drc_bucket.blob(test_file_name)
         test_blob.upload_from_filename(test_file_path)
 
-        gcs_path: str = f'gs://{self.bucket}/{test_file_name}'
+        gcs_path: str = f'gs://{self.drc_bucket.name}/{test_file_name}'
         load_results = bq_utils.load_csv(table_name, gcs_path, self.project_id,
                                          self.dataset_id, table_id)
         job_id = load_results['jobReference']['jobId']
@@ -126,5 +124,5 @@ class TopHeelErrorsTest(TestCase):
         self.assertCountEqual(actual_results, expected_results)
 
     def tearDown(self):
-        self.storage_client.empty_bucket(self.bucket)
+        self.storage_client.empty_bucket(self.drc_bucket)
         test_util.delete_all_tables(self.dataset_id)

--- a/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
+++ b/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
@@ -78,7 +78,7 @@ class TopHeelErrorsTest(TestCase):
         """
 
         heel_results: str = common.ACHILLES_HEEL_RESULTS
-        if hpo_id is not None:
+        if hpo_id:
             table_id: str = bq_utils.get_table_id(hpo_id, heel_results)
         else:
             table_id: str = heel_results

--- a/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
+++ b/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
@@ -77,19 +77,20 @@ class TopHeelErrorsTest(TestCase):
         :return: contents of the file as list of objects
         """
 
-        table_name: str = common.ACHILLES_HEEL_RESULTS
+        heel_results: str = common.ACHILLES_HEEL_RESULTS
         if hpo_id is not None:
-            table_id: str = bq_utils.get_table_id(hpo_id, table_name)
+            table_id: str = bq_utils.get_table_id(hpo_id, heel_results)
         else:
-            table_id: str = table_name
+            table_id: str = heel_results
         table = self.drc_bucket.blob(f'{table_id}.csv')
         table_path: str = os.path.join(test_util.TEST_DATA_PATH, table.name)
 
         table.upload_from_filename(table_path)
 
         gcs_path: str = f'gs://{self.drc_bucket.name}/{table.name}'
-        load_results = bq_utils.load_csv(table_name, gcs_path, self.project_id,
-                                         self.dataset_id, table_id)
+        load_results = bq_utils.load_csv(heel_results, gcs_path,
+                                         self.project_id, self.dataset_id,
+                                         table_id)
         job_id = load_results['jobReference']['jobId']
         bq_utils.wait_on_jobs([job_id])
         return resources.csv_to_list(table_path)

--- a/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
+++ b/tests/integration_tests/data_steward/tools/top_heel_errors_test.py
@@ -82,19 +82,17 @@ class TopHeelErrorsTest(TestCase):
             table_id: str = bq_utils.get_table_id(hpo_id, table_name)
         else:
             table_id: str = table_name
-        test_file_name: str = f'{table_id}.csv'
-        test_file_path: str = os.path.join(test_util.TEST_DATA_PATH,
-                                           test_file_name)
+        table = self.drc_bucket.blob(f'{table_id}.csv')
+        table_path: str = os.path.join(test_util.TEST_DATA_PATH, table.name)
 
-        test_blob = self.drc_bucket.blob(test_file_name)
-        test_blob.upload_from_filename(test_file_path)
+        table.upload_from_filename(table_path)
 
-        gcs_path: str = f'gs://{self.drc_bucket.name}/{test_file_name}'
+        gcs_path: str = f'gs://{self.drc_bucket.name}/{table.name}'
         load_results = bq_utils.load_csv(table_name, gcs_path, self.project_id,
                                          self.dataset_id, table_id)
         job_id = load_results['jobReference']['jobId']
         bq_utils.wait_on_jobs([job_id])
-        return resources.csv_to_list(test_file_path)
+        return resources.csv_to_list(table_path)
 
     def test_top_heel_errors_no_hpo_prefix(self):
         rows = self.load_test_data()


### PR DESCRIPTION
- Previous test method used gcs_utils to get a string and then used the string to create a bucket.  This change uses the string directly to create a bucket, eliminating the intermediate step and removing gcs_utils from the file entirely.