### PR TITLE
[DC-2185] Replace bq.get_client(...) calls in integration tests

### DIFF
--- a/tests/integration_tests/data_steward/cdr_cleaner/clean_cdr_engine_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/clean_cdr_engine_test.py
@@ -27,7 +27,7 @@ class CleanCDREngineTest(TestCase):
         self.dataset_id = os.environ.get('UNIONED_DATASET_ID')
         self.sandbox_dataset_id = sandbox.check_and_create_sandbox_dataset(
             self.project_id, self.dataset_id)
-        self.client = BigQueryClient(self.project_id)
+        self.bq_client = BigQueryClient(self.project_id)
         self.delete_sandbox()
 
     def test_clean_dataset(self):
@@ -101,9 +101,9 @@ class CleanCDREngineTest(TestCase):
 
     def delete_sandbox(self):
         sandbox_dataset_id = sandbox.get_sandbox_dataset_id(self.dataset_id)
-        self.client.delete_dataset(sandbox_dataset_id,
-                                   delete_contents=True,
-                                   not_found_ok=True)
+        self.bq_client.delete_dataset(sandbox_dataset_id,
+                                      delete_contents=True,
+                                      not_found_ok=True)
 
     def tearDown(self) -> None:
         self.delete_sandbox()

--- a/tests/integration_tests/data_steward/cdr_cleaner/clean_cdr_engine_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/clean_cdr_engine_test.py
@@ -10,7 +10,8 @@ import constants.cdr_cleaner.clean_cdr as cdr_consts
 from app_identity import get_application_id
 # Project imports
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
-from utils import bq, sandbox
+from utils import sandbox
+from gcloud.bq import BigQueryClient
 
 
 class CleanCDREngineTest(TestCase):
@@ -26,7 +27,7 @@ class CleanCDREngineTest(TestCase):
         self.dataset_id = os.environ.get('UNIONED_DATASET_ID')
         self.sandbox_dataset_id = sandbox.check_and_create_sandbox_dataset(
             self.project_id, self.dataset_id)
-        self.client = bq.get_client(self.project_id)
+        self.client = BigQueryClient(self.project_id)
         self.delete_sandbox()
 
     def test_clean_dataset(self):

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -20,6 +20,7 @@ from google.cloud import bigquery
 # Project imports
 from cdr_cleaner import clean_cdr_engine as engine
 from utils import bq
+from gcloud.bq import BigQueryClient
 from common import JINJA_ENV
 
 
@@ -73,7 +74,7 @@ class BaseTest:
                     f'Provide a list of fully qualified table names the '
                     f'test will manipulate.')
 
-            cls.client = bq.get_client(cls.project_id)
+            cls.client = BigQueryClient(cls.project_id)
 
             # get or create datasets, cleaning rules can assume the datasets exist
             required_datasets = []

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generalize_state_by_population_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generalize_state_by_population_test.py
@@ -22,7 +22,8 @@ from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.generalize_state_by_population import GeneralizeStateByPopulation
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from common import OBSERVATION
-from utils.bq import get_table_schema, get_client
+from utils.bq import get_table_schema
+from gcloud.bq import BigQueryClient
 
 PARTICIPANT_THRESH = 200
 
