### PR TITLE
[DC-2270] Update the participant validation process to account for cross-site participants

### DIFF
--- a/data_steward/common.py
+++ b/data_steward/common.py
@@ -216,6 +216,7 @@ VOCABULARY_UPDATES = {
 }
 
 COMBINED = 'combined'
+UNIONED = 'unioned'
 UNIONED_EHR = 'unioned_ehr'
 DEID = 'deid'
 EHR = 'ehr'

--- a/data_steward/constants/validation/main.py
+++ b/data_steward/constants/validation/main.py
@@ -185,8 +185,11 @@ PREFIX = '/data_steward/v1/'
 # Cron URLs
 PARTICIPANT_VALIDATION = 'ParticipantValidation/'
 
-# Return Values
+# Return value for participant validation cron
 VALIDATION_SUCCESS = 'participant-validation-done'
+
+# Return value for ps_api cron
+PS_API_SUCCESS = 'ps-api-done'
 
 CONTENT_TYPE = 'content-type'
 APPLICATION_JSON = 'application/json'

--- a/data_steward/constants/validation/participants/validate.py
+++ b/data_steward/constants/validation/participants/validate.py
@@ -419,10 +419,8 @@ LEFT JOIN ( SELECT person_id, cc.concept_name as sex
                 ON gender_concept_id = concept_id ) AS ehr_sex
     ON ehr_sex.person_id = ps.person_id
 WHERE upd.person_id = ps.person_id
-    AND upd._PARTITIONTIME = ps._PARTITIONTIME
-    AND ps._PARTITIONTIME = (
-        SELECT MAX(_PARTITIONTIME) FROM `{{project_id}}.{{drc_dataset_id}}.{{ps_api_table_id}}`
-        )
+    AND upd._PARTITIONTIME = ( SELECT MAX(_PARTITIONTIME) pt
+        FROM `{{project_id}}.{{drc_dataset_id}}.{{id_match_table_id}}` )
 """)
 
 MATCH_STREET_COMBINED_QUERY = JINJA_ENV.from_string("""
@@ -437,10 +435,8 @@ LEFT JOIN ( SELECT person_id, address_1, address_2, city, state, zip
                 USING (location_id) ) ehr_address
     ON ehr_address.person_id = ps.person_id
 WHERE upd.person_id = ps.person_id
-    AND upd._PARTITIONTIME = ps._PARTITIONTIME
-    AND ps._PARTITIONTIME = (
-        SELECT MAX(_PARTITIONTIME) FROM `{{project_id}}.{{drc_dataset_id}}.{{ps_api_table_id}}`
-        )
+    AND upd._PARTITIONTIME = ( SELECT MAX(_PARTITIONTIME) pt
+        FROM `{{project_id}}.{{drc_dataset_id}}.{{id_match_table_id}}` )
     -- This update skips the records whose address_1 or address_2 is already "match" --
     AND NOT(upd.address_1 = '{{match}}' OR upd.address_2 = '{{match}}')
     -- This update only updates the records whose street_1+street_2 comparison return "match" --

