### PR TITLE
[DC-1800] Added a copy of the fitbit dataset to the output-prod script

### DIFF
--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -113,6 +113,13 @@ def get_arg_parser() -> argparse.ArgumentParser:
                                  required=True,
                                  choices=DEID_STAGE_LIST)
 
+    argument_parser.add_argument('-f',
+                                 '--fitbit_dataset',
+                                 action='store',
+                                 dest='fitbit_dataset_id',
+                                 help='fitbit dataset to copy',
+                                 required=True)
+
     return argument_parser
 
 
@@ -148,7 +155,16 @@ if __name__ == '__main__':
                                        output_dataset_name, description, labels)
     bq_client.create_dataset(dataset_object, exists_ok=False)
 
-    #Copy tables from source to destination
+    #Copy fitbit tables to source dataset
+    LOGGER.info(
+        f'Copying fitbit tables from dataset {args.src_project_id}.{args.fitbit_dataset_id} to {args.src_project_id}.{args.src_dataset_id}...'
+    )
+
+    bq.copy_datasets(bq_client,
+                     f'{args.src_project_id}.{args.fitbit_dataset_id}',
+                     f'{args.src_project_id}.{args.src_dataset_id}')
+
+    #Copy tables from source to output-prod
     LOGGER.info(
         f'Copying tables from dataset {args.src_project_id}.{args.src_dataset_id} to {args.output_prod_project_id}.{output_dataset_name}...'
     )

--- a/tests/unit_tests/data_steward/tools/copy_dataset_to_output_prod_test.py
+++ b/tests/unit_tests/data_steward/tools/copy_dataset_to_output_prod_test.py
@@ -22,7 +22,8 @@ class CopyDatasetToOutputProdTest(unittest.TestCase):
         test_args = [
             "--run_as", "myemail.com", "-s", "mysrcproject", "-o",
             "mydestproject", "-d", "mysrcdataset", "-r", "2021Q2R4", "-t",
-            "controlled", "--deid_stage", "base"
+            "controlled", "--deid_stage", "base", "--fitbit_dataset",
+            "myfitbitdataset"
         ]
 
         args = self.parser.parse_args(test_args)
@@ -32,7 +33,8 @@ class CopyDatasetToOutputProdTest(unittest.TestCase):
         test_args = [
             "--run_as", "myemail.com", "-s", "mysrcproject", "-o",
             "mydestproject", "-d", "mysrcdataset", "-r", "2021q2r4", "-t",
-            "controlled", "--deid_stage", "base"
+            "controlled", "--deid_stage", "base", "--fitbit_dataset",
+            "myfitbitdataset"
         ]
 
         self.assertRaises(SystemExit, self.parser.parse_args, test_args)
@@ -41,7 +43,8 @@ class CopyDatasetToOutputProdTest(unittest.TestCase):
         test_args = [
             "--run_as", "myemail.com", "-s", "mysrcproject", "-o",
             "mydestproject", "-d", "mysrcdataset", "-r", "2021Q2R4", "-t",
-            "controlled", "--deid_stage", "extra_cleaned"
+            "controlled", "--deid_stage", "extra_cleaned", "--fitbit_dataset",
+            "myfitbitdataset"
         ]
 
         self.assertRaises(SystemExit, self.parser.parse_args, test_args)
@@ -50,7 +53,8 @@ class CopyDatasetToOutputProdTest(unittest.TestCase):
         test_args = [
             "--run_as", "myemail.com", "-s", "mysrcproject", "-o",
             "mydestproject", "-d", "mysrcdataset", "-r", "2021Q2R4", "-t",
-            "CONTROLLED", "--deid_stage", "clean"
+            "CONTROLLED", "--deid_stage", "clean", "--fitbit_dataset",
+            "myfitbitdataset"
         ]
 
         self.assertRaises(SystemExit, self.parser.parse_args, test_args)


### PR DESCRIPTION
The `copy_dataset_to_output_prod.py` script now contains a statement to copy fitbit tables into the deid or clean dataset.