@@ -94,13 +95,12 @@ class GeneralizeStateByPopulationTest(BaseTest.CleaningRulesTestBase):
         :param dataset_id
         :param table
         """
-        client = get_client(project_id)
+        bq_client = BigQueryClient(project_id)
         schema = get_table_schema(table)
         schema = [field for field in schema if field.name in list(df.columns)]
         load_job_config = LoadJobConfig(schema=schema)
-        load_job = client.load_table_from_dataframe(df,
-                                                    f'{dataset_id}.{table}',
-                                                    job_config=load_job_config)
+        load_job = bq_client.load_table_from_dataframe(
+            df, f'{dataset_id}.{table}', job_config=load_job_config)
         load_job.result()
 
     def test_generalize_state_by_population_cleaning(self):

--- a/tests/integration_tests/data_steward/metrics/required_labs_test.py
+++ b/tests/integration_tests/data_steward/metrics/required_labs_test.py
@@ -10,9 +10,9 @@ import app_identity
 import bq_utils
 import common
 from gcloud.gcs import StorageClient
+from gcloud.bq import BigQueryClient
 import resources
 import validation.sql_wrangle as sql_wrangle
-from utils import bq
 from tests import test_util
 from tests.test_util import FAKE_HPO_ID
 from validation.metrics import required_labs as required_labs
@@ -39,7 +39,7 @@ class RequiredLabsTest(unittest.TestCase):
         # Clients
         self.storage_client = StorageClient(self.project_id)
         self.hpo_bucket = self.storage_client.get_hpo_bucket(FAKE_HPO_ID)
-        self.bq_client = bq.get_client(self.project_id)
+        self.bq_client = BigQueryClient(self.project_id)
         self.rdr_dataset_id = bq_utils.get_rdr_dataset_id()
         # Cleanup
         self.storage_client.empty_bucket(self.hpo_bucket)

--- a/tests/integration_tests/data_steward/retraction/retract_deactivated_pids_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_deactivated_pids_test.py
@@ -12,6 +12,7 @@ import app_identity
 from common import JINJA_ENV
 from retraction import retract_deactivated_pids as rdp
 from utils import bq, sandbox as sb
+from gcloud.bq import BigQueryClient
 
 DEACTIVATED_PIDS = JINJA_ENV.from_string("""
 INSERT INTO `{{deact_table.project}}.{{deact_table.dataset_id}}.{{deact_table.table_id}}` 
@@ -116,7 +117,7 @@ class RetractDeactivatedEHRDataBqTest(unittest.TestCase):
         self.dataset_id = os.environ.get('UNIONED_DATASET_ID')
         self.deact_dataset_id = os.environ.get('COMBINED_DATASET_ID')
         self.deact_table = f'{self.project_id}.{self.deact_dataset_id}._deactivated_participants'
-        self.client = bq.get_client(self.project_id)
+        self.bq_client = BigQueryClient(self.project_id)
         self.bq_sandbox_dataset_id = sb.get_sandbox_dataset_id(self.dataset_id)
         self.tables = {**TABLE_ROWS, **MAPPING_TABLE_ROWS, **EXT_TABLE_ROWS}
         self.setup_data()
@@ -125,30 +126,30 @@ class RetractDeactivatedEHRDataBqTest(unittest.TestCase):
         self.tearDown()
         # setup deactivated participants table
         deact_table_ref = gbq.TableReference.from_string(self.deact_table)