--- a/data_steward/constants/validation/participants/validate.py
+++ b/data_steward/constants/validation/participants/validate.py
@@ -398,27 +398,52 @@ SET upd.first_name = `{{project_id}}.{{drc_dataset_id}}.CompareName`(ps.first_na
     upd.birth_date = `{{project_id}}.{{drc_dataset_id}}.CompareDateOfBirth`(ps.date_of_birth, ehr_dob.date_of_birth),
     upd.sex = `{{project_id}}.{{drc_dataset_id}}.CompareSexAtBirth`(ps.sex, ehr_sex.sex),
     upd.algorithm = 'yes'
-FROM `{{project_id}}.{{drc_dataset_id}}.{{ps_api_table_id}}` ps
-LEFT JOIN `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_name_table_id}}` ehr_name
-    ON ehr_name.person_id = ps.person_id
+FROM (SELECT * EXCEPT(r)
+        FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_person_table_id}}`)
+        WHERE r = 1) p
+LEFT JOIN `{{project_id}}.{{drc_dataset_id}}.{{ps_api_table_id}}` ps
+    ON p.person_id = ps.person_id
+LEFT JOIN (SELECT * EXCEPT(r)
+        FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_name_table_id}}`)
+        WHERE r = 1) ehr_name
+    ON ehr_name.person_id = p.person_id
 LEFT JOIN ( SELECT person_id, address_1, address_2, city, state, zip
-            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_address_table_id}}`
-            LEFT JOIN `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_location_table_id}}`
-                USING (location_id) ) ehr_address
-    ON ehr_address.person_id = ps.person_id
-LEFT JOIN `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_email_table_id}}` ehr_email
-    ON ehr_email.person_id = ps.person_id
-LEFT JOIN `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_phone_number_table_id}}` ehr_phone
-    ON ehr_phone.person_id = ps.person_id
-LEFT JOIN ( SELECT person_id, DATE(birth_datetime) AS date_of_birth
-           FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_person_table_id}}` ) AS ehr_dob
-    ON ehr_dob.person_id = ps.person_id
+        FROM (SELECT * EXCEPT(r)
+            FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_address_table_id}}`)
+            WHERE r = 1) per
+        LEFT JOIN (SELECT * EXCEPT(r)
+            FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY location_id) r
+                FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_location_table_id}}`)
+            WHERE r = 1) loc
+            USING (location_id) ) ehr_address
+    ON ehr_address.person_id = p.person_id
+LEFT JOIN (SELECT * EXCEPT(r)
+                FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                    FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_email_table_id}}`)
+            WHERE r = 1) ehr_email
+    ON ehr_email.person_id = p.person_id
+LEFT JOIN (SELECT * EXCEPT(r)
+                FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                    FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_phone_number_table_id}}`)
+            WHERE r = 1) ehr_phone
+    ON ehr_phone.person_id = p.person_id
+LEFT JOIN (SELECT person_id, DATE(birth_datetime) AS date_of_birth
+            FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_person_table_id}}`)
+            WHERE r = 1) AS ehr_dob
+    ON ehr_dob.person_id = p.person_id
 LEFT JOIN ( SELECT person_id, cc.concept_name as sex
-            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_person_table_id}}`
+            FROM (SELECT * EXCEPT(r)
+                FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                    FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_person_table_id}}`)
+                WHERE r = 1 )
             JOIN `{{project_id}}.{{ehr_ops_dataset_id}}.concept` cc
                 ON gender_concept_id = concept_id ) AS ehr_sex
-    ON ehr_sex.person_id = ps.person_id
-WHERE upd.person_id = ps.person_id
+    ON ehr_sex.person_id = p.person_id
+WHERE upd.person_id = p.person_id
     AND upd._PARTITIONTIME = ( SELECT MAX(_PARTITIONTIME) pt
         FROM `{{project_id}}.{{drc_dataset_id}}.{{id_match_table_id}}` )
 """)
@@ -428,13 +453,24 @@ UPDATE `{{project_id}}.{{drc_dataset_id}}.{{id_match_table_id}}` upd
 SET upd.address_1 = '{{match}}',
     upd.address_2 = '{{match}}',
     upd.algorithm = 'yes'
-FROM `{{project_id}}.{{drc_dataset_id}}.{{ps_api_table_id}}` ps
+FROM (SELECT * EXCEPT(r)
+        FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_person_table_id}}`)
+        WHERE r = 1) p
+LEFT JOIN `{{project_id}}.{{drc_dataset_id}}.{{ps_api_table_id}}` ps
+    ON p.person_id = ps.person_id
 LEFT JOIN ( SELECT person_id, address_1, address_2, city, state, zip
-            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_address_table_id}}`
-            LEFT JOIN `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_location_table_id}}`
+            FROM (SELECT * EXCEPT(r)
+                FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                    FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_pii_address_table_id}}`)
+                WHERE r = 1) per
+            LEFT JOIN (SELECT * EXCEPT(r)
+                FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+                    FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{hpo_location_table_id}}`)
+                WHERE r = 1) loc
                 USING (location_id) ) ehr_address
-    ON ehr_address.person_id = ps.person_id
-WHERE upd.person_id = ps.person_id
+    ON ehr_address.person_id = p.person_id
+WHERE upd.person_id = p.person_id
     AND upd._PARTITIONTIME = ( SELECT MAX(_PARTITIONTIME) pt
         FROM `{{project_id}}.{{drc_dataset_id}}.{{id_match_table_id}}` )
     -- This update skips the records whose address_1 or address_2 is already "match" --

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -372,6 +372,47 @@ def get_org_participant_information(project_id: str,
     return df
 
 
+def get_all_participant_information(project_id: str) -> pandas.DataFrame:
+    """
+    Fetches the necessary participant information.
+
+    :param project_id: The RDR project hosting the API
+
+    :return: a dataframe of participant information
+    :raises: RuntimeError if the project_id and hpo_id are not strings
+    :raises: TimeoutError if response takes longer than 10 minutes
+    """
+    # Parameter checks
+    if not isinstance(project_id, str):
+        raise RuntimeError(f'Please specify the RDR project')
+
+    # if not isinstance(org_id, str):
+    #     raise RuntimeError(f'Please provide an org_id')
+
+    # Make request to get API version. This is the current RDR version for reference see
+    # see https://github.com/all-of-us/raw-data-repository/blob/master/opsdataAPI.md for documentation of this API.
+    # consentForElectronicHealthRecords=SUBMITTED -- ensures only consenting participants are returned via the API
+    #   regardless if there is EHR data uploaded for that participant
+    # suspensionStatus=NOT_SUSPENDED and withdrawalStatus=NOT_WITHDRAWN -- ensures only active participants returned
+    #   via the API
+    params = {
+        'suspensionStatus': 'NOT_SUSPENDED',
+        'consentForElectronicHealthRecords': 'SUBMITTED',
+        'withdrawalStatus': 'NOT_WITHDRAWN',
+        '_sort': 'participantId',
+        '_count': '10000'
+    }
+
+    participant_data = get_participant_data(project_id, params=params)
+
+    column_map = {'participant_id': 'person_id'}
+
+    df = process_api_data_to_df(participant_data,
+                                FIELDS_OF_INTEREST_FOR_VALIDATION, column_map)
+
+    return df
+
+
 def get_digital_health_information(project_id: str):
     """
     Fetches the necessary participant information for a particular site.

--- a/data_steward/utils/participant_summary_requests.py
+++ b/data_steward/utils/participant_summary_requests.py
@@ -386,9 +386,6 @@ def get_all_participant_information(project_id: str) -> pandas.DataFrame:
     if not isinstance(project_id, str):
         raise RuntimeError(f'Please specify the RDR project')
 
-    # if not isinstance(org_id, str):
-    #     raise RuntimeError(f'Please provide an org_id')
-
     # Make request to get API version. This is the current RDR version for reference see
     # see https://github.com/all-of-us/raw-data-repository/blob/master/opsdataAPI.md for documentation of this API.
     # consentForElectronicHealthRecords=SUBMITTED -- ensures only consenting participants are returned via the API

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -1032,7 +1032,7 @@ app.add_url_rule(consts.PREFIX + 'UnionEHR',
                  view_func=union_ehr,
                  methods=['GET'])
 
-app.add_url_rule(consts.PREFIX + consts.PARTICIPANT_VALIDATION,
+app.add_url_rule(consts.PREFIX + consts.PARTICIPANT_VALIDATION + 'validate',
                  endpoint='validate_pii',
                  view_func=validate_pii,
                  methods=['GET'])
@@ -1042,7 +1042,8 @@ app.add_url_rule(consts.PREFIX + 'RetractPids',
                  view_func=run_retraction_cron,
                  methods=['GET'])
 
-app.add_url_rule(consts.PREFIX + 'RefreshPSapi',
+app.add_url_rule(consts.PREFIX + consts.PARTICIPANT_VALIDATION +
+                 'FetchPSapiData',
                  endpoint='ps_api_cron',
                  view_func=ps_api_cron,
                  methods=['GET'])

--- a/data_steward/validation/participants/create_update_drc_id_match_table.py
+++ b/data_steward/validation/participants/create_update_drc_id_match_table.py
@@ -19,7 +19,7 @@ import argparse
 import resources
 from utils import bq, auth
 import bq_utils
-from common import JINJA_ENV, PS_API_VALUES, DRC_OPS, CDR_SCOPES
+from common import JINJA_ENV, DRC_OPS, CDR_SCOPES, EHR_OPS, PERSON
 from constants.validation.participants.identity_match import IDENTITY_MATCH_TABLE
 
 LOGGER = logging.getLogger(__name__)
@@ -48,14 +48,18 @@ PARTITION BY TIMESTAMP_TRUNC(_PARTITIONTIME, HOUR)
 POPULATE_VALIDATION_TABLE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{drc_dataset_id}}.{{id_match_table_id}}` (_PARTITIONTIME, {{fields}}) 
 SELECT
