### PR TITLE
[DC-2247] Replace bq.get_client(...) calls in data_steward/tools

### DIFF
--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -16,9 +16,9 @@ import app_identity
 import bq_utils
 import constants.bq_utils as bq_consts
 from gcloud.gcs import StorageClient
+from gcloud.bq import BigQueryClient
 import resources
 from tools import cli_util
-from utils import bq
 from utils import pipeline_logging
 from common import JINJA_ENV, PIPELINE_TABLES, SITE_MASKING_TABLE_ID
 
@@ -261,7 +261,7 @@ def update_site_masking_table():
     project_id = app_identity.get_application_id()
     sandbox_id = PIPELINE_TABLES + '_sandbox'
 
-    client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
 
     update_site_maskings_query = UPDATE_SITE_MASKING_QUERY.render(
         project_id=project_id,
@@ -275,7 +275,7 @@ def update_site_masking_table():
         f'Updating site_masking table with new hpo_id and src_id with the following '
         f'query:\n {update_site_maskings_query}\n ')
 
-    query_job = client.query(update_site_maskings_query)
+    query_job = bq_client.query(update_site_maskings_query)
 
     return query_job
 

--- a/data_steward/tools/clean_project_datasets.py
+++ b/data_steward/tools/clean_project_datasets.py
@@ -12,7 +12,7 @@ import logging
 from googleapiclient.errors import HttpError
 
 # Project imports
-from utils import bq
+from gcloud.bq import BigQueryClient
 from utils import pipeline_logging
 
 LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ def _delete_datasets(client, datasets_to_delete_list):
     """
     Deletes datasets using their dataset_ids
 
-    :param client: client object associated with project to delete datasets from
+    :param client: a BigQueryClient object associated with project to delete datasets from
     :param datasets_to_delete_list: list of dataset_ids to delete
     :return:
     """
@@ -68,10 +68,10 @@ def run_deletion(project_id, name_substrings):
 
     LOGGER.info('Continuing with dataset deletions...')
 
-    client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
 
     all_datasets = [
-        dataset.dataset_id for dataset in list(client.list_datasets())
+        dataset.dataset_id for dataset in list(bq_client.list_datasets())
     ]
 
     datasets_with_substrings = [
@@ -92,7 +92,7 @@ def run_deletion(project_id, name_substrings):
     response = input(msg)
 
     if response.lower() == 'y':
-        _delete_datasets(client, datasets_with_substrings)
+        _delete_datasets(bq_client, datasets_with_substrings)
     else:
         LOGGER.info("Proper consent was not given.  Aborting deletion.")
 

--- a/data_steward/tools/recreate_person.py
+++ b/data_steward/tools/recreate_person.py
@@ -2,7 +2,7 @@
 import logging
 
 # Project imports
-from utils import bq
+from gcloud.bq import BigQueryClient
 from common import JINJA_ENV
 from utils import pipeline_logging
 
@@ -44,17 +44,16 @@ def update_schema(client, person):
     LOGGER.info(f'Updated person table schema to {person.schema}')
 
 
-def update_person(client, project_id, dataset_id):
+def update_person(client, dataset_id):
     """
     Populates person table with two additional columns from the ext table
 
-    :param client: bigquery client
-    :param project_id: identifies the project
+    :param client: A BigQueryClient
     :param dataset_id: identifies the dataset
     :return:
     """
-    person_table_id = f'{project_id}.{dataset_id}.person'
-    person_ext_table_id = f'{project_id}.{dataset_id}.person_ext'
+    person_table_id = f'{client.project}.{dataset_id}.person'
+    person_ext_table_id = f'{client.project}.{dataset_id}.person_ext'
     person = client.get_table(person_table_id)
     person_ext = client.get_table(person_ext_table_id)
 
@@ -87,5 +86,5 @@ if __name__ == '__main__':
                         required=True)
 
     ARGS = parser.parse_args()
-    bq_client = bq.get_client(ARGS.project_id)
-    update_person(bq_client, ARGS.project_id, ARGS.dataset_id)
+    bq_client = BigQueryClient(ARGS.project_id)
+    update_person(bq_client, ARGS.dataset_id)

