### PR TITLE
[DC-2131] Add street 1 & 2 combined comparison to DRC street address comparison

### DIFF
--- a/data_steward/validation/participants/validate.py
+++ b/data_steward/validation/participants/validate.py
@@ -133,11 +133,38 @@ def identify_rdr_ehr_match(client,
         hpo_person_table_id=hpo_person_table_id,
         ps_api_table_id=ps_api_table_id,
         drc_dataset_id=drc_dataset_id,
+        ehr_ops_dataset_id=ehr_ops_dataset_id)
+
+    LOGGER.info(f"Matching fields for {hpo_id}.")
+    LOGGER.info(f"Running the following update statement: {match_query}.")
+
+    job = client.query(match_query)
+    job.result()
+
+    match_query = consts.MATCH_STREET_1_2_COMBINED_QUERY.render(
+        project_id=project_id,
+        id_match_table_id=id_match_table_id,
+        hpo_pii_address_table_id=hpo_pii_address_table_id,
+        hpo_location_table_id=hpo_location_table_id,
+        ps_api_table_id=ps_api_table_id,
+        drc_dataset_id=drc_dataset_id,
+        ehr_ops_dataset_id=ehr_ops_dataset_id)
+
+    LOGGER.info(f"Matching fields for {hpo_id}.")
+    LOGGER.info(f"Running the following update statement: {match_query}.")
+
+    job = client.query(match_query)
+    job.result()
+
+    match_query = consts.MATCH_STREET_QUERY.render(
+        project_id=project_id,
+        id_match_table_id=id_match_table_id,
+        hpo_pii_address_table_id=hpo_pii_address_table_id,
+        hpo_location_table_id=hpo_location_table_id,
+        ps_api_table_id=ps_api_table_id,
+        drc_dataset_id=drc_dataset_id,
         ehr_ops_dataset_id=ehr_ops_dataset_id,
-        match=consts.MATCH,
-        no_match=consts.NO_MATCH,
-        missing_rdr=consts.MISSING_RDR,
-        missing_ehr=consts.MISSING_EHR)
+        match=consts.MATCH)
 
     LOGGER.info(f"Matching fields for {hpo_id}.")
     LOGGER.info(f"Running the following update statement: {match_query}.")

--- a/data_steward/validation/participants/validate.py
+++ b/data_steward/validation/participants/validate.py
@@ -142,23 +142,12 @@ def identify_rdr_ehr_match(client,
         hpo_location_table_id=hpo_location_table_id,
         ps_api_table_id=ps_api_table_id,
         drc_dataset_id=drc_dataset_id,
-        ehr_ops_dataset_id=ehr_ops_dataset_id)
-
-    street_match_query = consts.MATCH_STREET_QUERY.render(
-        project_id=project_id,
-        id_match_table_id=id_match_table_id,
-        hpo_pii_address_table_id=hpo_pii_address_table_id,
-        hpo_location_table_id=hpo_location_table_id,
-        ps_api_table_id=ps_api_table_id,
-        drc_dataset_id=drc_dataset_id,
         ehr_ops_dataset_id=ehr_ops_dataset_id,
         match=consts.MATCH)
 
     LOGGER.info(f"Matching fields for {hpo_id}.")
 
-    for query in [
-            fields_match_query, street_combined_match_query, street_match_query
-    ]:
+    for query in [fields_match_query, street_combined_match_query]:
         LOGGER.info(f"Running the following update statement: {query}.")
         job = client.query(query)
         job.result()

