### PR TITLE
[DC-2249] Replace bq.get_client(...) calls in data_steward/tools

### DIFF
--- a/data_steward/tools/import_rdr_omop.py
+++ b/data_steward/tools/import_rdr_omop.py
@@ -78,11 +78,9 @@ def create_rdr_tables(client, rdr_dataset, bucket):
     schema_dict = resources.cdm_schemas()
     schema_dict.update(resources.rdr_specific_schemas())
 
-    project = client.project
-
     for table, schema in schema_dict.items():
         schema_list = bq.get_table_schema(table, schema)
-        table_id = f'{project}.{rdr_dataset}.{table}'
+        table_id = f'{client.project}.{rdr_dataset}.{table}'
         job_config = bigquery.LoadJobConfig(
             schema=schema_list,
             skip_leading_rows=1,

--- a/data_steward/tools/load_archived_submission.py
+++ b/data_steward/tools/load_archived_submission.py
@@ -6,12 +6,13 @@ import argparse
 from typing import List
 from concurrent.futures import TimeoutError as TOError
 
-from google.cloud.bigquery import LoadJobConfig, LoadJob, Table, Client as BQClient
+from google.cloud.bigquery import LoadJobConfig, LoadJob, Table
 from gcloud.gcs import StorageClient
+from gcloud.bq import BigQueryClient
 from google.cloud.exceptions import GoogleCloudError
 
 from common import AOU_REQUIRED, JINJA_ENV
-from utils.bq import get_table_schema, get_client
+from utils.bq import get_table_schema
 import constants.bq_utils as bq_consts
 
 LOGGER = logging.getLogger(__name__)
@@ -23,11 +24,11 @@ WHERE hpo_id = '{{hpo_id}}'
 """)
 
 
-def get_bucket(client: BQClient, hpo_id: str) -> str:
+def get_bucket(client: BigQueryClient, hpo_id: str) -> str:
     """
     Retrieves bucket name for site
 
-    :param client: Bigquery Client object
+    :param client: a BigQueryClient
     :param hpo_id: Identifies the HPO site
     :return: bucket name for the HPO site as a string
     :raises GoogleCloudError/TimeoutError
@@ -63,14 +64,14 @@ def _filename_to_table_name(filename: str) -> str:
     return filename.split('/')[-1].replace('.csv', '').lower()
 
 
-def load_folder(dst_dataset: str, bq_client: BQClient, bucket_name: str,
+def load_folder(dst_dataset: str, bq_client: BigQueryClient, bucket_name: str,
                 prefix: str, gcs_client: StorageClient,
                 hpo_id: str) -> List[LoadJob]:
     """
     Stage files from a bucket to a dataset
 
     :param dst_dataset: Identifies the destination dataset
-    :param bq_client: a BigQuery client object
+    :param bq_client: a BigQueryClient
     :param bucket_name: the bucket in GCS containing the archive files
     :param prefix: prefix of the filepath URI
     :param gcs_client: a StorageClient object
@@ -153,7 +154,7 @@ def main(project_id, dataset_id, bucket_name, hpo_id, folder_name):
     :param folder_name: Name of the submission folder to load
     :return:
     """
-    bq_client = get_client(project_id)
+    bq_client = BigQueryClient(project_id)
     gcs_client = StorageClient(project_id)
     site_bucket = get_bucket(bq_client, hpo_id)
     prefix = f'{hpo_id}/{site_bucket}/{folder_name}'

--- a/data_steward/tools/load_vocab.py
+++ b/data_steward/tools/load_vocab.py
@@ -17,6 +17,7 @@ from google.cloud.bigquery import Client, Dataset, SchemaField, LoadJob, LoadJob
 
 # Project imports
 from gcloud.gcs import StorageClient
+from gcloud.bq import BigQueryClient
 from utils import bq, pipeline_logging
 from common import VOCABULARY_TABLES, JINJA_ENV, CONCEPT, VOCABULARY, VOCABULARY_UPDATES
 from resources import AOU_VOCAB_PATH
@@ -105,7 +106,7 @@ def check_and_create_staging_dataset(dst_dataset_id, bucket_name, bq_client):
 
     :param dst_dataset_id: final destination to load the vocabulary in BigQuery
     :param bucket_name: the location in GCS containing the vocabulary files
-    :param bq_client: google bigquery client
+    :param bq_client: a BigQueryClient
     :return: staging dataset object
     """
     staging_dataset_id = f'{dst_dataset_id}_staging'
@@ -150,7 +151,7 @@ def load_stage(dst_dataset: Dataset, bq_client: Client, bucket_name: str,
     Stage files from a bucket to a dataset
 
     :param dst_dataset: reference to destination dataset object
-    :param bq_client: a BigQuery client object
+    :param bq_client: a BigQueryClient
     :param bucket_name: the location in GCS containing the vocabulary files
     :param gcs_client: a StorageClient object
     :return: list of completed load jobs
@@ -195,7 +196,7 @@ def load(project_id, bq_client, src_dataset_id, dst_dataset_id):
     Transform safely loaded tables and store results in target dataset.
 
     :param project_id: Identifies the BQ project
-    :param bq_client: a BigQuery client object
+    :param bq_client: a BigQueryClient
     :param src_dataset_id: reference to source dataset object
     :param dst_dataset_id: reference to destination dataset object
     :return: List of BQ job_ids
@@ -236,7 +237,7 @@ def main(project_id: str, bucket_name: str, vocab_folder_path: str,
     :param vocab_folder_path: points to the directory containing files downloaded from athena with CPT4 applied
     :param dst_dataset_id: final destination to load the vocabulary in BigQuery
     """
-    bq_client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
     gcs_client = StorageClient(project_id)
     vocab_folder_path = Path(vocab_folder_path)
     update_aou_vocabs(vocab_folder_path)

--- a/data_steward/tools/load_vocab.py
+++ b/data_steward/tools/load_vocab.py
@@ -12,7 +12,7 @@ from typing import List
 
 # Third party imports
 from google.cloud.exceptions import NotFound
-from google.cloud.bigquery import Client, Dataset, SchemaField, LoadJob, LoadJobConfig, \
+from google.cloud.bigquery import  Dataset, SchemaField, LoadJob, LoadJobConfig, \
     QueryJobConfig, Table
 
 # Project imports
@@ -101,7 +101,8 @@ def upload_stage(bucket_name: str, vocab_folder_path: Path,
     return
 
 
-def check_and_create_staging_dataset(dst_dataset_id, bucket_name, bq_client):
+def check_and_create_staging_dataset(dst_dataset_id: str, bucket_name: str,
+                                     bq_client: BigQueryClient):
     """
 
     :param dst_dataset_id: final destination to load the vocabulary in BigQuery
@@ -145,8 +146,8 @@ def _table_name_to_filename(table_name: str) -> str:
     return f'{table_name.upper()}.csv'
 
 
-def load_stage(dst_dataset: Dataset, bq_client: Client, bucket_name: str,
-               gcs_client: StorageClient) -> List[LoadJob]:
+def load_stage(dst_dataset: Dataset, bq_client: BigQueryClient,
+               bucket_name: str, gcs_client: StorageClient) -> List[LoadJob]:
     """
     Stage files from a bucket to a dataset
 
@@ -191,7 +192,8 @@ def load_stage(dst_dataset: Dataset, bq_client: Client, bucket_name: str,
     return load_jobs
 
 
-def load(project_id, bq_client, src_dataset_id, dst_dataset_id):
+def load(project_id: str, bq_client: BigQueryClient, src_dataset_id: str,
+         dst_dataset_id: str):
     """
     Transform safely loaded tables and store results in target dataset.
 


### PR DESCRIPTION
Implements the new BigQueryClient by replacing bq.get_client(...) calls in data_steward/tools folder files:
- data_steward/tools/fitbit/generate_fitbit_dataset.py
- data_steward/tools/import_rdr_omop.py
- data_steward/tools/create_rdr_snapshot.py
- data_steward/tools/load_archived_submission.py
- data_steward/tools/load_vocab.py
