### PR TITLE
[DC-2170] Use StorageClient to create client instances

### DIFF
--- a/data_steward/ci/test_buckets.py
+++ b/data_steward/ci/test_buckets.py
@@ -5,7 +5,7 @@ Creates buckets with a 30 day lifecycle.
 Bucket deletion and modification functions (for testing purposes) should be
 added to this module.
 """
-from google.cloud import storage
+from gcloud.gcs import StorageClient
 from google.cloud.exceptions import Conflict
 from google.oauth2 import service_account
 
@@ -24,7 +24,7 @@ def get_client(project_id, app_creds):
     if not CLIENT:
         credentials = service_account.Credentials.from_service_account_file(
             app_creds)
-        CLIENT = storage.Client(project=project_id, credentials=credentials)
+        CLIENT = StorageClient(project_id=project_id, credentials=credentials)
 
     return CLIENT
 
@@ -41,7 +41,7 @@ def create_bucket(config, bucket_name):
                                 config.get('GOOGLE_APPLICATION_CREDENTIALS'))
 
     # Creates the new bucket
-    bucket = storage.bucket.Bucket(storage_client, name=bucket_name)
+    bucket = storage_client.bucket(name=bucket_name)
     # set lifecycle
     bucket.add_lifecycle_delete_rule(age=30)
     bucket.location = "US"

--- a/data_steward/ci/test_buckets.py
+++ b/data_steward/ci/test_buckets.py
@@ -18,7 +18,7 @@ def get_client(project_id, app_creds):
     Ensure only one client is created and reused
 
     :param project_id:  project to get a client for
-    :returns: a big query client object
+    :returns: a StorageClient object
     """
     global CLIENT
     if not CLIENT:

--- a/data_steward/ci/test_buckets.py
+++ b/data_steward/ci/test_buckets.py
@@ -41,7 +41,7 @@ def create_bucket(config, bucket_name):
                                 config.get('GOOGLE_APPLICATION_CREDENTIALS'))
 
     # Creates the new bucket
-    bucket = storage_client.bucket(name=bucket_name)
+    bucket = storage_client.bucket(bucket_name)
     # set lifecycle
     bucket.add_lifecycle_delete_rule(age=30)
     bucket.location = "US"

--- a/data_steward/tools/load_archived_submission.py
+++ b/data_steward/tools/load_archived_submission.py
@@ -7,7 +7,7 @@ from typing import List
 from concurrent.futures import TimeoutError as TOError
 
 from google.cloud.bigquery import LoadJobConfig, LoadJob, Table, Client as BQClient
-from google.cloud.storage import Client as GCSClient
+from gcloud.gcs import StorageClient
 from google.cloud.exceptions import GoogleCloudError
 
 from common import AOU_REQUIRED, JINJA_ENV
@@ -64,7 +64,7 @@ def _filename_to_table_name(filename: str) -> str:
 
 
 def load_folder(dst_dataset: str, bq_client: BQClient, bucket_name: str,
-                prefix: str, gcs_client: GCSClient,
+                prefix: str, gcs_client: StorageClient,
                 hpo_id: str) -> List[LoadJob]:
     """
     Stage files from a bucket to a dataset
@@ -73,7 +73,7 @@ def load_folder(dst_dataset: str, bq_client: BQClient, bucket_name: str,
     :param bq_client: a BigQuery client object
     :param bucket_name: the bucket in GCS containing the archive files
     :param prefix: prefix of the filepath URI
-    :param gcs_client: a Cloud Storage client object
+    :param gcs_client: a StorageClient object
     :param hpo_id: Identifies the HPO site
     :return: list of completed load jobs
     """