-    _PARTITIONTIME, 
-    person_id, {{case_statements}}, '' algorithm
-FROM `{{project_id}}.{{drc_dataset_id}}.{{ps_values_table_id}}`
-WHERE ABS(TIMESTAMP_DIFF(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, HOUR), _PARTITIONTIME, HOUR)) < 2
+    TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, HOUR), 
+    person_id,
+    {{case_statements}},
+    '' algorithm
+FROM (SELECT * EXCEPT(r)
+        FROM (SELECT *, ROW_NUMBER() OVER(PARTITION BY person_id) r
+            FROM `{{project_id}}.{{ehr_ops_dataset_id}}.{{ehr_person_table_id}}`)
+        WHERE r = 1)
 """)
 
 CASE_EXPRESSION = JINJA_ENV.from_string("""
-CASE WHEN {{ps_api_field}} IS NULL THEN 'missing_rdr' ELSE 'missing_ehr' END AS {{identity_match_field}}
+'missing_ehr' AS {{identity_match_field}}
 """)
 
 
@@ -126,7 +130,7 @@ def populate_validation_table(client,
 
     schema_list = bq.get_table_schema(IDENTITY_MATCH_TABLE)
     id_match_table_id = table_id
-    ps_values_table_id = f'{PS_API_VALUES}_{hpo_id}'
+    ehr_person_table_id = bq_utils.get_table_id(hpo_id, PERSON)
 
     fields_name_str = ', '.join([item.name for item in schema_list])
 
@@ -136,7 +140,8 @@ def populate_validation_table(client,
         id_match_table_id=id_match_table_id,
         fields=fields_name_str,
         case_statements=get_case_statements(),
-        ps_values_table_id=ps_values_table_id)
+        ehr_ops_dataset_id=EHR_OPS,
+        ehr_person_table_id=ehr_person_table_id)
 
     job = client.query(populate_query)
     job.result()

--- a/data_steward/validation/participants/store_participant_summary_results.py
+++ b/data_steward/validation/participants/store_participant_summary_results.py
@@ -13,8 +13,10 @@ from google.cloud import bigquery
 from google.cloud.exceptions import NotFound
 
 # Project imports
-from utils.participant_summary_requests import get_org_participant_information, store_participant_data
-from common import PS_API_VALUES, DRC_OPS
+from utils.participant_summary_requests import (get_org_participant_information,
+                                                get_all_participant_information,
+                                                store_participant_data)
+from common import PS_API_VALUES, DRC_OPS, UNIONED
 from utils import bq, pipeline_logging
 from constants import bq_utils as bq_consts
 
@@ -123,6 +125,48 @@ def fetch_and_store_ps_hpo_data(client,
                            f'{dataset_id}.{table_name}',
                            schema=schema,
                            to_hour_partition=True)
+
+    LOGGER.info(f'Done.')
+
+
+def fetch_and_store_full_ps_data(client,
+                                 project_id,
+                                 rdr_project_id,
+                                 dataset_id=DRC_OPS):
+    """
+    Fetches PS API data for all participants and stores in drc_ops.ps_api_unioned table
+
+    :param client: BQ client
+    :param project_id: Identifies the project
+    :param rdr_project_id: PS API project
+    :param dataset_id: contains table to store PS API data
+    :return: 
+    """
+
+    # Get participant summary data
+    LOGGER.info(f'Getting participant summary data')
+    participant_info = get_all_participant_information(rdr_project_id)
+
+    # Load schema
+    schema = bq.get_table_schema(PS_API_VALUES)
+    # TODO use resources.get_table_id after updating it to flip hpo_id, table_name
+    table_name = f'{PS_API_VALUES}_{UNIONED}'
+    fq_table_id = f'{project_id}.{dataset_id}.{table_name}'
+
+    # Clear existing table to refresh data
+    client.delete_table(fq_table_id, not_found_ok=True)
+    LOGGER.info(f'Creating table {fq_table_id}')
+
+    table = bigquery.Table(fq_table_id, schema=schema)
+    table = client.create_table(table)
+
+    # Insert summary data into table
+    LOGGER.info(f'Storing participant data in table {fq_table_id}')
+    store_participant_data(participant_info,
+                           project_id,
+                           f'{dataset_id}.{table_name}',
+                           schema=schema,
+                           to_hour_partition=False)
 
     LOGGER.info(f'Done.')
 

--- a/data_steward/validation/participants/validate.py
+++ b/data_steward/validation/participants/validate.py
@@ -23,13 +23,11 @@ import pandas
 
 # Project imports
 from app_identity import get_application_id
-from bq_utils import get_rdr_project_id
 from resources import get_table_id, VALIDATION_STREET_CSV, VALIDATION_CITY_CSV, VALIDATION_STATE_CSV
 from utils import bq, pipeline_logging, auth
-from common import (JINJA_ENV, PS_API_VALUES, DRC_OPS, EHR_OPS, CDR_SCOPES,
-                    PII_ADDRESS, PII_EMAIL, PII_PHONE_NUMBER, PII_NAME,
-                    LOCATION, PERSON)
-from validation.participants.store_participant_summary_results import fetch_and_store_ps_hpo_data
+from common import (PS_API_VALUES, DRC_OPS, EHR_OPS, CDR_SCOPES, PII_ADDRESS,
+                    PII_EMAIL, PII_PHONE_NUMBER, PII_NAME, LOCATION, PERSON,
+                    UNIONED)
 from validation.participants.create_update_drc_id_match_table import create_and_populate_drc_validation_table
 from constants.validation.participants.identity_match import IDENTITY_MATCH_TABLE
 from constants.validation.participants import validate as consts
@@ -86,7 +84,7 @@ def identify_rdr_ehr_match(client,
     hpo_pii_email_table_id = get_table_id(PII_EMAIL, hpo_id)
     hpo_pii_phone_number_table_id = get_table_id(PII_PHONE_NUMBER, hpo_id)
     hpo_pii_name_table_id = get_table_id(PII_NAME, hpo_id)
-    ps_api_table_id = f'{PS_API_VALUES}_{hpo_id}'
+    ps_api_table_id = f'{PS_API_VALUES}_{UNIONED}'
     hpo_location_table_id = get_table_id(LOCATION, hpo_id)
     hpo_person_table_id = get_table_id(PERSON, hpo_id)
 
@@ -161,10 +159,6 @@ def setup_and_validate_participants(hpo_id):
     """
     project_id = get_application_id()
     client = bq.get_client(project_id)
