### PR TITLE
[DC-2083] Modernize integration tests in retract_data_gcs_test.py

### DIFF
--- a/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
@@ -56,9 +56,11 @@ class RetractDataGcsTest(TestCase):
                         expected_lines_post[file_name].append(line)
 
                 # write file to cloud for testing
-                blob = self.gcs_bucket.blob(self.folder_prefix_1 + file_name)
+                blob = self.gcs_bucket.blob(
+                    f'{self.folder_prefix_1}{file_name}')
                 blob.upload_from_file(f, rewind=True, content_type='text/csv')
-                blob = self.gcs_bucket.blob(self.folder_prefix_2 + file_name)
+                blob = self.gcs_bucket.blob(
+                    f'{self.folder_prefix_2}{file_name}')
                 blob.upload_from_file(f, rewind=True, content_type='text/csv')
 
         rd.run_gcs_retraction(self.project_id,
@@ -73,7 +75,7 @@ class RetractDataGcsTest(TestCase):
         total_lines_post = {}
         for file_path in test_util.FIVE_PERSONS_FILES:
             file_name = file_path.split('/')[-1]
-            blob = self.gcs_bucket.blob(self.folder_prefix_1 + file_name)
+            blob = self.gcs_bucket.blob(f'{self.folder_prefix_1}{file_name}')
             actual_result_contents = blob.download_as_string().split(b'\n')
             # convert to list and remove header and last list item since it is a newline
             total_lines_post[file_name] = actual_result_contents[1:-1]
@@ -106,9 +108,11 @@ class RetractDataGcsTest(TestCase):
                             expected_lines_post[file_name].append(line)
 
                 # write file to cloud for testing
-                blob = self.gcs_bucket.blob(self.folder_prefix_1 + file_name)
+                blob = self.gcs_bucket.blob(
+                    f'{self.folder_prefix_1}{file_name}')
                 blob.upload_from_file(f, rewind=True, content_type='text/csv')
-                blob = self.gcs_bucket.blob(self.folder_prefix_2 + file_name)
+                blob = self.gcs_bucket.blob(
+                    f'{self.folder_prefix_2}{file_name}')
                 blob.upload_from_file(f, rewind=True, content_type='text/csv')
 
         rd.run_gcs_retraction(self.project_id,
@@ -123,7 +127,7 @@ class RetractDataGcsTest(TestCase):
         total_lines_post = {}
         for file_path in test_util.FIVE_PERSONS_FILES:
             file_name = file_path.split('/')[-1]
-            blob = self.gcs_bucket.blob(self.folder_prefix_1 + file_name)
+            blob = self.gcs_bucket.blob(f'{self.folder_prefix_1}{file_name}')
             actual_result_contents = blob.download_as_string().split(b'\n')
             # convert to list and remove header and last list item since it is a newline
             total_lines_post[file_name] = actual_result_contents[1:-1]

--- a/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
@@ -74,7 +74,7 @@ class RetractDataGcsTest(TestCase):
                               self.hpo_id,
                               folder='all_folders',
                               force_flag=True,
-                              bucket=self.gcs_bucket.name,
+                              bucket=self.gcs_bucket,
                               site_bucket=self.site_bucket)
 
         total_lines_post = {}
@@ -130,7 +130,7 @@ class RetractDataGcsTest(TestCase):
                               self.hpo_id,
                               folder='all_folders',
                               force_flag=True,
-                              bucket=self.gcs_bucket.name,
+                              bucket=self.gcs_bucket,
                               site_bucket=self.site_bucket)
 
         total_lines_post = {}

--- a/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
@@ -33,7 +33,7 @@ class RetractDataGcsTest(TestCase):
         self.project_id = 'project_id'
         self.sandbox_dataset_id = os.environ.get('UNIONED_DATASET_ID')
         self.pid_table_id = 'pid_table'
-        self.context_type = 'text/csv'
+        self.content_type = 'text/csv'
         self.gcs_bucket = self.client.get_hpo_bucket(self.hpo_id)
         self.client.empty_bucket(self.gcs_bucket)
 
@@ -61,12 +61,12 @@ class RetractDataGcsTest(TestCase):
                     f'{self.folder_prefix_1}{file_name}')
                 blob.upload_from_file(f,
                                       rewind=True,
-                                      content_type=self.context_type)
+                                      content_type=self.content_type)
                 blob = self.gcs_bucket.blob(
                     f'{self.folder_prefix_2}{file_name}')
                 blob.upload_from_file(f,
                                       rewind=True,
-                                      content_type=self.context_type)
+                                      content_type=self.content_type)
 
         rd.run_gcs_retraction(self.project_id,
                               self.sandbox_dataset_id,
@@ -117,12 +117,12 @@ class RetractDataGcsTest(TestCase):
                     f'{self.folder_prefix_1}{file_name}')
                 blob.upload_from_file(f,
                                       rewind=True,
-                                      content_type=self.context_type)
+                                      content_type=self.content_type)
                 blob = self.gcs_bucket.blob(
                     f'{self.folder_prefix_2}{file_name}')
                 blob.upload_from_file(f,
                                       rewind=True,
-                                      content_type=self.context_type)
+                                      content_type=self.content_type)
 
         rd.run_gcs_retraction(self.project_id,
                               self.sandbox_dataset_id,

--- a/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py
@@ -33,6 +33,7 @@ class RetractDataGcsTest(TestCase):
         self.project_id = 'project_id'
         self.sandbox_dataset_id = os.environ.get('UNIONED_DATASET_ID')
         self.pid_table_id = 'pid_table'
+        self.context_type = 'text/csv'
         self.gcs_bucket = self.client.get_hpo_bucket(self.hpo_id)
         self.client.empty_bucket(self.gcs_bucket)
 
@@ -58,10 +59,14 @@ class RetractDataGcsTest(TestCase):
                 # write file to cloud for testing
                 blob = self.gcs_bucket.blob(
                     f'{self.folder_prefix_1}{file_name}')
-                blob.upload_from_file(f, rewind=True, content_type='text/csv')
+                blob.upload_from_file(f,
+                                      rewind=True,
+                                      content_type=self.context_type)
                 blob = self.gcs_bucket.blob(
                     f'{self.folder_prefix_2}{file_name}')
-                blob.upload_from_file(f, rewind=True, content_type='text/csv')
+                blob.upload_from_file(f,
+                                      rewind=True,
+                                      content_type=self.context_type)
 
         rd.run_gcs_retraction(self.project_id,
                               self.sandbox_dataset_id,
@@ -110,10 +115,14 @@ class RetractDataGcsTest(TestCase):
                 # write file to cloud for testing
                 blob = self.gcs_bucket.blob(
                     f'{self.folder_prefix_1}{file_name}')
-                blob.upload_from_file(f, rewind=True, content_type='text/csv')
+                blob.upload_from_file(f,
+                                      rewind=True,
+                                      content_type=self.context_type)
                 blob = self.gcs_bucket.blob(
                     f'{self.folder_prefix_2}{file_name}')
-                blob.upload_from_file(f, rewind=True, content_type='text/csv')
+                blob.upload_from_file(f,
+                                      rewind=True,
+                                      content_type=self.context_type)
 
         rd.run_gcs_retraction(self.project_id,
                               self.sandbox_dataset_id,


### PR DESCRIPTION
*Removes `gcs_utils` from tests/integration_tests/data_steward/retraction/retract_data_gcs_test.py.
*Implements the new `StorageClient` in data_steward/retraction/retract_data_gcs.py