--- a/data_steward/tools/snapshot_by_query.py
+++ b/data_steward/tools/snapshot_by_query.py
@@ -27,9 +27,9 @@ BIGQUERY_DATA_TYPES = {
 def create_empty_dataset(project_id, dataset_id, snapshot_dataset_id):
     """
     Create the empty tables in the new snapshot dataset
-    :param project_id:
-    :param dataset_id:
-    :param snapshot_dataset_id:
+    :param project_id: identifies the project
+    :param dataset_id: identifies the source dataset
+    :param snapshot_dataset_id: identifies the new dataset
     :return:
     """
     create_dataset(
@@ -124,9 +124,9 @@ def get_copy_table_query(dataset_id, table_id, client):
 def copy_tables_to_new_dataset(project_id, dataset_id, snapshot_dataset_id):
     """
     lists the tables in the dataset and copies each table to a new dataset.
-    :param dataset_id:
-    :param project_id:
-    :param snapshot_dataset_id:
+    :param dataset_id: identifies the source dataset
+    :param project_id: identifies the project
+    :param snapshot_dataset_id: identifies the destination dataset
     :return:
     """
     copy_table_job_ids = []
@@ -162,9 +162,9 @@ def create_schemaed_snapshot_dataset(project_id,
                                      snapshot_dataset_id,
                                      overwrite_existing=True):
     """
-    :param project_id:
-    :param dataset_id:
-    :param snapshot_dataset_id:
+    :param project_id: identifies the project
+    :param dataset_id: identifies the source dataset
+    :param snapshot_dataset_id: identifies the destination dataset
     :param overwrite_existing: Default is True, False if a dataset is already created.
     :return:
     """

--- a/data_steward/tools/snapshot_by_query.py
+++ b/data_steward/tools/snapshot_by_query.py
@@ -6,6 +6,7 @@ import resources
 from bq_utils import create_dataset, list_all_table_ids, query, wait_on_jobs, BigQueryJobWaitError, \
     create_standard_table
 from utils import bq
+from gcloud.bq import BigQueryClient
 from utils.pipeline_logging import configure
 
 LOGGER = logging.getLogger(__name__)
@@ -96,10 +97,10 @@ def get_source_fields(client, source_table):
     return [f'{field.name}' for field in client.get_table(source_table).schema]
 
 
-def get_copy_table_query(project_id, dataset_id, table_id, client):
+def get_copy_table_query(dataset_id, table_id, client):
 
     try:
-        source_table = f'{project_id}.{dataset_id}.{table_id}'
+        source_table = f'{client.project}.{dataset_id}.{table_id}'
         source_fields = get_source_fields(client, source_table)
         dst_fields = resources.fields_for(table_id)
         if dst_fields:
@@ -115,7 +116,7 @@ def get_copy_table_query(project_id, dataset_id, table_id, client):
         col_expr = '*'
     select_all_query = 'SELECT {col_expr} FROM `{project_id}.{dataset_id}.{table_id}`'
     return select_all_query.format(col_expr=col_expr,
-                                   project_id=project_id,
+                                   project_id=client.project,
                                    dataset_id=dataset_id,
                                    table_id=table_id)
 
@@ -129,7 +130,7 @@ def copy_tables_to_new_dataset(project_id, dataset_id, snapshot_dataset_id):
     :return:
     """
     copy_table_job_ids = []
-    client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
     destination_tables = list_all_table_ids(snapshot_dataset_id)
     for table_id in list_all_table_ids(dataset_id):
         LOGGER.info(
@@ -139,12 +140,12 @@ def copy_tables_to_new_dataset(project_id, dataset_id, snapshot_dataset_id):
             try:
                 fields = resources.fields_for(table_id)
                 bq.create_tables(
-                    client, project_id,
+                    bq_client, project_id,
                     [f'{project_id}.{snapshot_dataset_id}.{table_id}'], False,
                     [fields])
             except RuntimeError:
                 LOGGER.info(f'Unable to find schema for {table_id}')
-        q = get_copy_table_query(project_id, dataset_id, table_id, client)
+        q = get_copy_table_query(dataset_id, table_id, bq_client)
         results = query(q,
                         use_legacy_sql=False,
                         destination_table_id=table_id,

--- a/tests/integration_tests/data_steward/tools/recreate_person_test.py
+++ b/tests/integration_tests/data_steward/tools/recreate_person_test.py
@@ -82,8 +82,7 @@ class RecreatePersonTest(TestCase):
         query_job.result()
 
     def test_update_person(self):
-        recreate_person.update_person(self.bq_client, self.project_id,
-                                      self.dataset_id)
+        recreate_person.update_person(self.bq_client, self.dataset_id)
         new_person_cols = (
             f'SELECT state_of_residence_concept_id, state_of_residence_source_value, '
             f'sex_at_birth_concept_id, sex_at_birth_source_concept_id, sex_at_birth_source_value '

--- a/tests/unit_tests/data_steward/tools/add_hpo_test.py
+++ b/tests/unit_tests/data_steward/tools/add_hpo_test.py
@@ -79,13 +79,13 @@ class AddHPOTest(TestCase):
                           new_site['hpo_id'], new_site['hpo_name'],
                           new_site['org_id'], new_site['display_order'])
 
-    @mock.patch('utils.bq.get_client')
-    def test_update_site_masking_table(self, mock_get_client):
+    @mock.patch('tools.add_hpo.BigQueryClient')
+    def test_update_site_masking_table(self, mock_bq_client):
         # Preconditions
         project_id = app_identity.get_application_id()
         sandbox_id = PIPELINE_TABLES + '_sandbox'
 
-        mock_query = mock_get_client.return_value.query
+        mock_query = mock_bq_client.return_value.query
 
         # Mocks the job return
         query_job_reference_results = mock.MagicMock(

--- a/tests/unit_tests/data_steward/tools/snapshot_by_query_test.py
+++ b/tests/unit_tests/data_steward/tools/snapshot_by_query_test.py
@@ -17,7 +17,9 @@ class SnapshotByQueryTest(unittest.TestCase):
         print(cls.__name__)
         print('**************************************************************')
 
-        cls.mock_client = ''
+        cls.mock_bq_client = mock.MagicMock()
+        type(cls.mock_bq_client).project = mock.PropertyMock(
+            return_value='test-project')
 
     @mock.patch('tools.snapshot_by_query.get_source_fields')
     def test_get_copy_table_query(self, mock_get_source_fields):
@@ -26,7 +28,7 @@ class SnapshotByQueryTest(unittest.TestCase):
         ]
 
         actual_query = snapshot_by_query.get_copy_table_query(
-            'test-project', 'test-dataset', 'person', self.mock_client)
+            'test-dataset', 'person', self.mock_bq_client)
         expected_query = """SELECT
   CAST(person_id AS INT64) AS person_id,
   CAST(gender_concept_id AS INT64) AS gender_concept_id,
@@ -53,6 +55,6 @@ FROM
                          re.sub(WHITESPACE, SPACE, expected_query))
 
         actual_query = snapshot_by_query.get_copy_table_query(
-            'test-project', 'test-dataset', 'non_cdm_table', self.mock_client)
+            'test-dataset', 'non_cdm_table', self.mock_bq_client)
         expected_query = '''SELECT * FROM `test-project.test-dataset.non_cdm_table`'''
         self.assertEqual(actual_query, expected_query)

--- a/tests/unit_tests/data_steward/tools/snapshot_by_query_test.py
+++ b/tests/unit_tests/data_steward/tools/snapshot_by_query_test.py
@@ -18,8 +18,7 @@ class SnapshotByQueryTest(unittest.TestCase):
         print('**************************************************************')
 
         cls.mock_bq_client = mock.MagicMock()
-        type(cls.mock_bq_client).project = mock.PropertyMock(
-            return_value='test-project')
+        cls.mock_bq_client.project = 'test-project'
 
     @mock.patch('tools.snapshot_by_query.get_source_fields')
     def test_get_copy_table_query(self, mock_get_source_fields):


### PR DESCRIPTION
Implements the new `BigQueryClient` by replacing `bq.get_client(...)` calls in data_steward/tools folder files:
- data_steward/tools/add_hpo.py
- data_steward/tools/clean_project_datasets.py
- data_steward/tools/copy_dataset_to_output_prod.py
- data_steward/tools/recreate_person.py
- data_steward/tools/snapshot_by_query_test.py
- Associated tests