@@ -154,7 +154,7 @@ def main(project_id, dataset_id, bucket_name, hpo_id, folder_name):
     :return:
     """
     bq_client = get_client(project_id)
-    gcs_client = GCSClient(project_id)
+    gcs_client = StorageClient(project_id)
     site_bucket = get_bucket(bq_client, hpo_id)
     prefix = f'{hpo_id}/{site_bucket}/{folder_name}'
     LOGGER.info(

--- a/data_steward/tools/load_vocab.py
+++ b/data_steward/tools/load_vocab.py
@@ -152,7 +152,7 @@ def load_stage(dst_dataset: Dataset, bq_client: Client, bucket_name: str,
     :param dst_dataset: reference to destination dataset object
     :param bq_client: a BigQuery client object
     :param bucket_name: the location in GCS containing the vocabulary files
-    :param gcs_client: a Cloud Storage client object
+    :param gcs_client: a StorageClient object
     :return: list of completed load jobs
     """
     blobs = list(gcs_client.list_blobs(bucket_name))

--- a/data_steward/tools/load_vocab.py
+++ b/data_steward/tools/load_vocab.py
@@ -11,12 +11,12 @@ from pathlib import Path
 from typing import List
 
 # Third party imports
-from google.cloud import storage
 from google.cloud.exceptions import NotFound
 from google.cloud.bigquery import Client, Dataset, SchemaField, LoadJob, LoadJobConfig, \
     QueryJobConfig, Table
 
 # Project imports
+from gcloud.gcs import StorageClient
 from utils import bq, pipeline_logging
 from common import VOCABULARY_TABLES, JINJA_ENV, CONCEPT, VOCABULARY, VOCABULARY_UPDATES
 from resources import AOU_VOCAB_PATH
@@ -80,7 +80,7 @@ def update_aou_vocabs(vocab_folder_path: Path):
 
 
 def upload_stage(bucket_name: str, vocab_folder_path: Path,
-                 gcs_client: storage.Client):
+                 gcs_client: StorageClient):
     """
     Upload vocabulary tables to cloud storage
 
@@ -145,7 +145,7 @@ def _table_name_to_filename(table_name: str) -> str:
 
 
 def load_stage(dst_dataset: Dataset, bq_client: Client, bucket_name: str,
-               gcs_client: storage.Client) -> List[LoadJob]:
+               gcs_client: StorageClient) -> List[LoadJob]:
     """
     Stage files from a bucket to a dataset
 
@@ -237,7 +237,7 @@ def main(project_id: str, bucket_name: str, vocab_folder_path: str,
     :param dst_dataset_id: final destination to load the vocabulary in BigQuery
     """
     bq_client = bq.get_client(project_id)
-    gcs_client = storage.Client(project_id)
+    gcs_client = StorageClient(project_id)
     vocab_folder_path = Path(vocab_folder_path)
     update_aou_vocabs(vocab_folder_path)
     upload_stage(bucket_name, vocab_folder_path, gcs_client)

--- a/tests/integration_tests/data_steward/tools/load_vocab_test.py
+++ b/tests/integration_tests/data_steward/tools/load_vocab_test.py
@@ -4,8 +4,9 @@ from pathlib import Path
 import mock
 import csv
 
-from google.cloud import storage, bigquery
+from google.cloud import bigquery
 
+from gcloud.gcs import StorageClient
 import app_identity
 from tests.test_util import TEST_VOCABULARY_PATH
 from resources import AOU_VOCAB_CONCEPT_CSV_PATH
@@ -47,7 +48,7 @@ class LoadVocabTest(unittest.TestCase):
         self.staging_dataset_id = f'{self.dataset_id}_staging'
         self.bucket = os.environ.get('BUCKET_NAME_FAKE')
         self.bq_client = bigquery.Client(project=self.project_id)
-        self.gcs_client = storage.Client(project=self.project_id)
+        self.gcs_client = StorageClient(project_id=self.project_id)
         self.test_vocab_folder_path = Path(TEST_VOCABULARY_PATH)
         self.test_vocabs = [CONCEPT, VOCABULARY]
         self.contents = {}


### PR DESCRIPTION
*Uses `StorageClient` to create new storage client instances in data_steward/tools/load_vacob.py and tests/integration_tests/data_steward/tools/load_vocab_test.py by replacing `storage.Client` calls and function parameters with `StorageClient`