-        bq.create_tables(self.client,
+        bq.create_tables(self.bq_client,
                          self.project_id, [self.deact_table],
                          exists_ok=True)
         job_config = gbq.QueryJobConfig()
-        job = self.client.query(
+        job = self.bq_client.query(
             DEACTIVATED_PIDS.render(deact_table=deact_table_ref), job_config)
         job.result()
 
         # create omop tables and mapping/ext tables
         for table in self.tables:
             fq_table = f'{self.project_id}.{self.dataset_id}.{table}'
-            bq.create_tables(self.client,
+            bq.create_tables(self.bq_client,
                              self.project_id, [fq_table],
                              exists_ok=True)
             table_ref = gbq.TableReference.from_string(fq_table)
             job_config = gbq.QueryJobConfig()
-            job = self.client.query(self.tables[table].render(table=table_ref),
-                                    job_config)
+            job = self.bq_client.query(
+                self.tables[table].render(table=table_ref), job_config)
             job.result()
 
     @mock.patch('retraction.retract_utils.is_deid_label_or_id')
     def test_queries_to_retract_from_fake_dataset(self, mock_deid):
         mock_deid.return_value = False
-        rdp.run_deactivation(self.client, self.project_id, [self.dataset_id],
+        rdp.run_deactivation(self.bq_client, self.project_id, [self.dataset_id],
                              self.deact_table)
         person_cols = [
             'person_id', 'gender_concept_id', 'year_of_birth', 'birth_datetime',
@@ -198,7 +199,7 @@ class RetractDeactivatedEHRDataBqTest(unittest.TestCase):
         for table in TABLE_ROWS:
             query = f"SELECT * FROM `{self.project_id}.{self.dataset_id}.{table}`"
             job_config = gbq.QueryJobConfig()
-            job = self.client.query(query, job_config)
+            job = self.bq_client.query(query, job_config)
             result_df = job.result().to_dataframe()
             result_df = result_df.dropna(how='all', axis=1)
             date_cols = [col for col in result_df.columns if 'date' in col]
@@ -217,8 +218,8 @@ class RetractDeactivatedEHRDataBqTest(unittest.TestCase):
         for table in self.tables:
             fq_table = f'{self.project_id}.{self.dataset_id}.{table}'
             table_ref = gbq.TableReference.from_string(fq_table)
-            self.client.delete_table(table_ref, not_found_ok=True)
-        self.client.delete_table(self.deact_table, not_found_ok=True)
-        self.client.delete_dataset(self.bq_sandbox_dataset_id,
-                                   delete_contents=True,
-                                   not_found_ok=True)
+            self.bq_client.delete_table(table_ref, not_found_ok=True)
+        self.bq_client.delete_table(self.deact_table, not_found_ok=True)
+        self.bq_client.delete_dataset(self.bq_sandbox_dataset_id,
+                                      delete_contents=True,
+                                      not_found_ok=True)

--- a/tests/integration_tests/data_steward/tools/delete_stale_test_datasets_test.py
+++ b/tests/integration_tests/data_steward/tools/delete_stale_test_datasets_test.py
@@ -15,7 +15,7 @@ from google.cloud import bigquery
 
 # Project imports
 from tools import delete_stale_test_datasets
-from utils import bq
+from gcloud.bq import BigQueryClient
 
 
 class DeleteStaleTestDatasetsTest(TestCase):
@@ -28,7 +28,7 @@ class DeleteStaleTestDatasetsTest(TestCase):
 
     def setUp(self):
         self.first_n = 3
-        self.bq_client = bq.get_client(os.environ.get('GOOGLE_CLOUD_PROJECT'))
+        self.bq_client = BigQueryClient(os.environ.get('GOOGLE_CLOUD_PROJECT'))
         self.now = datetime.now(timezone.utc)
 
     @patch('google.cloud.bigquery.Client.delete_dataset')

--- a/tests/integration_tests/data_steward/tools/generate_ehr_upload_pids_test.py
+++ b/tests/integration_tests/data_steward/tools/generate_ehr_upload_pids_test.py
@@ -18,11 +18,11 @@ class GenerateEhrUploadPids(unittest.TestCase):
     def setUp(self):
         self.project_id = app_identity.get_application_id()
         self.dataset_id = os.environ.get('UNIONED_DATASET_ID')
-        self.client = BigQueryClient(self.project_id)
+        self.bq_client = BigQueryClient(self.project_id)
 
     def test_generate_ehr_upload_pids_query(self):
         hpo_query = f"SELECT hpo_id FROM `{self.project_id}.{LOOKUP_TABLES_DATASET_ID}.{HPO_SITE_ID_MAPPINGS_TABLE_ID}`"
-        hpo_query_job = self.client.query(hpo_query)
+        hpo_query_job = self.bq_client.query(hpo_query)
         hpo_ids = hpo_query_job.result().to_dataframe()["hpo_id"].to_list()
         hpo_ids.sort()
         query = eup.generate_ehr_upload_pids_query(self.project_id,

--- a/tests/integration_tests/data_steward/tools/generate_ehr_upload_pids_test.py
+++ b/tests/integration_tests/data_steward/tools/generate_ehr_upload_pids_test.py
@@ -2,7 +2,7 @@ import unittest
 import os
 
 import app_identity
-from utils import bq
+from gcloud.bq import BigQueryClient
 from constants.utils.bq import LOOKUP_TABLES_DATASET_ID, HPO_SITE_ID_MAPPINGS_TABLE_ID
 from tools import generate_ehr_upload_pids as eup
 
@@ -18,7 +18,7 @@ class GenerateEhrUploadPids(unittest.TestCase):
     def setUp(self):
         self.project_id = app_identity.get_application_id()
         self.dataset_id = os.environ.get('UNIONED_DATASET_ID')
-        self.client = bq.get_client(self.project_id)
+        self.client = BigQueryClient(self.project_id)
 
     def test_generate_ehr_upload_pids_query(self):
         hpo_query = f"SELECT hpo_id FROM `{self.project_id}.{LOOKUP_TABLES_DATASET_ID}.{HPO_SITE_ID_MAPPINGS_TABLE_ID}`"

--- a/tests/integration_tests/data_steward/utils/sandbox_test.py
+++ b/tests/integration_tests/data_steward/utils/sandbox_test.py
@@ -5,7 +5,7 @@ import unittest
 import app_identity
 # Project Imports
 from utils import sandbox
-from utils.bq import get_client
+from gcloud.bq import BigQueryClient
 
 
 class SandboxTest(unittest.TestCase):
@@ -22,14 +22,15 @@ class SandboxTest(unittest.TestCase):
         self.sandbox_id = sandbox.get_sandbox_dataset_id(self.dataset_id)
         self.fq_sandbox_id = f'{self.project_id}.{self.sandbox_id}'
         # Removing any existing datasets that might interfere with the test
-        self.client = get_client(self.project_id)
-        self.client.delete_dataset(self.fq_sandbox_id,
-                                   delete_contents=True,
-                                   not_found_ok=True)
+        self.bq_client = BigQueryClient(self.project_id)
+        self.bq_client.delete_dataset(self.fq_sandbox_id,
+                                      delete_contents=True,
+                                      not_found_ok=True)
 
     def test_create_sandbox_dataset(self):
         # pre-conditions
-        pre_test_datasets_obj = list(self.client.list_datasets(self.project_id))
+        pre_test_datasets_obj = list(
+            self.bq_client.list_datasets(self.project_id))
         pre_test_datasets = [d.dataset_id for d in pre_test_datasets_obj]
 
         # Create sandbox dataset
@@ -37,8 +38,8 @@ class SandboxTest(unittest.TestCase):
             self.project_id, self.dataset_id)
 
         # Post condition checks
-        post_test_datasets_obj = list(self.client.list_datasets(
-            self.project_id))
+        post_test_datasets_obj = list(
+            self.bq_client.list_datasets(self.project_id))
         post_test_datasets = [d.dataset_id for d in post_test_datasets_obj]
 
         # make sure the dataset didn't already exist
@@ -52,6 +53,6 @@ class SandboxTest(unittest.TestCase):
 
     def tearDown(self):
         # Remove fake dataset created in project
-        self.client.delete_dataset(self.fq_sandbox_id,
-                                   delete_contents=True,
-                                   not_found_ok=True)
+        self.bq_client.delete_dataset(self.fq_sandbox_id,
+                                      delete_contents=True,
+                                      not_found_ok=True)

--- a/tests/integration_tests/data_steward/validation/ehr_union_test.py
+++ b/tests/integration_tests/data_steward/validation/ehr_union_test.py
@@ -49,7 +49,7 @@ class EhrUnionTest(unittest.TestCase):
         self.input_dataset_id = bq_utils.get_dataset_id()
         self.output_dataset_id = bq_utils.get_unioned_dataset_id()
         self.storage_client = StorageClient(self.project_id)
-        self.client = BigQueryClient(self.project_id)
+        self.bq_client = BigQueryClient(self.project_id)
         self.tearDown()
 
         # TODO Generalize to work for all foreign key references

--- a/tests/integration_tests/data_steward/validation/ehr_union_test.py
+++ b/tests/integration_tests/data_steward/validation/ehr_union_test.py
@@ -11,7 +11,7 @@ import cdm
 import common
 from constants.tools import combine_ehr_rdr
 from constants.validation import ehr_union as eu_constants
-from utils import bq
+from gcloud.bq import BigQueryClient
 from gcloud.gcs import StorageClient
 import resources
 import tests.test_util as test_util
@@ -49,7 +49,7 @@ class EhrUnionTest(unittest.TestCase):
         self.input_dataset_id = bq_utils.get_dataset_id()
         self.output_dataset_id = bq_utils.get_unioned_dataset_id()
         self.storage_client = StorageClient(self.project_id)
-        self.client = bq.get_client(self.project_id)
+        self.client = BigQueryClient(self.project_id)
         self.tearDown()
 
         # TODO Generalize to work for all foreign key references


### PR DESCRIPTION
- Implements the new BigQueryClient by replacing bq.get_client(...) calls in tests/integration_tests.
- Excludes: 
        tests/integration_tests/data_steward/validation/participants/create_update_drc_id_match_table_test.py.
        tests/integration_tests/data_steward/validation/participants/validate_test.py.
        tests/integration_tests/data_steward/validation/participants/store_participant_summary_results_test.py