### PR TITLE
[DC-2190] Update `DropPpiDuplicateResponses` and `DropCopeDuplicateResponses` to use `cope_survey_semantic_version_map` instead of `cope_concepts` table

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_cope_duplicate_responses.py
@@ -75,7 +75,8 @@ FROM (
     JOIN
       `{{project}}.{{dataset}}.{{cope_survey_version_table}}` cope
     ON
-      obs.questionnaire_response_id = cope.questionnaire_response_id )
+      obs.questionnaire_response_id = cope.questionnaire_response_id 
+      AND obs.person_id = cope.participant_id)
     ) o
 WHERE
   o.rank_order != 1

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_ppi_duplicate_responses_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_ppi_duplicate_responses_test.py
@@ -57,7 +57,10 @@ class DropPpiDuplicateResponsesTest(BaseTest.CleaningRulesTestBase):
             cls.fq_sandbox_table_names.append(
                 f'{project_id}.{sandbox_id}.{table_name}')
 
-        cls.fq_table_names = [f'{project_id}.{dataset_id}.observation']
+        cls.fq_table_names = [
+            f'{project_id}.{dataset_id}.observation',
+            f'{project_id}.{dataset_id}.cope_survey_semantic_version_map'
+        ]
 
         # call super to set up the client, create datasets, and create
         # empty test tables
@@ -117,7 +120,21 @@ VALUES
    'Alcohol_6orMoreDrinksOccurence', '6orMoreDrinksOccurence_Weekly', 999999999)"""
                                          )
 
+        tmp2 = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_dataset_name}}.cope_survey_semantic_version_map` (
+              participant_id, questionnaire_response_id,
+              semantic_version,
+              cope_month)
+        VALUES (2222222, 333333333, '4', 'jul' ),
+              (2222222, 555555555, '4', 'jul' ),
+              (2222222, 444444444, '6', 'aug' ),
+              (2222222, 666666666, '14','dec' )
+                """)
+
         query = tmpl.render(fq_dataset_name=self.fq_dataset_name)
+        self.load_test_data([query])
+
+        query = tmp2.render(fq_dataset_name=self.fq_dataset_name)
         self.load_test_data([query])
 
         # Expected results list

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_ppi_duplicate_responses_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/drop_ppi_duplicate_responses_test.py
@@ -1,7 +1,7 @@
 import unittest
 
 from cdr_cleaner.cleaning_rules.drop_ppi_duplicate_responses import (
-    DropPpiDuplicateResponses, PIPELINE_DATASET, COPE_CONCEPTS_TABLE)
+    DropPpiDuplicateResponses, get_select_statement, get_delete_statement)
 from constants.cdr_cleaner import clean_cdr as clean_consts
 
 
@@ -36,17 +36,13 @@ class DropPpiDuplicateResponsesTest(unittest.TestCase):
         results_list = self.rule_instance.get_query_specs()
         # Post conditions
         sandbox_query = dict()
-        sandbox_query[
-            clean_consts.QUERY] = self.rule_instance.get_select_statement(
-                self.project_id, self.dataset_id, self.sandbox_id,
-                self.rule_instance.get_sandbox_tablenames()[0],
-                PIPELINE_DATASET, COPE_CONCEPTS_TABLE)
+        sandbox_query[clean_consts.QUERY] = get_select_statement(
+            self.project_id, self.dataset_id, self.sandbox_id,
+            self.rule_instance.get_sandbox_tablenames()[0])
 
         update_query = dict()
-        update_query[
-            clean_consts.QUERY] = self.rule_instance.get_delete_statement(
-                self.project_id, self.dataset_id, PIPELINE_DATASET,
-                COPE_CONCEPTS_TABLE)
+        update_query[clean_consts.QUERY] = get_delete_statement(
+            self.project_id, self.dataset_id)
 
         expected_list = [sandbox_query, update_query]
 
@@ -58,14 +54,12 @@ class DropPpiDuplicateResponsesTest(unittest.TestCase):
         self.assertEqual(self.rule_instance.affected_datasets,
                          [clean_consts.RDR])
 
-        store_duplicate_rows = self.rule_instance.get_select_statement(
+        store_duplicate_rows = get_select_statement(
             self.project_id, self.dataset_id, self.sandbox_id,
-            self.rule_instance.get_sandbox_tablenames()[0], PIPELINE_DATASET,
-            COPE_CONCEPTS_TABLE)
+            self.rule_instance.get_sandbox_tablenames()[0])
 
-        delete_duplicate_rows = self.rule_instance.get_delete_statement(
-            self.project_id, self.dataset_id, PIPELINE_DATASET,
-            COPE_CONCEPTS_TABLE)
+        delete_duplicate_rows = get_delete_statement(self.project_id,
+                                                     self.dataset_id)
 
         # Test
         with self.assertLogs(level='INFO') as cm:


### PR DESCRIPTION
* Update usage of `cope_concepts` table to `cope_surey_semantic_version_map` is drop_ppi_duplicate_responses.py and drop_cope_duplicate_responses.py
* update integration tests
* update unit tests