### PR TITLE
[DC-2086] Modernize integration tests in main_test to use GCS

### DIFF
--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -858,12 +858,12 @@ def load_table_from_csv(project_id,
                    the fields are stored in a json file in resource_files/fields named table_name.json
     :return: BQ response for the load query
     """
-    if csv_path is None:
+    if not csv_path:
         csv_path = os.path.join(resources.resource_files_path,
                                 table_name + ".csv")
     table_list = resources.csv_to_list(csv_path)
 
-    if fields is None:
+    if not fields:
         fields = resources.fields_for(table_name)
     field_names = ', '.join([field['name'] for field in fields])
     row_exprs = [csv_line_to_sql_row_expr(t, fields) for t in table_list]

--- a/data_steward/constants/validation/main.py
+++ b/data_steward/constants/validation/main.py
@@ -18,6 +18,9 @@ RESULT_PASS_COLOR = 'green'
 # datetime format
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
 
+# lag before submission is processed
+SUBMISSION_LAG_TIME_MINUTES = 5
+
 # Table Headers
 RESULT_FILE_HEADERS = ["File Name", "Found", "Parsed", "Loaded"]
 ERROR_FILE_HEADERS = ["File Name", "Message"]
@@ -30,15 +33,15 @@ DUPLICATE_IDS_HEADERS = ['Table Name', 'Duplicate ID Count']
 
 # Used in get_heel_errors_in_results_html()
 HEEL_ERROR_QUERY_VALIDATION = '''
-    SELECT 
+    SELECT
         analysis_id AS analysis_id,
         achilles_heel_warning AS heel_error,
         rule_id AS rule_id,
         record_count AS record_count
     FROM `{project_id}.{dataset_id}.{table_id}`
     WHERE achilles_heel_warning LIKE 'ERROR:%'
-    ORDER BY 
-        record_count DESC, 
+    ORDER BY
+        record_count DESC,
         analysis_id
     '''
 HEEL_ERROR_FAIL_ROWS = [(NULL_MESSAGE, HEEL_ERROR_FAIL_MESSAGE, NULL_MESSAGE,
@@ -111,11 +114,11 @@ DRUG_CLASS_QUERY = '''
             21600744,
             21604303,
             21601278,
-            21601783) 
+            21601783)
     '''
 
 DUPLICATE_IDS_WRAPPER = '''
-    SELECT 
+    SELECT
         table_name,
         count
     FROM
@@ -124,7 +127,7 @@ DUPLICATE_IDS_WRAPPER = '''
     '''
 
 DUPLICATE_IDS_SUBQUERY = '''
-    SELECT 
+    SELECT
         '{table_name}' AS table_name,
         SUM(Individual_Duplicate_ID_Count-1) as count
     FROM

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -546,8 +546,7 @@ def process_hpo(hpo_id, force_run=False):
         storage_client = StorageClient(project_id)
         bucket = storage_client.get_hpo_bucket(hpo_id)
         bucket_items: list = storage_client.get_bucket_items_metadata(bucket)
-        folder_prefix = _get_submission_folder(bucket.name, bucket_items,
-                                               force_run)
+        folder_prefix = _get_submission_folder(bucket, bucket_items, force_run)
         if folder_prefix is None:
             logging.info(
                 f"No submissions to process in {hpo_id} bucket {bucket.name}")
@@ -873,7 +872,7 @@ def _get_submission_folder(bucket, bucket_items, force_process=False):
                 [item['updated'] for item in submitted_bucket_items])
             folder_datetime_list.append(latest_datetime)
 
-    if folder_datetime_list and folder_datetime_list != []:
+    if folder_datetime_list:
         latest_datetime_index = folder_datetime_list.index(
             max(folder_datetime_list))
         to_process_folder = folders_with_submitted_files[latest_datetime_index]

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -767,7 +767,7 @@ def list_submitted_bucket_items(folder_bucketitems):
     files_list = []
     object_retention_days = 30
     object_process_lag_minutes = consts.SUBMISSION_LAG_TIME_MINUTES
-    today = datetime.datetime.utcnow()
+    today = datetime.datetime.now(tz=None)
 
     # If any required file missing, stop submission
     folder_bucketitems_basenames = [

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -172,7 +172,10 @@ def _upload_achilles_files(hpo_id: str = None,
     project_id = app_identity.get_application_id()
     storage_client = StorageClient(project_id)
 
-    if not target_bucket:
+    if target_bucket:
+        pass
+        # would create a bucket from string above
+    else:
         if not hpo_id:
             raise RuntimeError(
                 f"Either hpo_id or target_bucket must be specified")
@@ -547,7 +550,7 @@ def process_hpo(hpo_id, force_run=False):
         bucket = storage_client.get_hpo_bucket(hpo_id)
         bucket_items: list = storage_client.get_bucket_items_metadata(bucket)
         folder_prefix = _get_submission_folder(bucket, bucket_items, force_run)
-        if folder_prefix is None:
+        if not folder_prefix:
             logging.info(
                 f"No submissions to process in {hpo_id} bucket {bucket.name}")
         else:

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -737,9 +737,9 @@ def perform_validation_on_file(file_name, found_file_names, hpo_id,
     return results, errors
 
 
-def _validation_done(bucket, folder):
-    project_id = app_identity.get_application_id()
-    storage_client = StorageClient(project_id)
+def _validation_done(bucket, folder: str):
+    application_id: str = app_identity.get_application_id()
+    storage_client = StorageClient(application_id)
     return Blob(bucket=bucket,
                 name=f'{folder}{common.PROCESSED_TXT}').exists(storage_client)
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -168,10 +168,10 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     results = []
     project_id = app_identity.get_application_id()
     storage_client = StorageClient(project_id)
-    if target_bucket:
+    if target_bucket is not None:
         bucket = storage_client.bucket(target_bucket)
     else:
-        if not hpo_id:
+        if hpo_id is None:
             raise RuntimeError(
                 f"Either hpo_id or target_bucket must be specified")
         bucket = storage_client.get_hpo_bucket(hpo_id)
@@ -180,12 +180,11 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     )
     for filename in resources.ACHILLES_INDEX_FILES:
         logging.info(
-            f"Uploading achilles file '{filename}' to bucket {target_bucket.name}"
-        )
+            f"Uploading achilles file '{filename}' to bucket {bucket.name}")
         bucket_file_name = filename.split(resources.resource_files_path +
                                           os.sep)[1].strip().replace('\\', '/')
         with open(filename, 'rb') as fp:
-            blob = target_bucket.blob(f'{folder_prefix}{bucket_file_name}')
+            blob = bucket.blob(f'{folder_prefix}{bucket_file_name}')
             blob.upload_from_file(fp)
             upload_result: dict = storage_client.get_blob_metadata(blob)
             results.append(upload_result)

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -767,7 +767,7 @@ def list_submitted_bucket_items(folder_bucketitems):
     files_list = []
     object_retention_days = 30
     object_process_lag_minutes = consts.SUBMISSION_LAG_TIME_MINUTES
-    today = datetime.datetime.now(tz=None)
+    utc_today = datetime.datetime.now(tz=None)
 
     # If any required file missing, stop submission
     folder_bucketitems_basenames = [
@@ -792,7 +792,7 @@ def list_submitted_bucket_items(folder_bucketitems):
             upper_age_threshold = created_date + retention_time - retention_start_time
             upper_age_threshold = upper_age_threshold.replace(tzinfo=None)
 
-            if upper_age_threshold > today:
+            if upper_age_threshold > utc_today:
                 files_list.append(item)
 
             if basename(item) in AOU_REQUIRED_FILES:
@@ -802,7 +802,7 @@ def list_submitted_bucket_items(folder_bucketitems):
                 lower_age_threshold = item['updated'] + lag_time
                 lower_age_threshold = lower_age_threshold.replace(tzinfo=None)
 
-                if lower_age_threshold > today:
+                if lower_age_threshold > utc_today:
                     logging.info(
                         f"Delaying processing for hpo_id by 3 hrs (to next cron run) "
                         f"since files are still being uploaded. "

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -168,9 +168,9 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     results = []
     project_id = app_identity.get_application_id()
     storage_client = StorageClient(project_id)
-    if not target_bucket and not hpo_id:
+    if not target_bucket and not hpo_id: # might be ~not~ hpo_id
         raise RuntimeError(f"Either hpo_id or target_bucket must be specified")
-    target_bucket = storage_client.get_hpo_bucket(hpo_id)
+
     logging.info(
         f"Uploading achilles index files to 'gs://{target_bucket.name}/{folder_prefix}'"
     )

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -161,7 +161,7 @@ def upload_achilles_files(hpo_id):
 
 def _upload_achilles_files(hpo_id: str = None,
                            folder_prefix: str = '',
-                           target_bucket: Bucket = None):
+                           target_bucket=None):
     """
     uploads achilles web files to the corresponding hpo bucket
 
@@ -187,8 +187,7 @@ def _upload_achilles_files(hpo_id: str = None,
         bucket_file_name = filename.split(resources.resource_files_path +
                                           os.sep)[1].strip().replace('\\', '/')
         with open(filename, 'rb') as fp:
-            blob = target_bucket.blob(
-                f'{folder_prefix}{bucket_file_name}')
+            blob = target_bucket.blob(f'{folder_prefix}{bucket_file_name}')
             blob.upload_from_file(fp)
             upload_result: dict = storage_client.get_blob_metadata(blob)
             results.append(upload_result)
@@ -238,7 +237,7 @@ def categorize_folder_items(folder_items):
     return found_cdm_files, found_pii_files, unknown_files
 
 
-def validate_submission(hpo_id: str, bucket: Bucket, folder_items: list,
+def validate_submission(hpo_id: str, bucket, folder_items: list,
                         folder_prefix: str):
     """
     Load submission in BigQuery and summarize outcome
@@ -684,7 +683,7 @@ def get_hpo_missing_pii_query(hpo_id):
 
 
 def perform_validation_on_file(file_name: str, found_file_names: list,
-                               hpo_id: str, folder_prefix, bucket: Bucket):
+                               hpo_id: str, folder_prefix, bucket):
     """
     Attempts to load a csv file into BigQuery
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -742,7 +742,7 @@ def _validation_done(bucket, folder: str):
 def basename(item_metadata):
     """returns name of file inside folder
 
-    :item_metadata: metadata as returned by list bucket
+    :item_metadata: metadata as returned by get bucket times metadata
     :returns: name without folder name
 
     """

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -746,14 +746,14 @@ def _validation_done(bucket, folder: str):
                 name=f'{folder}{common.PROCESSED_TXT}').exists(storage_client)
 
 
-def basename(gcs_object_metadata):
+def basename(item_metadata):
     """returns name of file inside folder
 
-    :gcs_object_metadata: metadata as returned by list bucket
+    :item_metadata: metadata as returned by list bucket
     :returns: name without folder name
 
     """
-    name = gcs_object_metadata['name']
+    name = item_metadata['name']
     if len(name.split('/')) > 1:
         return '/'.join(name.split('/')[1:])
     return ''
@@ -804,6 +804,7 @@ def list_submitted_bucket_items(folder_bucketitems):
                 lag_time = datetime.timedelta(
                     minutes=object_process_lag_minutes)
                 lower_age_threshold = item['updated'] + lag_time
+                lower_age_threshold = lower_age_threshold.replace(tzinfo=None)
 
                 if lower_age_threshold > today:
                     logging.info(
@@ -822,7 +823,7 @@ def _get_submission_folder(bucket, bucket_items, force_process=False):
     Skips directories listed in IGNORE_DIRECTORIES with a case insensitive
     match.
 
-    :param bucket: string bucket name to look into
+    :param bucket: Bucket Object to validate on
     :param bucket_items: list of unicode string items in the bucket
     :param force_process: if True return most recently updated directory, even
         if it has already been processed.

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -168,11 +168,9 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     results = []
     project_id = app_identity.get_application_id()
     storage_client = StorageClient(project_id)
-    if not target_bucket:
-        if hpo_id is None:
-            raise RuntimeError(
-                f"Either hpo_id or target_bucket must be specified")
-        target_bucket = storage_client.get_hpo_bucket(hpo_id)
+    if not target_bucket and not hpo_id:
+        raise RuntimeError(f"Either hpo_id or target_bucket must be specified")
+    target_bucket = storage_client.get_hpo_bucket(hpo_id)
     logging.info(
         f"Uploading achilles index files to 'gs://{target_bucket.name}/{folder_prefix}'"
     )

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -168,12 +168,16 @@ def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     results = []
     project_id = app_identity.get_application_id()
     storage_client = StorageClient(project_id)
-    if not target_bucket and not hpo_id: # might be ~not~ hpo_id
-        raise RuntimeError(f"Either hpo_id or target_bucket must be specified")
 
+    if not target_bucket:
+        if not hpo_id:
+            raise RuntimeError(
+                f"Either hpo_id or target_bucket must be specified")
+        target_bucket = storage_client.get_hpo_bucket(hpo_id)
     logging.info(
         f"Uploading achilles index files to 'gs://{target_bucket.name}/{folder_prefix}'"
     )
+
     for filename in resources.ACHILLES_INDEX_FILES:
         logging.info(
             f"Uploading achilles file '{filename}' to bucket {target_bucket.name}"

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -159,7 +159,9 @@ def upload_achilles_files(hpo_id):
     return json.dumps(result, sort_keys=True, indent=4, separators=(',', ': '))
 
 
-def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
+def _upload_achilles_files(hpo_id: str = None,
+                           folder_prefix: str = '',
+                           target_bucket: Bucket = None):
     """
     uploads achilles web files to the corresponding hpo bucket
 
@@ -236,7 +238,8 @@ def categorize_folder_items(folder_items):
     return found_cdm_files, found_pii_files, unknown_files
 
 
-def validate_submission(hpo_id, bucket, folder_items, folder_prefix):
+def validate_submission(hpo_id: str, bucket: Bucket, folder_items: list,
+                        folder_prefix: str):
     """
     Load submission in BigQuery and summarize outcome
 
@@ -680,8 +683,8 @@ def get_hpo_missing_pii_query(hpo_id):
         participant_match_table_id=participant_match_table_id)
 
 
-def perform_validation_on_file(file_name, found_file_names, hpo_id,
-                               folder_prefix, bucket):
+def perform_validation_on_file(file_name: str, found_file_names: list,
+                               hpo_id: str, folder_prefix, bucket: Bucket):
     """
     Attempts to load a csv file into BigQuery
 

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -26,7 +26,6 @@ import app_identity
 import bq_utils
 import cdm
 import common
-import gcs_utils
 from gcloud.gcs import StorageClient
 import resources
 from common import ACHILLES_EXPORT_PREFIX_STRING, ACHILLES_EXPORT_DATASOURCES_JSON, AOU_REQUIRED_FILES

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -159,29 +159,24 @@ def upload_achilles_files(hpo_id):
     return json.dumps(result, sort_keys=True, indent=4, separators=(',', ': '))
 
 
-def _upload_achilles_files(hpo_id: str = None,
-                           folder_prefix: str = '',
-                           target_bucket=None):
+def _upload_achilles_files(hpo_id=None, folder_prefix='', target_bucket=None):
     """
     uploads achilles web files to the corresponding hpo bucket
-
     :hpo_id: which hpo bucket do these files go into
     :returns:
     """
     results = []
     project_id = app_identity.get_application_id()
     storage_client = StorageClient(project_id)
-
     if target_bucket:
-        pass
-        # would create a bucket from string above
+        bucket = storage_client.bucket(target_bucket)
     else:
         if not hpo_id:
             raise RuntimeError(
                 f"Either hpo_id or target_bucket must be specified")
-        target_bucket = storage_client.get_hpo_bucket(hpo_id)
+        bucket = storage_client.get_hpo_bucket(hpo_id)
     logging.info(
-        f"Uploading achilles index files to 'gs://{target_bucket.name}/{folder_prefix}'"
+        f"Uploading achilles index files to 'gs://{bucket.name}/{folder_prefix}'"
     )
     for filename in resources.ACHILLES_INDEX_FILES:
         logging.info(

--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -122,7 +122,6 @@ class BqUtilsTest(unittest.TestCase):
                                         locals())
         self.assertEqual(query_response['kind'], 'bigquery#queryResponse')
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_load_cdm_csv(self):
         table_blob: Blob = self.hpo_bucket.blob('person.csv')
@@ -140,7 +139,6 @@ class BqUtilsTest(unittest.TestCase):
         num_rows = table_info.get('numRows')
         self.assertEqual(num_rows, '5')
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_query_result(self):
         table_blob: Blob = self.hpo_bucket.blob('person.csv')
@@ -203,7 +201,6 @@ class BqUtilsTest(unittest.TestCase):
             # sanity check
             self.assertTrue(bq_utils.table_exists(table_id))
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_load_ehr_observation(self):
         hpo_id = PITT_HPO_ID

--- a/tests/integration_tests/data_steward/validation/achilles_test.py
+++ b/tests/integration_tests/data_steward/validation/achilles_test.py
@@ -44,7 +44,6 @@ class AchillesTest(unittest.TestCase):
     def tearDownClass(cls):
         test_util.drop_hpo_id_bucket_name_table(cls.dataset_id)
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def _load_dataset(self):
         for cdm_table in resources.CDM_TABLES:

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -54,6 +54,9 @@ class ValidationMainTest(unittest.TestCase):
 
         self.storage_client = StorageClient(self.project_id)
         self.hpo_bucket = self.storage_client.get_hpo_bucket(self.hpo_id)
+        self.drc_bucket = self.storage_client.get_drc_bucket()
+
+        self.storage_client.empty_bucket(self.drc_bucket)
         self.storage_client.empty_bucket(self.hpo_bucket)
 
         test_util.delete_all_tables(self.dataset_id)
@@ -234,8 +237,6 @@ class ValidationMainTest(unittest.TestCase):
             test_blob = self.hpo_bucket.blob(blob_name)
             test_blob.upload_from_filename(cdm_pathfile)
 
-        drc_bucket = self.storage_client.get_drc_bucket()
-
         main.app.testing = True
         with main.app.test_client() as c:
             c.get(test_util.COPY_HPO_FILES_URL)
@@ -250,7 +251,7 @@ class ValidationMainTest(unittest.TestCase):
             ])
 
             raw_metadata: list = self.storage_client.get_bucket_items_metadata(
-                drc_bucket)
+                self.drc_bucket)
             actual_metadata: list = [item['name'] for item in raw_metadata]
             self.assertSetEqual(set(expected_metadata), set(actual_metadata))
 

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -41,13 +41,13 @@ class ValidationMainTest(unittest.TestCase):
         self.hpo_id: str = test_util.FAKE_HPO_ID
         self.project_id: str = app_identity.get_application_id()
         self.rdr_dataset_id: str = bq_utils.get_rdr_dataset_id()
-        self.bigquery_dataset_id: str = bq_utils.get_dataset_id()
 
         mock_get_hpo_name = mock.patch('validation.main.get_hpo_name')
         self.mock_get_hpo_name = mock_get_hpo_name.start()
         self.mock_get_hpo_name.return_value = 'Fake HPO'
         self.addCleanup(mock_get_hpo_name.stop)
 
+        self.bigquery_dataset_id: str = bq_utils.get_dataset_id()
         self.folder_prefix: str = '2019-01-01-v1/'
 
         self.bq_client = get_client(self.project_id)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -349,7 +349,9 @@ class ValidationMainTest(unittest.TestCase):
     @mock.patch('api_util.check_cron')
     def test_html_report_five_person(self, mock_check_cron, mock_first_run,
                                      mock_required_files_loaded,
-                                     mock_has_all_required_files):
+                                     mock_has_all_required_files,
+                                     mock_setup_validate_participants,
+                                     mock_part_val_summary_query):
         mock_required_files_loaded.return_value = False
         mock_first_run.return_value = False
         mock_has_all_required_files.return_value = True

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -209,7 +209,6 @@ class ValidationMainTest(unittest.TestCase):
             item['updated'] = datetime.datetime.today() - datetime.timedelta(
                 minutes=7)
 
-        # TODO use a bucket!
         result = main._get_submission_folder(self.hpo_bucket,
                                              items_metadata,
                                              force_process=False)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -180,7 +180,7 @@ class ValidationMainTest(unittest.TestCase):
         self.assertSetEqual(set(actual['results']), set(expected_results))
 
         # check tables exist and are clustered as expected
-        for table in f'{resources.CDM_TABLES}{common.PII_TABLES}':
+        for table in resources.CDM_TABLES + common.PII_TABLES:
             table_id: str = bq_utils.get_table_id(test_util.FAKE_HPO_ID, table)
             table_info = bq_utils.get_table_info(table_id)
             fields = resources.fields_for(table)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -35,7 +35,6 @@ class ValidationMainTest(unittest.TestCase):
         print('**************************************************************')
         test_util.setup_hpo_id_bucket_name_table(cls.dataset_id)
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def setUp(self):
         self.hpo_id: str = test_util.FAKE_HPO_ID
@@ -111,7 +110,6 @@ class ValidationMainTest(unittest.TestCase):
         tpe = time_partitioning.get('type')
         self.assertEqual(tpe, 'DAY')
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_all_files_unparseable_output(self):
         # TODO possible bug: if no pre-existing table, results in bq table not found error
@@ -152,7 +150,6 @@ class ValidationMainTest(unittest.TestCase):
                                                 self.folder_prefix)
         self.assertCountEqual(expected_warnings, actual['warnings'])
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch('api_util.check_cron')
     def test_validate_five_persons_success(self, mock_check_cron):
@@ -256,7 +253,6 @@ class ValidationMainTest(unittest.TestCase):
             self.assertSetEqual(set(expected_metadata), set(actual_metadata))
 
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_target_bucket_upload(self):
         bucket_nyc = self.storage_client.get_hpo_bucket('nyc')
         folder_prefix: str = 'test-folder-fake/'
@@ -442,7 +438,6 @@ class ValidationMainTest(unittest.TestCase):
         self.assertGreater(len(submitted_labs), 0)
         self.assertGreater(len(missing_labs), 0)
 
-    @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def tearDown(self):
         nyc_bucket = self.storage_client.get_hpo_bucket('nyc')

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -280,7 +280,7 @@ class ValidationMainTest(unittest.TestCase):
         test_file_path = os.path.basename(test_util.PII_NAME_FILE)
 
         blob_name: str = f'{self.folder_prefix}{test_file_path}'
-        test_blob = self.storage_bucket.blob(blob_name)
+        test_blob = self.hpo_bucket.blob(blob_name)
         test_blob.upload_from_filename(test_util.PII_NAME_FILE)
         bucket_items = self.storage_client.get_bucket_items_metadata(
             self.hpo_bucket)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -15,12 +15,12 @@ import app_identity
 import common
 from constants import bq_utils as bq_consts
 from constants.validation import main as main_consts
-import gcs_utils
 from gcloud.gcs import StorageClient
 from utils.bq import get_client
 import resources
 from tests import test_util
 from validation import main
+from validation.app_errors import BucketDoesNotExistError
 from validation.metrics import required_labs
 
 
@@ -38,22 +38,22 @@ class ValidationMainTest(unittest.TestCase):
     @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def setUp(self):
-        self.hpo_id = test_util.FAKE_HPO_ID
-        self.hpo_bucket = gcs_utils.get_hpo_bucket(self.hpo_id)
-        self.project_id = app_identity.get_application_id()
-        self.rdr_dataset_id = bq_utils.get_rdr_dataset_id()
-        mock_get_hpo_name = mock.patch('validation.main.get_hpo_name')
+        self.hpo_id: str = test_util.FAKE_HPO_ID
+        self.project_id: str = app_identity.get_application_id()
+        self.rdr_dataset_id: str = bq_utils.get_rdr_dataset_id()
+        self.bigquery_dataset_id: str = bq_utils.get_dataset_id()
 
+        mock_get_hpo_name = mock.patch('validation.main.get_hpo_name')
         self.mock_get_hpo_name = mock_get_hpo_name.start()
         self.mock_get_hpo_name.return_value = 'Fake HPO'
         self.addCleanup(mock_get_hpo_name.stop)
 
-        self.folder_prefix = '2019-01-01-v1/'
+        self.folder_prefix: str = '2019-01-01-v1/'
 
         self.bq_client = get_client(self.project_id)
 
         self.storage_client = StorageClient(self.project_id)
-        self.storage_bucket = self.storage_client.get_bucket(self.hpo_bucket)
+        self.hpo_bucket = self.storage_client.get_hpo_bucket(self.hpo_id)
         self.storage_client.empty_bucket(self.hpo_bucket)
 
         test_util.delete_all_tables(self.dataset_id)
@@ -62,8 +62,8 @@ class ValidationMainTest(unittest.TestCase):
     @staticmethod
     def _create_drug_class_table(bigquery_dataset_id):
 
-        table_name = 'drug_class'
-        fields = [{
+        table_name: str = 'drug_class'
+        fields: list = [{
             "type": "integer",
             "name": "concept_id",
             "mode": "required"
@@ -113,16 +113,18 @@ class ValidationMainTest(unittest.TestCase):
     def test_all_files_unparseable_output(self):
         # TODO possible bug: if no pre-existing table, results in bq table not found error
         for cdm_table in common.SUBMISSION_FILES:
-            cdm_blob = self.storage_bucket.blob(
-                f'{self.folder_prefix}{cdm_table}')
+            cdm_blob = self.hpo_bucket.blob(f'{self.folder_prefix}{cdm_table}')
             cdm_blob.upload_from_string('.\n .')
 
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        folder_items = main.get_folder_items(bucket_items, self.folder_prefix)
-        expected_results = [(f, 1, 0, 0) for f in common.SUBMISSION_FILES]
-        r = main.validate_submission(self.hpo_id, self.hpo_bucket, folder_items,
-                                     self.folder_prefix)
-        self.assertSetEqual(set(expected_results), set(r['results']))
+        item_metadata: list = self.storage_client.get_bucket_items_metadata(
+            self.hpo_bucket)
+        folder_items: list = main.get_folder_items(item_metadata,
+                                                   self.folder_prefix)
+        expected_results: list = [(f, 1, 0, 0) for f in common.SUBMISSION_FILES]
+        actual: list = main.validate_submission(self.hpo_id, self.hpo_bucket,
+                                                folder_items,
+                                                self.folder_prefix)
+        self.assertSetEqual(set(expected_results), set(actual['results']))
 
     def test_bad_file_names(self):
         bad_file_names: list = [
@@ -133,17 +135,19 @@ class ValidationMainTest(unittest.TestCase):
         ]  # unsupported file extension
         expected_warnings: list = []
         for file_name in bad_file_names:
-            bad_blob = self.storage_bucket.blob(
-                f'{self.folder_prefix}{file_name}')
+            bad_blob = self.hpo_bucket.blob(f'{self.folder_prefix}{file_name}')
             bad_blob.upload_from_string('.')
 
             expected_item: tuple = (file_name, common.UNKNOWN_FILE)
             expected_warnings.append(expected_item)
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        folder_items = main.get_folder_items(bucket_items, self.folder_prefix)
-        r = main.validate_submission(self.hpo_id, self.hpo_bucket, folder_items,
-                                     self.folder_prefix)
-        self.assertCountEqual(expected_warnings, r['warnings'])
+        items_metadata: list = self.storage_client.get_bucket_items_metadata(
+            self.hpo_bucket)
+        folder_items: list = main.get_folder_items(items_metadata,
+                                                   self.folder_prefix)
+        actual: dict = main.validate_submission(self.hpo_id, self.hpo_bucket,
+                                                folder_items,
+                                                self.folder_prefix)
+        self.assertCountEqual(expected_warnings, actual['warnings'])
 
     @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
@@ -159,25 +163,28 @@ class ValidationMainTest(unittest.TestCase):
                 expected_result: tuple = (cdm_filename, 1, 1, 1)
                 test_filepath: str = os.path.join(test_util.FIVE_PERSONS_PATH,
                                                   cdm_filename)
-                test_blob = self.storage_bucket.blob(
+                test_blob = self.hpo_bucket.blob(
                     f'{self.folder_prefix}{cdm_filename}')
                 test_blob.upload_from_filename(test_filepath)
 
             else:
                 expected_result: tuple = (cdm_filename, 0, 0, 0)
             expected_results.append(expected_result)
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        folder_items = main.get_folder_items(bucket_items, self.folder_prefix)
-        r = main.validate_submission(self.hpo_id, self.hpo_bucket, folder_items,
-                                     self.folder_prefix)
-        self.assertSetEqual(set(r['results']), set(expected_results))
+        items_metadata: list = self.storage_client.get_bucket_items_metadata(
+            self.hpo_bucket)
+        folder_items: list = main.get_folder_items(items_metadata,
+                                                   self.folder_prefix)
+        actual: dict = main.validate_submission(self.hpo_id, self.hpo_bucket,
+                                                folder_items,
+                                                self.folder_prefix)
+        self.assertSetEqual(set(actual['results']), set(expected_results))
 
         # check tables exist and are clustered as expected
-        for table in resources.CDM_TABLES + common.PII_TABLES:
-            table_id = bq_utils.get_table_id(test_util.FAKE_HPO_ID, table)
+        for table in f'{resources.CDM_TABLES}{common.PII_TABLES}':
+            table_id: str = bq_utils.get_table_id(test_util.FAKE_HPO_ID, table)
             table_info = bq_utils.get_table_info(table_id)
             fields = resources.fields_for(table)
-            field_names = [field['name'] for field in fields]
+            field_names: list = [field['name'] for field in fields]
             if 'person_id' in field_names:
                 self.table_has_clustering(table_info)
 
@@ -189,23 +196,25 @@ class ValidationMainTest(unittest.TestCase):
 
         for fname in common.AOU_REQUIRED_FILES:
             blob_name: str = f'{self.folder_prefix}{fname}'
-            test_blob = self.storage_bucket.blob(blob_name)
+            test_blob = self.hpo_bucket.blob(blob_name)
             test_blob.upload_from_string('\n')
 
             sleep(1)
 
         blob_name: str = f'{self.folder_prefix}{common.PROCESSED_TXT}'
-        test_blob = self.storage_bucket.blob(blob_name)
+        test_blob = self.hpo_bucket.blob(blob_name)
         test_blob.upload_from_string('\n')
 
-        bucket_items = self.storage_client.get_bucket_items_metadata(
-            self.storage_bucket)
-        result = main._get_submission_folder(self.hpo_bucket,
-                                             bucket_items,
+        items_metadata: list = self.storage_client.get_bucket_items_metadata(
+            self.hpo_bucket)
+
+        #! to use a bucket!
+        result = main._get_submission_folder(self.hpo_bucket.name,
+                                             items_metadata,
                                              force_process=False)
         self.assertIsNone(result)
-        result = main._get_submission_folder(self.hpo_bucket,
-                                             bucket_items,
+        result = main._get_submission_folder(self.hpo_bucket.name,
+                                             items_metadata,
                                              force_process=True)
         self.assertEqual(result, self.folder_prefix)
 
@@ -217,44 +226,47 @@ class ValidationMainTest(unittest.TestCase):
             test_filename: str = os.path.basename(cdm_pathfile)
 
             blob_name: str = f'{self.folder_prefix}{test_filename}'
-            test_blob = self.storage_bucket.blob(blob_name)
+            test_blob = self.hpo_bucket.blob(blob_name)
             test_blob.upload_from_filename(cdm_pathfile)
 
             blob_name: str = f'{self.folder_prefix}{self.folder_prefix}{test_filename}'
-            test_blob = self.storage_bucket.blob(blob_name)
+            test_blob = self.hpo_bucket.blob(blob_name)
             test_blob.upload_from_filename(cdm_pathfile)
+
+        drc_bucket = self.storage_client.get_drc_bucket()
 
         main.app.testing = True
         with main.app.test_client() as c:
             c.get(test_util.COPY_HPO_FILES_URL)
-            prefix: str = f'{test_util.FAKE_HPO_ID}/{self.hpo_bucket}/{self.folder_prefix}'
-            expected_bucket_items = [
+            prefix: str = f'{test_util.FAKE_HPO_ID}/{self.hpo_bucket.name}/{self.folder_prefix}'
+            expected_metadata: list = [
                 f'{prefix}{item.split(os.sep)[-1]}'
                 for item in test_util.FIVE_PERSONS_FILES
             ]
-            expected_bucket_items.extend([
+            expected_metadata.extend([
                 f'{prefix}{self.folder_prefix}{item.split(os.sep)[-1]}'
                 for item in test_util.FIVE_PERSONS_FILES
             ])
 
-            list_bucket_result = gcs_utils.list_bucket(
-                gcs_utils.get_drc_bucket())
-            actual_bucket_items = [item['name'] for item in list_bucket_result]
-            self.assertSetEqual(set(expected_bucket_items),
-                                set(actual_bucket_items))
+            raw_metadata: list = self.storage_client.get_bucket_items_metadata(
+                drc_bucket)
+            actual_metadata: list = [item['name'] for item in raw_metadata]
+            self.assertSetEqual(set(expected_metadata), set(actual_metadata))
 
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_target_bucket_upload(self):
-        bucket_nyc = gcs_utils.get_hpo_bucket(test_util.NYC_HPO_ID)
-        folder_prefix = 'test-folder-fake/'
+        bucket_nyc = self.storage_client.get_hpo_bucket('nyc')
+        folder_prefix: str = 'test-folder-fake/'
         self.storage_client.empty_bucket(bucket_nyc)
 
         main._upload_achilles_files(hpo_id=None,
                                     folder_prefix=folder_prefix,
                                     target_bucket=bucket_nyc)
-        actual_bucket_files = set(
-            [item['name'] for item in gcs_utils.list_bucket(bucket_nyc)])
+        actual_bucket_files = set([
+            item['name'] for item in
+            self.storage_client.get_bucket_items_metadata(bucket_nyc)
+        ])
         expected_bucket_files = set([
             f'test-folder-fake/{item}'
             for item in resources.ALL_ACHILLES_INDEX_FILES
@@ -307,26 +319,29 @@ class ValidationMainTest(unittest.TestCase):
         test_file_names: list = [os.path.basename(f) for f in test_file_paths]
 
         blob_name: str = f'{self.folder_prefix}{os.path.basename(test_util.PII_NAME_FILE)}'
-        test_blob = self.storage_bucket.blob(blob_name)
+        test_blob = self.hpo_bucket.blob(blob_name)
         test_blob.upload_from_filename(test_util.PII_NAME_FILE)
 
         blob_name: str = f'{self.folder_prefix}{os.path.basename(test_util.PII_MRN_BAD_PERSON_ID_FILE)}'
-        test_blob = self.storage_bucket.blob(blob_name)
+        test_blob = self.hpo_bucket.blob(blob_name)
         test_blob.upload_from_filename(test_util.PII_MRN_BAD_PERSON_ID_FILE)
 
-        rs = resources.csv_to_list(test_util.PII_FILE_LOAD_RESULT_CSV)
-        expected_results = [(r['file_name'], int(r['found']), int(r['parsed']),
-                             int(r['loaded'])) for r in rs]
+        rs: list = resources.csv_to_list(test_util.PII_FILE_LOAD_RESULT_CSV)
+        expected_results: list = [(r['file_name'], int(r['found']),
+                                   int(r['parsed']), int(r['loaded']))
+                                  for r in rs]
         for f in common.SUBMISSION_FILES:
             if f not in test_file_names:
-                expected_result = (f, 0, 0, 0)
+                expected_result: tuple = (f, 0, 0, 0)
                 expected_results.append(expected_result)
 
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
+        bucket_items: list = self.storage_client.get_bucket_items_metadata(
+            self.hpo_bucket)
         folder_items = main.get_folder_items(bucket_items, self.folder_prefix)
-        r = main.validate_submission(self.hpo_id, self.hpo_bucket, folder_items,
-                                     self.folder_prefix)
-        self.assertSetEqual(set(expected_results), set(r['results']))
+        actual: dict = main.validate_submission(self.hpo_id, self.hpo_bucket,
+                                                folder_items,
+                                                self.folder_prefix)
+        self.assertSetEqual(set(expected_results), set(actual['results']))
 
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
@@ -350,8 +365,8 @@ class ValidationMainTest(unittest.TestCase):
         ) - datetime.timedelta(minutes=7)
 
         for cdm_file in test_util.FIVE_PERSONS_FILES:
-            blob_name = f'{self.folder_prefix}{os.path.basename(cdm_file)}'
-            test_blob = self.storage_bucket.blob(blob_name)
+            blob_name: str = f'{self.folder_prefix}{os.path.basename(cdm_file)}'
+            test_blob = self.hpo_bucket.blob(blob_name)
             test_blob.upload_from_filename(cdm_file)
 
         # load person table in RDR
@@ -367,15 +382,17 @@ class ValidationMainTest(unittest.TestCase):
             project_id=self.project_id, dataset_id=self.dataset_id)
 
         main.app.testing = True
-        with main.app.test_client() as c:
-            c.get(test_util.VALIDATE_HPO_FILES_URL)
-            actual_result = self.storage_bucket.get_blob(
+        with main.app.test_client() as test_client:
+            test_client.get(test_util.VALIDATE_HPO_FILES_URL)
+            actual_result = self.hpo_bucket.get_blob(
                 f'{self.folder_prefix}{common.RESULTS_HTML}').download_as_text(
                 )
 
         # ensure emails are not sent
-        bucket_items = gcs_utils.list_bucket(self.hpo_bucket)
-        folder_items = main.get_folder_items(bucket_items, self.folder_prefix)
+        items_metadata: list = self.storage_client.get_bucket_items_metadata(
+            self.hpo_bucket)
+        folder_items: list = main.get_folder_items(items_metadata,
+                                                   self.folder_prefix)
         self.assertFalse(main.is_first_validation_run(folder_items))
 
         # parse html
@@ -387,7 +404,7 @@ class ValidationMainTest(unittest.TestCase):
         self.assertEqual('Count', table_headers[1].get_text())
 
         table_rows = missing_pii_html_table.find_next('tbody').find_all('tr')
-        missing_record_types = [
+        missing_record_types: list = [
             table_row.find('td').text for table_row in table_rows
         ]
         self.assertIn(main_consts.EHR_NO_PII, missing_record_types)
@@ -395,7 +412,7 @@ class ValidationMainTest(unittest.TestCase):
 
         # the missing from RDR component is obsolete (see DC-1932)
         # this is to confirm it was removed successfully from the report
-        rdr_date = '2020-01-01'
+        rdr_date: str = '2020-01-01'
         self.assertNotIn(main_consts.EHR_NO_RDR.format(date=rdr_date),
                          missing_record_types)
         self.assertIn(main_consts.EHR_NO_PARTICIPANT_MATCH,
@@ -409,28 +426,33 @@ class ValidationMainTest(unittest.TestCase):
         self.assertEqual('Found', table_headers[2].get_text())
 
         table_rows = required_lab_html_table.find_next('tbody').find_all('tr')
-        table_rows_last_column = [
+        table_rows_last_column: list = [
             table_row.find_all('td')[-1] for table_row in table_rows
         ]
-        submitted_labs = [
+        submitted_labs: list = [
             row for row in table_rows_last_column
             if 'result-1' in row.attrs['class']
         ]
-        missing_labs = [
+        missing_labs: list = [
             row for row in table_rows_last_column
             if 'result-0' in row.attrs['class']
         ]
-        self.assertTrue(len(table_rows) > 0)
-        self.assertTrue(len(submitted_labs) > 0)
-        self.assertTrue(len(missing_labs) > 0)
+
+        self.assertGreater(len(table_rows), 0)
+        self.assertGreater(len(submitted_labs), 0)
+        self.assertGreater(len(missing_labs), 0)
 
     @mock.patch("gcs_utils.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def tearDown(self):
+        nyc_bucket = self.storage_client.get_hpo_bucket('nyc')
+        self.storage_client.empty_bucket(nyc_bucket)
+
+        self.storage_client.empty_bucket(self.drc_bucket)
+        self.drc_bucket = self.storage_client.get_drc_bucket()
+
         self.storage_client.empty_bucket(self.hpo_bucket)
-        bucket_nyc = gcs_utils.get_hpo_bucket(test_util.NYC_HPO_ID)
-        self.storage_client.empty_bucket(bucket_nyc)
-        self.storage_client.empty_bucket(gcs_utils.get_drc_bucket())
+
         test_util.delete_all_tables(self.dataset_id)
 
     @classmethod

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -208,7 +208,7 @@ class ValidationMainTest(unittest.TestCase):
         items_metadata: list = self.storage_client.get_bucket_items_metadata(
             self.hpo_bucket)
 
-        #! to use a bucket!
+        # TODO use a bucket!
         result = main._get_submission_folder(self.hpo_bucket.name,
                                              items_metadata,
                                              force_process=False)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -208,6 +208,9 @@ class ValidationMainTest(unittest.TestCase):
         items_metadata: list = self.storage_client.get_bucket_items_metadata(
             self.hpo_bucket)
 
+        #! may need to adjust timedata here
+        #! See above timedate changeq
+
         # TODO use a bucket!
         result = main._get_submission_folder(self.hpo_bucket.name,
                                              items_metadata,
@@ -391,6 +394,8 @@ class ValidationMainTest(unittest.TestCase):
         # ensure emails are not sent
         items_metadata: list = self.storage_client.get_bucket_items_metadata(
             self.hpo_bucket)
+
+        #! May need to adjust time here
         folder_items: list = main.get_folder_items(items_metadata,
                                                    self.folder_prefix)
         self.assertFalse(main.is_first_validation_run(folder_items))

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -343,6 +343,7 @@ class ValidationMainTest(unittest.TestCase):
                                                 self.folder_prefix)
         self.assertSetEqual(set(expected_results), set(actual['results']))
 
+    @mock.patch('constants.validation.main.SUBMISSION_LAG_TIME_MINUTES', 0)
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch('validation.main.get_participant_validation_summary_query')
     @mock.patch('validation.main.setup_and_validate_participants')

--- a/tests/unit_tests/data_steward/validation/app_errors_test.py
+++ b/tests/unit_tests/data_steward/validation/app_errors_test.py
@@ -77,7 +77,6 @@ class AppErrorHandlersTest(TestCase):
             self.assertEqual(view, app_errors.DEFAULT_VIEW_MESSAGE)
             self.assertTrue(code, app_errors.DEFAULT_ERROR_STATUS)
 
-    @mock.patch('gcs_utils.list_bucket')
     @mock.patch('api_util.check_cron')
     def test_handlers_fire(self, mock_check_cron, mock_list_bucket):
         """

--- a/tests/unit_tests/data_steward/validation/app_errors_test.py
+++ b/tests/unit_tests/data_steward/validation/app_errors_test.py
@@ -78,12 +78,12 @@ class AppErrorHandlersTest(TestCase):
             self.assertTrue(code, app_errors.DEFAULT_ERROR_STATUS)
 
     @mock.patch('api_util.check_cron')
-    def test_handlers_fire(self, mock_check_cron, mock_list_bucket):
+    def test_handlers_fire(self, mock_check_cron):
         """
         Test the os handler method fires as expected when an OSError is raised.
         """
-        mock_list_bucket.side_effect = HttpError(mock.Mock(status=404),
-                                                 'not found'.encode())
+        # mock_list_bucket.side_effect = HttpError(mock.Mock(status=404),
+        #                                          'not found'.encode())
         hpo_id = 'no_bucket_exists'
         with main.app.test_client() as tc:
             os.environ.pop(f"BUCKET_NAME_{hpo_id.upper()}", None)

--- a/tests/unit_tests/data_steward/validation/app_errors_test.py
+++ b/tests/unit_tests/data_steward/validation/app_errors_test.py
@@ -82,8 +82,6 @@ class AppErrorHandlersTest(TestCase):
         """
         Test the os handler method fires as expected when an OSError is raised.
         """
-        # mock_list_bucket.side_effect = HttpError(mock.Mock(status=404),
-        #                                          'not found'.encode())
         hpo_id = 'no_bucket_exists'
         with main.app.test_client() as tc:
             os.environ.pop(f"BUCKET_NAME_{hpo_id.upper()}", None)

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -53,13 +53,13 @@ class ValidationMainTest(TestCase):
 
     def test_retention_checks_list_submitted_bucket_items(self):
         #Define times to use
-        within_retention = datetime.datetime.utcnow() - datetime.timedelta(
+        within_retention = datetime.datetime.now(tz=None) - datetime.timedelta(
             days=25)
-        outside_retention = datetime.datetime.utcnow() - datetime.timedelta(
+        outside_retention = datetime.datetime.now(tz=None) - datetime.timedelta(
             days=29)
-        before_lag_time = datetime.datetime.utcnow() - datetime.timedelta(
+        before_lag_time = datetime.datetime.now(tz=None) - datetime.timedelta(
             minutes=3)
-        after_lag_time = datetime.datetime.utcnow() - datetime.timedelta(
+        after_lag_time = datetime.datetime.now(tz=None) - datetime.timedelta(
             minutes=7)
 
         # If any required files are missing, nothing should be returned

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -400,9 +400,11 @@ class ValidationMainTest(TestCase):
         mock_folder_items.assert_called_once_with(
             mock_client.get_bucket_items_metadata.return_value, submission_path)
         mock_validation.assert_called()
-        mock_validation.assert_called_once_with(fake_hpo, 'fake_bucket_name',
-                                                mock_folder_items.return_value,
-                                                submission_path)
+        mock_validation.assert_called_once_with(
+            fake_hpo,
+            mock_bucket,  #'fake_bucket_name',
+            mock_folder_items.return_value,
+            submission_path)
         mock_run_achilles.assert_called()
         mock_export.assert_called()
         mock_export.assert_called_once_with(datasource_id=fake_hpo,

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -4,7 +4,6 @@ Unit test components of data_steward.validation.main
 # Python imports
 import datetime
 import re
-import os
 from unittest import TestCase, mock
 
 # Project imports
@@ -60,7 +59,6 @@ class ValidationMainTest(TestCase):
             days=29)
         before_lag_time = datetime.datetime.today() - datetime.timedelta(
             minutes=3)
-
         after_lag_time = datetime.datetime.today() - datetime.timedelta(
             minutes=7)
 
@@ -259,7 +257,10 @@ class ValidationMainTest(TestCase):
 
         mock_perform_validation_on_file.side_effect = perform_validation_on_file
 
-        actual_result = main.validate_submission(self.hpo_id, self.hpo_bucket,
+        mock_bucket = mock.MagicMock()
+        type(mock_bucket).name = mock.PropertyMock(return_value=self.hpo_bucket)
+
+        actual_result = main.validate_submission(self.hpo_id, mock_bucket,
                                                  folder_items, folder_prefix)
         self.assertCountEqual(expected_results, actual_result.get('results'))
         self.assertCountEqual(expected_errors, actual_result.get('errors'))

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -53,13 +53,13 @@ class ValidationMainTest(TestCase):
 
     def test_retention_checks_list_submitted_bucket_items(self):
         #Define times to use
-        within_retention = datetime.datetime.today() - datetime.timedelta(
+        within_retention = datetime.datetime.utcnow() - datetime.timedelta(
             days=25)
-        outside_retention = datetime.datetime.today() - datetime.timedelta(
+        outside_retention = datetime.datetime.utcnow() - datetime.timedelta(
             days=29)
-        before_lag_time = datetime.datetime.today() - datetime.timedelta(
+        before_lag_time = datetime.datetime.utcnow() - datetime.timedelta(
             minutes=3)
-        after_lag_time = datetime.datetime.today() - datetime.timedelta(
+        after_lag_time = datetime.datetime.utcnow() - datetime.timedelta(
             minutes=7)
 
         # If any required files are missing, nothing should be returned

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -400,11 +400,9 @@ class ValidationMainTest(TestCase):
         mock_folder_items.assert_called_once_with(
             mock_client.get_bucket_items_metadata.return_value, submission_path)
         mock_validation.assert_called()
-        mock_validation.assert_called_once_with(
-            fake_hpo,
-            mock_bucket,  #'fake_bucket_name',
-            mock_folder_items.return_value,
-            submission_path)
+        mock_validation.assert_called_once_with(fake_hpo, mock_bucket,
+                                                mock_folder_items.return_value,
+                                                submission_path)
         mock_run_achilles.assert_called()
         mock_export.assert_called()
         mock_export.assert_called_once_with(datasource_id=fake_hpo,


### PR DESCRIPTION
- The integration tests in main_test.py use gcs_utils in several places. These tests require updates.
- Sections of these tests (and the code under test) rely on strings of date and times.  These are then converted to `datetime` objects later on.  The new client returns these dates and times as `datetime` objects directly.  However, these objects supply time zone-aware objects (UTC). In the past these `datetime` objects were time zone naive, so keeping compatibility required time zone information stripped out.