### PR TITLE
[DC-2172] Replace bq.get_table_schema(...) calls in data_steward/cdr_cleaner/clearning_rules

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/identifying_field_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/identifying_field_suppression.py
@@ -28,15 +28,13 @@ Should occur after data remapping rules.
 Should not be applied to mapping tables or other non-OMOP tables.
 """
 import logging
-import json
-import os
 
 # Project imports
 from constants import bq_utils as bq_consts
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 from common import JINJA_ENV, CDM_TABLES
 from gcloud.bq import BigQueryClient
-from utils import pipeline_logging, bq
+from utils import pipeline_logging
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
 from cdr_cleaner.cleaning_rules.table_suppression import TableSuppression
 

--- a/data_steward/cdr_cleaner/cleaning_rules/identifying_field_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/identifying_field_suppression.py
@@ -35,6 +35,7 @@ import os
 from constants import bq_utils as bq_consts
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 from common import JINJA_ENV, CDM_TABLES
+from gcloud.bq import BigQueryClient
 from utils import pipeline_logging, bq
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
 from cdr_cleaner.cleaning_rules.table_suppression import TableSuppression
@@ -104,7 +105,8 @@ class IDFieldSuppression(BaseCleaningRule):
         """
         queries = []
         for table in self.affected_tables:
-            schema = bq.get_table_schema(table)
+            bq_client = BigQueryClient(self.project_id)
+            schema = bq_client.get_table_schema(table)
             statements = []
             for item in schema:
                 if item.name in fields:

--- a/tests/unit_tests/data_steward/cdr_cleaner/args_parser_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/args_parser_test.py
@@ -3,9 +3,6 @@ import os
 import unittest
 
 from cdr_cleaner import args_parser as parser
-import cdr_cleaner.clean_cdr as control
-import constants.cdr_cleaner.clean_cdr as cdr_consts
-import constants.cdr_cleaner.reporter as consts
 
 
 class CleanRulesArgsParserTest(unittest.TestCase):

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/base_cleaning_rule_test.py
@@ -7,7 +7,6 @@ The point is to make it explicitly clear what is and is not required.
 import unittest
 
 # Third party imports
-import googleapiclient
 import oauth2client
 import test_util
 from mock import patch

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
@@ -51,7 +51,6 @@ class PpiBranchingTest(unittest.TestCase):
         self.dataset_id = 'fake_dataset'
         self.sandbox_dataset_id = 'fake_sandbox'
         self.observation_schema = _get_table_schema('observation')
-
         self.mock_bq_client_patcher = mock.patch(
             'cdr_cleaner.cleaning_rules.ppi_branching.BigQueryClient')
         self.mock_bq_client = self.mock_bq_client_patcher.start()
@@ -59,7 +58,6 @@ class PpiBranchingTest(unittest.TestCase):
         self.mock_client = mock.MagicMock()
         self.mock_bq_client.return_value = self.mock_client
         self.mock_client.get_table_schema.return_value = self.observation_schema
-
         self.cleaning_rule = PpiBranching(self.project_id, self.dataset_id,
                                           self.sandbox_dataset_id)
 

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
@@ -7,7 +7,6 @@ from pandas import DataFrame
 from cdr_cleaner.cleaning_rules.ppi_branching import OBSERVATION_BACKUP_TABLE_ID
 from cdr_cleaner.cleaning_rules.ppi_branching import PPI_BRANCHING_RULE_PATHS
 from cdr_cleaner.cleaning_rules.ppi_branching import PpiBranching, OBSERVATION
-from utils.bq import get_table_schema
 
 
 def _get_csv_row_count() -> int:
@@ -24,6 +23,21 @@ def _get_csv_row_count() -> int:
     return csv_row_count
 
 
+def _get_table_schema(table_name):
+    from resources import fields_for
+    fields = fields_for(table_name)
+    schema = []
+    for column in fields:
+        name = column.get('name')
+        field_type = column.get('type')
+        column_def = bigquery.SchemaField(name,
+                                          field_type).from_api_repr(column)
+
+        schema.append(column_def)
+
+    return schema
+
+
 class PpiBranchingTest(unittest.TestCase):
 
     @classmethod