-
-    # Fetch Participant summary data
-    rdr_project_id = get_rdr_project_id()
-    fetch_and_store_ps_hpo_data(client, client.project, rdr_project_id, hpo_id)
 
     # Populate identity match table based on PS data
     create_and_populate_drc_validation_table(client, hpo_id)

--- a/tests/integration_tests/data_steward/validation/main_test.py
+++ b/tests/integration_tests/data_steward/validation/main_test.py
@@ -270,41 +270,6 @@ class ValidationMainTest(unittest.TestCase):
         self.assertSetEqual(expected_bucket_files, actual_bucket_files)
 
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
-    @mock.patch('validation.main.setup_and_validate_participants')
-    @mock.patch('api_util.check_cron')
-    def test_participant_validation_duplicate_check(self, mock_check_cron,
-                                                    mock_setup_validate):
-        # tests if pii file is loaded
-        test_file_path = os.path.basename(test_util.PII_NAME_FILE)
-
-        blob_name: str = f'{self.folder_prefix}{test_file_path}'
-        test_blob = self.hpo_bucket.blob(blob_name)
-        test_blob.upload_from_filename(test_util.PII_NAME_FILE)
-        bucket_items = self.storage_client.get_bucket_items_metadata(
-            self.hpo_bucket)
-        folder_items = main.get_folder_items(bucket_items, self.folder_prefix)
-        # Load the table
-        r = main.validate_submission(self.hpo_id, self.hpo_bucket, folder_items,
-                                     self.folder_prefix)
-        # Create duplicates
-        job = self.bq_client.query(
-            f'INSERT INTO {self.project_id}.{self.dataset_id}.{self.hpo_id}_{common.PII_NAME} '
-            f'(person_id, first_name, middle_name, last_name, suffix, prefix) '
-            f'SELECT * FROM {self.project_id}.{self.dataset_id}.{self.hpo_id}_{common.PII_NAME}'
-        )
-        job.result()
-
-        result_data = {}
-        duplicates_query = main.get_duplicate_counts_query(self.hpo_id)
-        result_data[main.report_consts.
-                    NONUNIQUE_KEY_METRICS_REPORT_KEY] = main.query_rows(
-                        duplicates_query)
-        expected_duplicate_tables = ["pii_name"]
-        actual_duplicate_tables = main.check_duplicates_and_validate(
-            self.hpo_id, result_data)
-        self.assertListEqual(expected_duplicate_tables, actual_duplicate_tables)
-
-    @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     @mock.patch('api_util.check_cron')
     def test_pii_files_loaded(self, mock_check_cron):
         # tests if pii files are loaded

