### PR TITLE
[DC-2250] Replace bq.get_client(...) calls in data_steward/tools

### DIFF
--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -203,7 +203,6 @@ def create_tier(credentials_filepath, project_id, tier, input_dataset,
     impersonation_creds = auth.get_impersonation_credentials(
         run_as, CDR_SCOPES, credentials_filepath)
 
-    # client = bq.get_client(project_id, credentials=impersonation_creds)
     bq_client = BigQueryClient(project_id, credentials=impersonation_creds)
 
     # Get Final Dataset name

--- a/data_steward/tools/delete_stale_test_datasets.py
+++ b/data_steward/tools/delete_stale_test_datasets.py
@@ -14,17 +14,17 @@ import os
 from google.api_core import exceptions
 
 # Project imports
-from utils import bq, pipeline_logging
+from utils import pipeline_logging
 from gcloud.bq import BigQueryClient
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _check_project(bq_client):
+def _check_project(bq_client: BigQueryClient):
     """
     Check if the project is set to test.
 
-    :param bq_client: Client
+    :param bq_client: a BigQueryClient
     :return: None if the project is set properly
     :raise: ValueError if project is not 'aou-res-curation-test'
     """
@@ -37,13 +37,13 @@ def _check_project(bq_client):
     return None
 
 
-def _filter_stale_datasets(bq_client, first_n: int = None):
+def _filter_stale_datasets(bq_client: BigQueryClient, first_n: int = None):
     """
     Get the first n datasets that meet all of the following criteria:
     1. Datasets older than 90 days
     2. Empty datasets
 
-    :param bq_client: Client
+    :param bq_client: a BigQueryClient
     :param first_n: number of datasets to return. If not specified, return all.
     :return: list of dataset names that are stale
     """
@@ -101,7 +101,7 @@ def main(first_n):
 
     pipeline_logging.configure(logging.INFO, add_console_handler=True)
 
-    bq_client = bq.get_client(os.environ.get('GOOGLE_CLOUD_PROJECT'))
+    bq_client = BigQueryClient(os.environ.get('GOOGLE_CLOUD_PROJECT'))
 
     _check_project(bq_client)
 

--- a/data_steward/tools/delete_stale_test_datasets.py
+++ b/data_steward/tools/delete_stale_test_datasets.py
@@ -15,6 +15,7 @@ from google.api_core import exceptions
 
 # Project imports
 from utils import bq, pipeline_logging
+from gcloud.bq import BigQueryClient
 
 LOGGER = logging.getLogger(__name__)
 

--- a/data_steward/tools/generate_ehr_upload_pids.py
+++ b/data_steward/tools/generate_ehr_upload_pids.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-from utils import bq
+from gcloud.bq import BigQueryClient
 
 from constants.utils import bq as bq_consts
 from common import JINJA_ENV
@@ -73,7 +73,7 @@ def generate_ehr_upload_pids_query(project_id,
     :param excluded_hpo_ids: List of sites
     :return: Query string to use in ehr_upload_pids view
     """
-    client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
     excluded_hpo_ids_str = get_excluded_hpo_ids_str(excluded_hpo_ids)
     query = EHR_UPLOAD_PIDS_BQ_SCRIPT.render(
         project_id=project_id,
@@ -81,7 +81,7 @@ def generate_ehr_upload_pids_query(project_id,
         lookup_dataset_id=bq_consts.LOOKUP_TABLES_DATASET_ID,
         hpo_mappings=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID,
         excluded_sites_str=excluded_hpo_ids_str)
-    query_job = client.query(query)
+    query_job = bq_client.query(query)
     res = query_job.result().to_dataframe()
     full_query = res["q"].to_list()[0]
     return full_query

--- a/data_steward/tools/recreate_cope_concepts.py
+++ b/data_steward/tools/recreate_cope_concepts.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 
 import common
-from utils import bq
+from gcloud.bq import BigQueryClient
 from utils import pipeline_logging
 
 LOGGER = logging.getLogger(__name__)
@@ -110,15 +110,14 @@ GROUP BY
 def update_cope_concepts(project_id, pipeline_dataset_id, vocabulary_dataset):
     """
 
-    :param project_id:
+    :param project_id: identifies the project
     :param pipeline_dataset_id:
     :param vocabulary_dataset:
     :return:
     """
-    client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
 
     queries = []
-    results = []
     # recreate concept_ancestor_cope table
     queries.append(
         COPE_DESCENDANT_QUERY.render(
@@ -138,7 +137,7 @@ def update_cope_concepts(project_id, pipeline_dataset_id, vocabulary_dataset):
 
     for q in queries:
         LOGGER.info(f'Running query -- {q}')
-        query_job = client.query(q)
+        query_job = bq_client.query(q)
         if query_job.errors:
             raise RuntimeError(
                 f"Job {query_job.job_id} failed with error {query_job.errors} for query"

--- a/data_steward/tools/run_deid.py
+++ b/data_steward/tools/run_deid.py
@@ -19,7 +19,7 @@ import bq_utils
 import deid.aou as aou
 from deid.parser import odataset_name_verification
 from resources import fields_for, fields_path, DEID_PATH
-from utils import bq
+from gcloud.bq import BigQueryClient
 from common import JINJA_ENV
 
 LOGGER = logging.getLogger(__name__)
@@ -257,7 +257,7 @@ def copy_deid_map_table(deid_map_table, project_id, lookup_dataset_id,
     :param lookup_dataset_id: Name of the dataset where the master _deid_map table is stored
     :param input_dataset_id: Name of the dataset where _deid_map dataset needs to be created.
     :param age_limit: Allowed Max_age of a participant
-    :param client: Bigquery client
+    :param client: a BigQueryClient
     :return: None
     """
     q = COPY_PID_RID_QUERY.render(map_table=deid_map_table,
@@ -277,13 +277,13 @@ def load_deid_map_table(deid_map_dataset_name, age_limit):
 
     # Create _deid_map table in input dataset
     project_id = app_identity.get_application_id()
-    client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
     deid_map_table = f'{project_id}.{deid_map_dataset_name}._deid_map'
     # Copy master _deid_map table records to _deid_map table
     if bq_utils.table_exists(DEID_MAP_TABLE,
                              dataset_id=PIPELINE_TABLES_DATASET):
         copy_deid_map_table(deid_map_table, project_id, PIPELINE_TABLES_DATASET,
-                            deid_map_dataset_name, age_limit, client)
+                            deid_map_dataset_name, age_limit, bq_client)
         logging.info(
             f"copied participants younger than {age_limit} to the table {deid_map_table}"
         )

--- a/data_steward/tools/snapshot_by_query.py
+++ b/data_steward/tools/snapshot_by_query.py
@@ -89,7 +89,7 @@ def get_source_fields(client, source_table):
     """
     Gets column names of a table in bigquery
 
-    :param client: BigQuery client
+    :param client: a BigQueryClient
     :param source_table: fully qualified table name.
 
     returns as a list of column names.

--- a/data_steward/validation/participants/snapshot_validation_dataset.py
+++ b/data_steward/validation/participants/snapshot_validation_dataset.py
@@ -120,7 +120,7 @@ def main():
     bq_client = BigQueryClient(args.project_id, credentials=impersonation_creds)
 
     dataset_id = create_snapshot(bq_client, args.snapshot_date)
-    create_id_match_tables(client, dataset_id)
+    create_id_match_tables(bq_client, dataset_id)
 
 
 if __name__ == '__main__':

--- a/data_steward/validation/participants/snapshot_validation_dataset.py
+++ b/data_steward/validation/participants/snapshot_validation_dataset.py
@@ -7,7 +7,8 @@ partitions from drc_ops.
 import argparse
 import logging
 
-from utils import bq, auth, pipeline_logging
+from utils import auth, pipeline_logging
+from gcloud.bq import BigQueryClient
 from common import DRC_OPS, CDR_SCOPES, IDENTITY_MATCH
 from constants.validation.participants.snapshot_validaiton_dataset import (
     PARTITIONS_QUERY, CREATE_TABLE_QUERY)
@@ -32,7 +33,7 @@ def create_id_match_tables(client, dataset_id):
     """
     Generate id_match tables in the specified snapshot dataset
 
-    :param client: BigQuery client
+    :param client: a BigQueryClient
     :param dataset_id: Identifies the snapshot dataset
 
     :return: None
@@ -72,7 +73,7 @@ def create_snapshot(client, date_str):
     """
     Generates the snapshot dataset based on date passed
 
-    :param client: BigQuery client
+    :param client: a BigQueryClient
     :param date_str: date string to snapshot on
     :return: 
     """
@@ -116,9 +117,9 @@ def main():
     impersonation_creds = auth.get_impersonation_credentials(
         args.run_as_email, CDR_SCOPES)
 
-    client = bq.get_client(args.project_id, credentials=impersonation_creds)
+    bq_client = BigQueryClient(args.project_id, credentials=impersonation_creds)
 
-    dataset_id = create_snapshot(client, args.snapshot_date)
+    dataset_id = create_snapshot(bq_client, args.snapshot_date)
     create_id_match_tables(client, dataset_id)
 
 

--- a/tests/integration_tests/data_steward/tools/delete_stale_test_datasets_test.py
+++ b/tests/integration_tests/data_steward/tools/delete_stale_test_datasets_test.py
@@ -5,10 +5,8 @@ Unit test for delete_stale_test_buckets module
 # Python imports
 import os
 from unittest import TestCase
-from unittest.mock import patch, Mock
-from datetime import datetime, timedelta, timezone
-
-from google.api_core.exceptions import NotFound
+from unittest.mock import patch
+from datetime import datetime, timezone
 
 # Third party imports
 from google.cloud import bigquery

--- a/tests/integration_tests/data_steward/validation/participants/validate_test.py
+++ b/tests/integration_tests/data_steward/validation/participants/validate_test.py
@@ -13,7 +13,7 @@ from unittest import TestCase
 from google.cloud.bigquery import DatasetReference, Table, TimePartitioning, TimePartitioningType, SchemaField
 
 # Project imports
-from utils import bq
+from gcloud.bq import BigQueryClient
 from tests import test_util
 from app_identity import PROJECT_ID
 from common import JINJA_ENV, PS_API_VALUES, PII_EMAIL, PII_PHONE_NUMBER, PII_NAME, PII_ADDRESS
@@ -91,7 +91,7 @@ class ValidateTest(TestCase):
         self.project_id = os.environ.get(PROJECT_ID)
         self.dataset_id = os.environ.get('COMBINED_DATASET_ID')
         self.dataset_ref = DatasetReference(self.project_id, self.dataset_id)
-        self.client = bq.get_client(self.project_id)
+        self.client = BigQueryClient(self.project_id)
 
         self.hpo_id = 'fake_site'
         self.id_match_table_id = f'{IDENTITY_MATCH_TABLE}_{self.hpo_id}'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,7 +15,7 @@ from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 from constants.utils.bq import HPO_ID_BUCKET_NAME_TABLE_ID
 from constants.validation import main
 import resources
-from utils import bq
+from gcloud.bq import BigQueryClient
 
 RESOURCES_BUCKET_FMT = '{project_id}-resources'
 
@@ -468,7 +468,7 @@ def setup_hpo_id_bucket_name_table(dataset_id):
     :param dataset_id: dataset id where the lookup table is created
     """
     project_id = app_identity.get_application_id()
-    bq_client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
 
     drop_hpo_id_bucket_name_table(dataset_id)
 
@@ -515,7 +515,7 @@ def drop_hpo_id_bucket_name_table(dataset_id):
     :param dataset_id: dataset id where the lookup table is located
     """
     project_id = app_identity.get_application_id()
-    bq_client = bq.get_client(project_id)
+    bq_client = BigQueryClient(project_id)
 
     DROP_LOOKUP_TABLE = common.JINJA_ENV.from_string("""
         DROP TABLE IF EXISTS `{{project_id}}.{{lookup_dataset_id}}.{{hpo_id_bucket_table_id}}` 

--- a/tests/unit_tests/data_steward/tools/delete_stale_test_datasets_test.py
+++ b/tests/unit_tests/data_steward/tools/delete_stale_test_datasets_test.py
@@ -62,8 +62,7 @@ class DeleteStaleTestDatasetsTest(TestCase):
         self.addCleanup(self.bq_client_patcher.stop)
 
     def test_check_project_error(self):
-        type(self.mock_bq_client).project = PropertyMock(
-            return_value='aou-wrong-project-name')
+        self.mock_bq_client.project = 'aou-wrong-project-name'
 
         with self.assertRaises(ValueError):
             delete_stale_test_datasets._check_project(self.mock_bq_client)

--- a/tests/unit_tests/data_steward/tools/delete_stale_test_datasets_test.py
+++ b/tests/unit_tests/data_steward/tools/delete_stale_test_datasets_test.py
@@ -5,7 +5,7 @@ Unit test for delete_stale_test_buckets module
 # Python imports
 import os
 from unittest import TestCase
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, PropertyMock
 from datetime import datetime, timedelta, timezone
 
 # Third party imports
@@ -56,69 +56,70 @@ class DeleteStaleTestDatasetsTest(TestCase):
 
         self.mock_table = Mock()
 
-    @patch('tools.delete_stale_test_datasets.bq')
-    def test_check_project_error(self, mock_bq):
-        mock_bq.get_client.project = 'aou-wrong-project-name'
+    @patch('tools.delete_stale_test_datasets.BigQueryClient')
+    def test_check_project_error(self, mock_bq_client):
+        type(mock_bq_client).project = PropertyMock(
+            return_value='aou-wrong-project-name')
 
         with self.assertRaises(ValueError):
-            delete_stale_test_datasets._check_project(mock_bq.get_client)
+            delete_stale_test_datasets._check_project(mock_bq_client)
 
-    @patch('tools.delete_stale_test_datasets.bq')
-    def test_filter_stale_datasets_all_not_empty(self, mock_bq):
+    @patch('tools.delete_stale_test_datasets.BigQueryClient')
+    def test_filter_stale_datasets_all_not_empty(self, mock_bq_client):
         """Test case: All datasets are NOT empty.
         """
-        mock_bq.get_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq.get_client.get_dataset.side_effect = self.datasets
-        mock_bq.get_client.list_tables.return_value = [
+        mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        mock_bq_client.get_dataset.side_effect = self.datasets
+        mock_bq_client.list_tables.return_value = [
             self.mock_table for _ in range(0, 3)
         ]
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq.get_client, 100)
+            mock_bq_client, 100)
 
         self.assertEqual(result, [])
 
-    @patch('tools.delete_stale_test_datasets.bq')
-    def test_filter_stale_datasets_all_empty(self, mock_bq):
+    @patch('tools.delete_stale_test_datasets.BigQueryClient')
+    def test_filter_stale_datasets_all_empty(self, mock_bq_client):
         """Test case: All datasets are empty.
         """
-        mock_bq.get_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq.get_client.get_dataset.side_effect = self.datasets
-        mock_bq.get_client.list_tables.return_value = []
+        mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        mock_bq_client.get_dataset.side_effect = self.datasets
+        mock_bq_client.list_tables.return_value = []
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq.get_client, 100)
+            mock_bq_client, 100)
 
         self.assertEqual(result, [
             self.mock_old_dataset_list_item_1.dataset_id,
             self.mock_old_dataset_list_item_2.dataset_id
         ])
 
-    @patch('tools.delete_stale_test_datasets.bq')
-    def test_filter_stale_datasets_first_n_not_given(self, mock_bq):
+    @patch('tools.delete_stale_test_datasets.BigQueryClient')
+    def test_filter_stale_datasets_first_n_not_given(self, mock_bq_client):
         """Test case: All buckets are empty. first_n not given.
         """
-        mock_bq.get_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq.get_client.get_dataset.side_effect = self.datasets
-        mock_bq.get_client.list_tables.return_value = []
+        mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        mock_bq_client.get_dataset.side_effect = self.datasets
+        mock_bq_client.list_tables.return_value = []
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq.get_client)
+            mock_bq_client)
 
         self.assertEqual(result, [
             self.mock_old_dataset_list_item_1.dataset_id,
             self.mock_old_dataset_list_item_2.dataset_id
         ])
 
-    @patch('tools.delete_stale_test_datasets.bq')
-    def test_filter_stale_datasets_first_n_given(self, mock_bq):
+    @patch('tools.delete_stale_test_datasets.BigQueryClient')
+    def test_filter_stale_datasets_first_n_given(self, mock_bq_client):
         """Test case: All buckets are empty. first_n given. first_n < # of stale buckets.
         """
-        mock_bq.get_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq.get_client.get_dataset.side_effect = self.datasets
-        mock_bq.get_client.list_tables.return_value = []
+        mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        mock_bq_client.get_dataset.side_effect = self.datasets
+        mock_bq_client.list_tables.return_value = []
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq.get_client, 1)
+            mock_bq_client, 1)
 
         self.assertEqual(result, [self.mock_old_dataset_list_item_1.dataset_id])

--- a/tests/unit_tests/data_steward/tools/delete_stale_test_datasets_test.py
+++ b/tests/unit_tests/data_steward/tools/delete_stale_test_datasets_test.py
@@ -56,70 +56,70 @@ class DeleteStaleTestDatasetsTest(TestCase):
 
         self.mock_table = Mock()
 
-    @patch('tools.delete_stale_test_datasets.BigQueryClient')
-    def test_check_project_error(self, mock_bq_client):
-        type(mock_bq_client).project = PropertyMock(
+        self.bq_client_patcher = patch(
+            'tools.delete_stale_test_datasets.BigQueryClient')
+        self.mock_bq_client = self.bq_client_patcher.start()
+        self.addCleanup(self.bq_client_patcher.stop)
+
+    def test_check_project_error(self):
+        type(self.mock_bq_client).project = PropertyMock(
             return_value='aou-wrong-project-name')
 
         with self.assertRaises(ValueError):
-            delete_stale_test_datasets._check_project(mock_bq_client)
+            delete_stale_test_datasets._check_project(self.mock_bq_client)
 
-    @patch('tools.delete_stale_test_datasets.BigQueryClient')
-    def test_filter_stale_datasets_all_not_empty(self, mock_bq_client):
+    def test_filter_stale_datasets_all_not_empty(self):
         """Test case: All datasets are NOT empty.
         """
-        mock_bq_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq_client.get_dataset.side_effect = self.datasets
-        mock_bq_client.list_tables.return_value = [
+        self.mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        self.mock_bq_client.get_dataset.side_effect = self.datasets
+        self.mock_bq_client.list_tables.return_value = [
             self.mock_table for _ in range(0, 3)
         ]
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq_client, 100)
+            self.mock_bq_client, 100)
 
         self.assertEqual(result, [])
 
-    @patch('tools.delete_stale_test_datasets.BigQueryClient')
-    def test_filter_stale_datasets_all_empty(self, mock_bq_client):
+    def test_filter_stale_datasets_all_empty(self):
         """Test case: All datasets are empty.
         """
-        mock_bq_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq_client.get_dataset.side_effect = self.datasets
-        mock_bq_client.list_tables.return_value = []
+        self.mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        self.mock_bq_client.get_dataset.side_effect = self.datasets
+        self.mock_bq_client.list_tables.return_value = []
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq_client, 100)
+            self.mock_bq_client, 100)
 
         self.assertEqual(result, [
             self.mock_old_dataset_list_item_1.dataset_id,
             self.mock_old_dataset_list_item_2.dataset_id
         ])
 
-    @patch('tools.delete_stale_test_datasets.BigQueryClient')
-    def test_filter_stale_datasets_first_n_not_given(self, mock_bq_client):
+    def test_filter_stale_datasets_first_n_not_given(self,):
         """Test case: All buckets are empty. first_n not given.
         """
-        mock_bq_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq_client.get_dataset.side_effect = self.datasets
-        mock_bq_client.list_tables.return_value = []
+        self.mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        self.mock_bq_client.get_dataset.side_effect = self.datasets
+        self.mock_bq_client.list_tables.return_value = []
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq_client)
+            self.mock_bq_client)
 
         self.assertEqual(result, [
             self.mock_old_dataset_list_item_1.dataset_id,
             self.mock_old_dataset_list_item_2.dataset_id
         ])
 
-    @patch('tools.delete_stale_test_datasets.BigQueryClient')
-    def test_filter_stale_datasets_first_n_given(self, mock_bq_client):
+    def test_filter_stale_datasets_first_n_given(self):
         """Test case: All buckets are empty. first_n given. first_n < # of stale buckets.
         """
-        mock_bq_client.list_datasets.return_value = self.dataset_list_items
-        mock_bq_client.get_dataset.side_effect = self.datasets
-        mock_bq_client.list_tables.return_value = []
+        self.mock_bq_client.list_datasets.return_value = self.dataset_list_items
+        self.mock_bq_client.get_dataset.side_effect = self.datasets
+        self.mock_bq_client.list_tables.return_value = []
 
         result = delete_stale_test_datasets._filter_stale_datasets(
-            mock_bq_client, 1)
+            self.mock_bq_client, 1)
 
         self.assertEqual(result, [self.mock_old_dataset_list_item_1.dataset_id])

--- a/tests/unit_tests/data_steward/tools/migrate_cdm52_to_cdm531_test.py
+++ b/tests/unit_tests/data_steward/tools/migrate_cdm52_to_cdm531_test.py
@@ -122,15 +122,13 @@ FROM
         expected_query = '''SELECT * FROM `test-project.test-dataset.non_cdm_table`'''
         self.assertEqual(actual_query, expected_query)
 
-    @mock.patch('utils.bq.get_client')
+    @mock.patch('tools.migrate_cdm52_to_cdm531.BigQueryClient')
     @mock.patch('tools.snapshot_by_query.create_empty_cdm_tables')
     @mock.patch('tools.snapshot_by_query.get_source_fields')
     def test_get_upgrade_hpo_table_query(self, mock_source_fields,
-                                         mock_create_tables, mock_get_client):
+                                         mock_create_tables, mock_bq_client):
         hpo_id = 'fake'
-        mock_client = mock.MagicMock()
-        mock_client.project = self.project_id
-        mock_get_client.return_value = mock_client
+        mock_bq_client.return_value = self.mock_client
         mocked_fields = []
         for table in resources.CDM_TABLES + PII_TABLES:
             fields = self.get_mock_fields(table)
@@ -152,12 +150,12 @@ FROM
             all_tables.extend(tables)
             call_q = mock.call(
                 migrate_cdm52_to_cdm531.get_upgrade_table_query(
-                    mock_client, self.dataset_id, f'{hpo_id}_{table}', hpo_id),
-                mock.ANY)
+                    self.mock_client, self.dataset_id, f'{hpo_id}_{table}',
+                    hpo_id), mock.ANY)
             mock_query_calls.append(call_q)
-        mock_client.list_tables.return_value = all_tables
+        self.mock_client.list_tables.return_value = all_tables
         mock_job = mock.MagicMock(job_id=None, result=lambda: None)
-        mock_client.query.return_value = mock_job
+        self.mock_client.query.return_value = mock_job
         migrate_cdm52_to_cdm531.schema_upgrade_cdm52_to_cdm531(
             self.project_id, self.dataset_id, self.snapshot_dataset_id, hpo_id)
-        mock_client.query.assert_has_calls(mock_query_calls)
+        self.mock_client.query.assert_has_calls(mock_query_calls)


### PR DESCRIPTION
Implements the new BigQueryClient by replacing bq.get_client(...) calls in data_steward/tools folder files:

- data_steward/tools/create_tier.py
- data_steward/tools/delete_stale_test_datasets.py
- data_steward/tools/generate_ehr_upload_pids.py
- data_steward/tools/migrate_cdm52_to_cdm531.py
- data_steward/tools/recreate_cope_concepts.py
- data_steward/tools/run_deid.py
- data_steward/tools/snapshot_by_query.py
data_steward/validation/participants/snapshot_validation_dataset.py
Associated tests