@@ -36,7 +50,16 @@ class PpiBranchingTest(unittest.TestCase):
         self.project_id = 'fake_project'
         self.dataset_id = 'fake_dataset'
         self.sandbox_dataset_id = 'fake_sandbox'
-        self.observation_schema = get_table_schema('observation')
+        self.observation_schema = _get_table_schema('observation')
+
+        self.mock_bq_client_patcher = mock.patch(
+            'cdr_cleaner.cleaning_rules.ppi_branching.BigQueryClient')
+        self.mock_bq_client = self.mock_bq_client_patcher.start()
+        self.addCleanup(self.mock_bq_client_patcher.stop)
+        self.mock_client = mock.MagicMock()
+        self.mock_bq_client.return_value = self.mock_client
+        self.mock_client.get_table_schema.return_value = self.observation_schema
+
         self.cleaning_rule = PpiBranching(self.project_id, self.dataset_id,
                                           self.sandbox_dataset_id)
 

--- a/tests/unit_tests/data_steward/cdr_cleaner/reporter_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/reporter_test.py
@@ -1,8 +1,6 @@
-import csv
 import logging
 import mock
 from google.cloud import bigquery
-import os
 import unittest
 
 from cdr_cleaner import reporter

--- a/tests/unit_tests/data_steward/cdr_cleaner/reporter_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/reporter_test.py
@@ -187,14 +187,18 @@ class CleanRulesReporterTest(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    @mock.patch(
+        'cdr_cleaner.cleaning_rules.identifying_field_suppression.BigQueryClient'
+    )
     @mock.patch('cdr_cleaner.cleaning_rules.ppi_branching.BigQueryClient')
-    def test_get_stage_elements(self, mock_bq_client):
+    def test_get_stage_elements(self, mock_branching_client,
+                                mock_supression_client):
         """
         Makes sure the lists are all readable.
         """
         # preconditions
         mock_client = mock.MagicMock()
-        mock_bq_client.return_value = mock_client
+        mock_branching_client.return_value = mock_supression_client.return_value = mock_client
         mock_client.get_table_schema.return_value = _get_table_schema(
             'observation')
         fields_list = ['name', 'module', 'sql', 'jira-issues', 'description']

--- a/tests/unit_tests/data_steward/cdr_cleaner/reporter_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/reporter_test.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import mock
+from google.cloud import bigquery
 import os
 import unittest
 
@@ -15,6 +16,21 @@ def mock_function_obj(self):
     A mock description.
     """
     pass
+
+
+def _get_table_schema(table_name):
+    from resources import fields_for
+    fields = fields_for(table_name)
+    schema = []
+    for column in fields:
+        name = column.get('name')
+        field_type = column.get('type')
+        column_def = bigquery.SchemaField(name,
+                                          field_type).from_api_repr(column)
+
+        schema.append(column_def)
+
+    return schema
 
 
 class CleanRulesReporterTest(unittest.TestCase):
@@ -171,11 +187,16 @@ class CleanRulesReporterTest(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
-    def test_get_stage_elements(self):
+    @mock.patch('cdr_cleaner.cleaning_rules.ppi_branching.BigQueryClient')
+    def test_get_stage_elements(self, mock_bq_client):
         """
         Makes sure the lists are all readable.
         """
         # preconditions
+        mock_client = mock.MagicMock()
+        mock_bq_client.return_value = mock_client
+        mock_client.get_table_schema.return_value = _get_table_schema(
+            'observation')
         fields_list = ['name', 'module', 'sql', 'jira-issues', 'description']
 
         # test


### PR DESCRIPTION
Replaces all bq.get_table_schema(...) calls with BigQueryClient.get_table_schema(...) in data_steward/cdr_cleaner/clearning_rules folder files and associated unit tests.