--- a/tests/unit_tests/data_steward/validation/main_test.py
+++ b/tests/unit_tests/data_steward/validation/main_test.py
@@ -289,7 +289,7 @@ class ValidationMainTest(TestCase):
     @mock.patch(
         'utils.bq.get_client',
         mock.MagicMock(query=lambda: mock.MagicMock(result=lambda: None)))
-    @mock.patch('validation.participants.validate.fetch_and_store_ps_hpo_data',
+    @mock.patch('validation.main.setup_and_validate_participants',
                 mock.MagicMock())
     @mock.patch('bq_utils.table_exists', mock.MagicMock())
     @mock.patch('bq_utils.query')
@@ -534,7 +534,7 @@ class ValidationMainTest(TestCase):
     @mock.patch(
         'utils.bq.get_client',
         mock.MagicMock(query=lambda: mock.MagicMock(result=lambda: None)))
-    @mock.patch('validation.participants.validate.fetch_and_store_ps_hpo_data',
+    @mock.patch('validation.main.setup_and_validate_participants',
                 mock.MagicMock())
     @mock.patch('bq_utils.table_exists', mock.MagicMock())
     @mock.patch('bq_utils.query', mock.MagicMock())


### PR DESCRIPTION
* [DC-2270] Use de-dup ehr person table as reference for id_match
* [DC-2270] Use id_match table partition
* [DC-2270] De-duplicate every table used in queries
* [DC-2270] Delete unused function since duplicates are handled
* [DC-2270] Add capability to fetch all participant data
* [DC-2270] Store all participant data in unioned table
* [DC-2270] Use ps_api_unioned table
* [DC-2270] Update cron for validation and add ps_api cron
* [DC-2270] Use participant validation sub dir for crons

[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-2270]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