--- a/data_steward/validation/participants/validate.py
+++ b/data_steward/validation/participants/validate.py
@@ -122,7 +122,7 @@ def identify_rdr_ehr_match(client,
         job = client.query(query)
         job.result()
 
-    match_query = consts.MATCH_FIELDS_QUERY.render(
+    fields_match_query = consts.MATCH_FIELDS_QUERY.render(
         project_id=project_id,
         id_match_table_id=id_match_table_id,
         hpo_pii_address_table_id=hpo_pii_address_table_id,
@@ -135,13 +135,7 @@ def identify_rdr_ehr_match(client,
         drc_dataset_id=drc_dataset_id,
         ehr_ops_dataset_id=ehr_ops_dataset_id)
 
-    LOGGER.info(f"Matching fields for {hpo_id}.")
-    LOGGER.info(f"Running the following update statement: {match_query}.")
-
-    job = client.query(match_query)
-    job.result()
-
-    match_query = consts.MATCH_STREET_1_2_COMBINED_QUERY.render(
+    street_combined_match_query = consts.MATCH_STREET_COMBINED_QUERY.render(
         project_id=project_id,
         id_match_table_id=id_match_table_id,
         hpo_pii_address_table_id=hpo_pii_address_table_id,
@@ -150,13 +144,7 @@ def identify_rdr_ehr_match(client,
         drc_dataset_id=drc_dataset_id,
         ehr_ops_dataset_id=ehr_ops_dataset_id)
 
-    LOGGER.info(f"Matching fields for {hpo_id}.")
-    LOGGER.info(f"Running the following update statement: {match_query}.")
-
-    job = client.query(match_query)
-    job.result()
-
-    match_query = consts.MATCH_STREET_QUERY.render(
+    street_match_query = consts.MATCH_STREET_QUERY.render(
         project_id=project_id,
         id_match_table_id=id_match_table_id,
         hpo_pii_address_table_id=hpo_pii_address_table_id,
@@ -167,10 +155,13 @@ def identify_rdr_ehr_match(client,
         match=consts.MATCH)
 
     LOGGER.info(f"Matching fields for {hpo_id}.")
-    LOGGER.info(f"Running the following update statement: {match_query}.")
 
-    job = client.query(match_query)
-    job.result()
+    for query in [
+            fields_match_query, street_combined_match_query, street_match_query
+    ]:
+        LOGGER.info(f"Running the following update statement: {query}.")
+        job = client.query(query)
+        job.result()
 
 
 def setup_and_validate_participants(hpo_id):

--- a/tests/integration_tests/data_steward/validation/participants/validate_test.py
+++ b/tests/integration_tests/data_steward/validation/participants/validate_test.py
@@ -47,11 +47,11 @@ INSERT INTO `{{project_id}}.{{drc_dataset_id}}.{{ps_values_table_id}}`
 VALUES 
     (1, 'John', 'Jacob', 'Smith', '1 Government Dr', '', 'St. Louis', 'MO', '63110', 'john@gmail.com', '(123)456-7890', date('1978-10-01'), 'SexAtBirth_Female'),
     (2, 'Rebecca', 'Howard', 'Glass', '476 5th Ave', '', 'New York', 'NY', '10018', 'rebecca@gmail.com', '1234567890', date('1984-10-23'), 'SexAtBirth_Male'),
-    (3, 'Sam', 'Felix Rose', 'Smith', 'University St', 'APT 7D', 'Andersen AFB', 'ABCD', '96923', 'samwjeo', '123456-7890', date('2003-01-05'), 'SexAtBirth_SexAtBirthNoneOfThese'),
-    (4, 'Chris', 'Arthur', 'Smith', '915 PR-17', 'Apt 7D', NULL, 'PIIState_PR', '00921', 'chris@gmail.com', '1234567890', date('2003-05-1'), 'SexAtBirth_Intersex'),
-    (5, 'John', NULL, 'Doe', NULL, '', 'Trenton', 'NJ', '08611', '  johndoe@gmail.com  ', '', date('1993-11-01'), 'PMI_Skip'),
+    (3, 'Sam', 'Felix Rose', 'Smith', '1 2nd 3 4th St', 'APT 7D', 'Andersen AFB', 'ABCD', '96923', 'samwjeo', '123456-7890', date('2003-01-05'), 'SexAtBirth_SexAtBirthNoneOfThese'),
+    (4, 'Chris', 'Arthur', 'Smith', '1234 4th ave', 'apt 15B', NULL, 'PIIState_PR', '00921', 'chris@gmail.com', '1234567890', date('2003-05-1'), 'SexAtBirth_Intersex'),
+    (5, 'John', NULL, 'Doe', NULL, '915 PR-17, Apt 7D', 'Trenton', 'NJ', '08611', '  johndoe@gmail.com  ', '', date('1993-11-01'), 'PMI_Skip'),
     (6, 'Rebecca', '', 'Mayers-James', '1501 Riverplace Blvd', '', 'Jacksonville', 'FL', '32207', 'rebeccamayers@gmail.co', '814321-0987', NULL, 'PMI_PreferNotToAnswer'),
-    (7, 'Leo', '', "O’Keefe", '1 2nd 3 4th St', '', 'Cincinnati', 'OH', '45202', 'leo@yahoo.com', '0987654321', date('1981-10-01'), 'UNSET'),
+    (7, 'Leo', '', "O’Keefe", NULL, '', 'Cincinnati', 'OH', '45202', 'leo@yahoo.com', '0987654321', date('1981-10-01'), 'UNSET'),
     (8, '1ois', 'Frankl1n', 'Rhodes', '42 Nason St', '', 'Maynard', 'MA', '01754', '', '1-800-800-0911', date('1999-12-01'), 'SexAtBirth_SexAtBirthNoneOfThese'),
     (9, 'Jack', 'Isaac', 'Dean', '777 NE Martin Luther King Jr Blvd', '', 'Portland', 'OR', '97232', 'jd@gmail.com', '555-555-1234', date('2002-03-14'), 'SexAtBirth_Female')
 """)
@@ -266,43 +266,45 @@ class ValidateTest(TestCase):
         VALUES
             (11, ' 1 government drive ', '', 'Saint Louis ', 'mo', '63110'),
             (12, 'Wrong street', 'Wrong apartment', 'Wrong city', 'NJ', '12345'),
-            (13, 'University Street', 'Apartment 7 D', 'Andersen Air Force Base', 'Gu', '  96923  '),
-            (14, '915 pr-17', 'Apt 7-D', ' San Juan ', 'pr', '921'),
-            (15, '50 Riverview Plaza', '', NULL, 'NJ', '08611-1234'),
+            (13, '1st 2 3rd 4 Street', 'Apartment 7 D', 'Andersen Air Force Base', 'Gu', '  96923  '),
+            (14, '1234 4th Ave, APT 15B', '', ' San Juan ', 'pr', '921'),
+            (15, '50 Riverview Plaza', '915 pr-17, Apt 7-D', NULL, 'NJ', '08611-1234'),
             (16, NULL, '', 'Jacksonville', 'FL', '32207  5678'),
-            (17, '1st 2 3rd 4 Street', '', 'Cincinnati', 'OH', '45202'),
+            (17, '', NULL, 'Cincinnati', 'OH', '45202'),
             (18, '42  Nason   St', '', 'Maynard', 'MA', '01754')
         """)
         """ 
         Note: Each test entry is testing for the following test cases:
             11: street_1 - match (dr vs drive, whitespace padding, uppercase vs lowercase)
             12: street_1 - no_match (different address)
-            13: street_1 - match (St vs Street)
-            14: street_1 - match (uppercase vs lowercase)
+            13: street_1 - match (St vs Street, 1st vs 1, 2nd vs 2, 3rd vs 3, 4th vs 4)
+            14: street_1 - match (based on street_1 + street_2)
             15: street_1 - missing_rdr
             16: street_1 - missing_ehr
-            17: street_1 - match (1st vs 1, 2nd vs 2, 3rd vs 3, 4th vs 4)
+            17: street_1 - missing_rdr (NULL vs '')
             18: street_1 - match (multiple white spaces)
-            19: No record for 19
+            19: street_1 - missing_ehr (No record for 19)
 
             11: street_2 - match (both blank)
             12: street_2 - no_match (blank vs non-blank)
             13: street_2 - match (APT 7D vs Apartment 7 D)
-            14: street_2 - match (APT 7D vs Apt 7-D)
-            19: No record for 19
+            14: street_2 - match (based on street_1 + street_2)
+            15: street_2 - match (uppercase vs lowercase, APT 7D vs Apt 7-D)
+            17: street_2 - missing_ehr (NULL vs '')
+            19: street_2 - missing_ehr (No record for 19)
 
             11: city - match (St. vs saint, whitespace padding, uppercase vs lowercase)
             12: city - no_match (different city)
             13: city - match (AFB vs Air Force Base)
             14: city - missing_rdr
             15: city - missing_ehr
-            19: No record for 19
+            19: city - missing_ehr (No record for 19)
 
             11: state - match (uppercase vs lowercase)
             12: state - no_match (different state)
             13: state - no_match (Non-existent state (ABCD) vs Gu)
             14: state - match (PIISTATE_)
-            19: No record for 19
+            19: state - missing_ehr (No record for 19)
 
             11: zip - match (identical)
             12: zip - no_match (different zip)
@@ -310,7 +312,7 @@ class ValidateTest(TestCase):
             14: zip - match (00921 vs 921)
             15: zip - match (08611 vs 08611-1234)
             16: zip - match (32207 vs 32207  5678)
-            19: No record for 19
+            19: zip - missing_ehr (No record for 19)
         """
 
         # Create and populate concept table
@@ -484,8 +486,8 @@ class ValidateTest(TestCase):
             'first_name': 'match',
             'middle_name': 'match',
             'last_name': 'match',
-            'address_1': 'match',
-            'address_2': 'match',
+            'address_1': 'missing_rdr',
+            'address_2': 'missing_ehr',
             'city': 'match',
             'state': 'match',
             'zip': 'match',

--- a/tests/integration_tests/data_steward/validation/participants/validate_test.py
+++ b/tests/integration_tests/data_steward/validation/participants/validate_test.py
@@ -46,14 +46,14 @@ INSERT INTO `{{project_id}}.{{drc_dataset_id}}.{{ps_values_table_id}}`
 (person_id, first_name, middle_name, last_name, street_address, street_address2, city, state, zip_code, email, phone_number, date_of_birth, sex)
 VALUES 
     (1, 'John', 'Jacob', 'Smith', '1 Government Dr', '', 'St. Louis', 'MO', '63110', 'john@gmail.com', '(123)456-7890', date('1978-10-01'), 'SexAtBirth_Female'),
-    (2, 'Rebecca', 'Howard', 'Glass', '476 5th Ave', '', 'New York', 'NY', '10018', 'rebecca@gmail.com', '1234567890', date('1984-10-23'), 'SexAtBirth_Male'),
+    (2, 'Rebecca', 'Howard', 'Glass', '476 5th Ave', 'Apt 14A', 'New York', 'NY', '10018', 'rebecca@gmail.com', '1234567890', date('1984-10-23'), 'SexAtBirth_Male'),
     (3, 'Sam', 'Felix Rose', 'Smith', '1 2nd 3 4th St', 'APT 7D', 'Andersen AFB', 'ABCD', '96923', 'samwjeo', '123456-7890', date('2003-01-05'), 'SexAtBirth_SexAtBirthNoneOfThese'),
     (4, 'Chris', 'Arthur', 'Smith', '1234 4th ave', 'apt 15B', NULL, 'PIIState_PR', '00921', 'chris@gmail.com', '1234567890', date('2003-05-1'), 'SexAtBirth_Intersex'),
     (5, 'John', NULL, 'Doe', NULL, '915 PR-17, Apt 7D', 'Trenton', 'NJ', '08611', '  johndoe@gmail.com  ', '', date('1993-11-01'), 'PMI_Skip'),
     (6, 'Rebecca', '', 'Mayers-James', '1501 Riverplace Blvd', '', 'Jacksonville', 'FL', '32207', 'rebeccamayers@gmail.co', '814321-0987', NULL, 'PMI_PreferNotToAnswer'),
     (7, 'Leo', '', "O’Keefe", NULL, '', 'Cincinnati', 'OH', '45202', 'leo@yahoo.com', '0987654321', date('1981-10-01'), 'UNSET'),
-    (8, '1ois', 'Frankl1n', 'Rhodes', '42 Nason St', '', 'Maynard', 'MA', '01754', '', '1-800-800-0911', date('1999-12-01'), 'SexAtBirth_SexAtBirthNoneOfThese'),
-    (9, 'Jack', 'Isaac', 'Dean', '777 NE Martin Luther King Jr Blvd', '', 'Portland', 'OR', '97232', 'jd@gmail.com', '555-555-1234', date('2002-03-14'), 'SexAtBirth_Female')
+    (8, '1ois', 'Frankl1n', 'Rhodes', '42 Nason St', 'Apt 21C', 'Maynard', 'MA', '01754', '', '1-800-800-0911', date('1999-12-01'), 'SexAtBirth_SexAtBirthNoneOfThese'),
+    (9, 'Jack', 'Isaac', 'Dean', 'Test address 0000', '', 'Portland', 'OR', '97232', 'jd@gmail.com', '555-555-1234', date('2002-03-14'), 'SexAtBirth_Female')
 """)
 
 POPULATE_ID_MATCH = JINJA_ENV.from_string("""
@@ -275,23 +275,15 @@ class ValidateTest(TestCase):
         """)
         """ 
         Note: Each test entry is testing for the following test cases:
-            11: street_1 - match (dr vs drive, whitespace padding, uppercase vs lowercase)
-            12: street_1 - no_match (different address)
-            13: street_1 - match (St vs Street, 1st vs 1, 2nd vs 2, 3rd vs 3, 4th vs 4)
-            14: street_1 - match (based on street_1 + street_2)
-            15: street_1 - missing_rdr
-            16: street_1 - missing_ehr
-            17: street_1 - missing_rdr (NULL vs '')
-            18: street_1 - match (multiple white spaces)
-            19: street_1 - missing_ehr (No record for 19)
-
-            11: street_2 - match (both blank)
-            12: street_2 - no_match (blank vs non-blank)
-            13: street_2 - match (APT 7D vs Apartment 7 D)
-            14: street_2 - match (based on street_1 + street_2)
-            15: street_2 - match (uppercase vs lowercase, APT 7D vs Apt 7-D)
-            17: street_2 - missing_ehr (NULL vs '')
-            19: street_2 - missing_ehr (No record for 19)
+            11: street_1: match,       street_2: missing_rdr ('1 Government Dr', '') vs (' 1 government drive ', '')
+            12: street_1: no_match,    street_2: no_match    ('476 5th Ave', 'Apt 14A') vs ('Wrong street', 'Wrong apartment')
+            13: street_1: match,       street_2: match       ('1 2nd 3 4th St', 'APT 7D') vs ('1st 2 3rd 4 Street', 'Apartment 7 D')
+            14: street_1: match,       street_2: match       ('1234 4th ave', 'apt 15B') vs ('1234 4th Ave, APT 15B', '')
+            15: street_1: missing_rdr, street_2: match       (NULL, '915 PR-17, Apt 7D') vs ('50 Riverview Plaza', '915 pr-17, Apt 7-D')
+            16: street_1: missing_ehr, street_2: missing_rdr ('1501 Riverplace Blvd', '') vs (NULL, '')
+            17: street_1: missing_rdr, street_2: missing_rdr (NULL, '') vs ('', NULL)
+            18: street_1: match,       street_2: missing_ehr ('42 Nason St', 'Apt 21C') vs ('42  Nason   St', '')
+            19: street_1: missing_ehr, street_2: missing_rdr ('Test address 0000', '') vs No record for 19
 
             11: city - match (St. vs saint, whitespace padding, uppercase vs lowercase)
             12: city - no_match (different city)
@@ -397,7 +389,7 @@ class ValidateTest(TestCase):
             'middle_name': 'match',
             'last_name': 'match',
             'address_1': 'match',
-            'address_2': 'match',
+            'address_2': 'missing_rdr',
             'city': 'match',
             'state': 'match',
             'zip': 'match',
@@ -472,7 +464,7 @@ class ValidateTest(TestCase):
             'middle_name': 'match',
             'last_name': 'match',
             'address_1': 'missing_ehr',
-            'address_2': 'match',
+            'address_2': 'missing_rdr',
             'city': 'match',
             'state': 'match',
             'zip': 'match',
@@ -487,7 +479,7 @@ class ValidateTest(TestCase):
             'middle_name': 'match',
             'last_name': 'match',
             'address_1': 'missing_rdr',
-            'address_2': 'missing_ehr',
+            'address_2': 'missing_rdr',
             'city': 'match',
             'state': 'match',
             'zip': 'match',
@@ -502,7 +494,7 @@ class ValidateTest(TestCase):
             'middle_name': 'no_match',
             'last_name': 'match',
             'address_1': 'match',
-            'address_2': 'match',
+            'address_2': 'missing_ehr',
             'city': 'match',
             'state': 'match',
             'zip': 'match',
@@ -517,7 +509,7 @@ class ValidateTest(TestCase):
             'middle_name': 'no_match',
             'last_name': 'no_match',
             'address_1': 'missing_ehr',
-            'address_2': 'missing_ehr',
+            'address_2': 'missing_rdr',
             'city': 'missing_ehr',
             'state': 'missing_ehr',
             'zip': 'missing_ehr',


### PR DESCRIPTION
Regarding `tests/integration_tests/data_steward/validation/participants/validate_test.py`:

[14](https://github.com/all-of-us/curation/pull/1142/files#diff-7f674a2a861ab3b7729a706943248dc33339696ca61e2be79c6383e6fbd507ffR270) and [17](https://github.com/all-of-us/curation/pull/1142/files#diff-7f674a2a861ab3b7729a706943248dc33339696ca61e2be79c6383e6fbd507ffR273) are the new test cases for street 1 & 2 combined comparison. The rest of the updates in the test file are not directly related to this 1 & 2 combined comparison: I reorganized them so that I do not need to create new test records.