### PR TITLE
[DC-1599] [BigQuery] Define BigQuery client

### DIFF
--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -8,6 +8,10 @@ import os
 from google.cloud import bigquery
 from google.cloud.bigquery import Client
 from google.auth import default
+from opentelemetry import trace
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 # Project imports
 from utils import auth
@@ -28,7 +32,15 @@ class BigQueryClient(Client):
 
         :return:  A BigQueryClient instance
         """
-        if scopes:
-            credentials, project_id = default()
-            credentials = auth.delegated_credentials(credentials, scopes=scopes)
-        super().__init__(project=project_id, credentials=credentials)
+        tracer_provider = TracerProvider()
+        cloud_trace_exporter = CloudTraceSpanExporter(project_id=project_id)
+        tracer_provider.add_span_processor(
+            BatchSpanProcessor(cloud_trace_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span('Client'):
+            if scopes:
+                credentials, project_id = default()
+                credentials = auth.delegated_credentials(credentials,
+                                                         scopes=scopes)
+            super().__init__(project=project_id, credentials=credentials)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -8,10 +8,6 @@ import os
 from google.cloud import bigquery
 from google.cloud.bigquery import Client
 from google.auth import default
-from opentelemetry import trace
-from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 # Project imports
 from utils import auth
@@ -32,15 +28,7 @@ class BigQueryClient(Client):
 
         :return:  A BigQueryClient instance
         """
-        tracer_provider = TracerProvider()
-        cloud_trace_exporter = CloudTraceSpanExporter(project_id=project_id)
-        tracer_provider.add_span_processor(
-            BatchSpanProcessor(cloud_trace_exporter))
-        trace.set_tracer_provider(tracer_provider)
-        tracer = trace.get_tracer(__name__)
-        with tracer.start_as_current_span('Client'):
-            if scopes:
-                credentials, project_id = default()
-                credentials = auth.delegated_credentials(credentials,
-                                                         scopes=scopes)
-            super().__init__(project=project_id, credentials=credentials)
+        if scopes:
+            credentials, project_id = default()
+            credentials = auth.delegated_credentials(credentials, scopes=scopes)
+        super().__init__(project=project_id, credentials=credentials)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -1,0 +1,33 @@
+"""
+Interact with Google Cloud BigQuery
+"""
+# Python stl imports
+import os
+
+# Third-party imports
+from google.cloud.bigquery import Client
+from google.auth import default
+
+# Project imports
+from utils import auth
+
+
+class BigQueryClient(Client):
+    """
+    A client that extends GCBQ functionality
+    See https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.client.Client.html#google.cloud.bigquery.client.Client
+    """
+
+    def __init__(self, project_id: str, scopes=None, credentials=None):
+        """
+        :param project_id: Identifies the project to create a cloud BigQuery client for
+        :param scopes: List of Google scopes as strings
+        :param credentials: Google credentials object (ignored if scopes is defined,
+            uses delegated credentials instead)
+
+        :return:  A BigQueryClient instance
+        """
+        if scopes:
+            credentials, project_id = default()
+            credentials = auth.delegated_credentials(credentials, scopes=scopes)
+        super().__init__(project=project_id, credentials=credentials)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -5,6 +5,7 @@ Interact with Google Cloud BigQuery
 import os
 
 # Third-party imports
+from google.cloud import bigquery
 from google.cloud.bigquery import Client
 from google.auth import default
 

--- a/data_steward/requirements.txt
+++ b/data_steward/requirements.txt
@@ -98,9 +98,6 @@ notebook==6.4.0
 numpy==1.20.3
 oauth2client==4.1.3
 oauthlib==3.1.0
-opentelemetry-api==1.9.1
-opentelemetry-sdk==1.9.1
-opentelemetry-exporter-gcp-trac==1.1.0
 packaging==20.9
 pandas==1.2.4
 pandas-gbq==0.15.0

--- a/data_steward/requirements.txt
+++ b/data_steward/requirements.txt
@@ -98,6 +98,9 @@ notebook==6.4.0
 numpy==1.20.3
 oauth2client==4.1.3
 oauthlib==3.1.0
+opentelemetry-api==1.9.1
+opentelemetry-sdk==1.9.1
+opentelemetry-exporter-gcp-trace==1.1.0
 packaging==20.9
 pandas==1.2.4
 pandas-gbq==0.15.0

--- a/data_steward/requirements.txt
+++ b/data_steward/requirements.txt
@@ -98,6 +98,9 @@ notebook==6.4.0
 numpy==1.20.3
 oauth2client==4.1.3
 oauthlib==3.1.0
+opentelemetry-api==1.9.1
+opentelemetry-sdk==1.9.1
+opentelemetry-exporter-gcp-trac==1.1.0
 packaging==20.9
 pandas==1.2.4
 pandas-gbq==0.15.0

--- a/tests/integration_tests/data_steward/gcloud/bq_client_test.py
+++ b/tests/integration_tests/data_steward/gcloud/bq_client_test.py
@@ -1,0 +1,22 @@
+"""
+Test the Google Cloud Big Query Client and associated helper functions
+"""
+# Python stl imports
+from unittest import TestCase
+
+# Project imports
+import app_identity
+from gcloud.bq import BigQueryClient
+
+
+class BqClientTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = app_identity.get_application_id()
+        self.bq_client = BigQueryClient(self.project_id)

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -1,0 +1,16 @@
+# Python imports
+from unittest import TestCase
+
+# Third party imports
+
+# Project imports
+from gcloud.bq import BigQueryClient
+
+
+class BQCTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')


### PR DESCRIPTION
Defines location and package for our extended class to live, data_steward/gcloud/bq.
Adds OpenTelemetry package requirements to data_steward/requirements.txt.
Adds OpenTelemetry functionality inside the constructor of the `BigQueryClient`.
Adds `BQC` integration test in tests/integration_tests/data_steward/gcloud/bq_client_test.py.
Adds `BQC` unit test in tests/unit_tests/data_steward/gcloud/bq.