### PR TITLE
[DC-2254] Refactor qrid check in RDR export notebook

### DIFF
--- a/data_steward/analytics/cdr_ops/rdr_export_qc.py
+++ b/data_steward/analytics/cdr_ops/rdr_export_qc.py
@@ -584,9 +584,9 @@ execute(client, query)
 
 # Survey data in the RDR export should all have **questionnaire_response_id**
 # except the pmi skip data backfilled by Curation cleaning rule.
-# [DC-1776](https://precisionmedicineinitiative.atlassian.net/browse/DC-1776).
-# [DC-2254](https://precisionmedicineinitiative.atlassian.net/browse/DC-2254)
 # Any violations should be reported to the RDR team.
+# [DC-1776](https://precisionmedicineinitiative.atlassian.net/browse/DC-1776).
+# [DC-2254](https://precisionmedicineinitiative.atlassian.net/browse/DC-2254).
 
 tpl = JINJA_ENV.from_string('''
 SELECT  

--- a/data_steward/analytics/cdr_ops/rdr_export_qc.py
+++ b/data_steward/analytics/cdr_ops/rdr_export_qc.py
@@ -583,7 +583,9 @@ execute(client, query)
 # # Check for missing questionnaire_response_id
 
 # Survey data in the RDR export should all have **questionnaire_response_id**
+# except the pmi skip data backfilled by Curation cleaning rule.
 # [DC-1776](https://precisionmedicineinitiative.atlassian.net/browse/DC-1776).
+# [DC-2254](https://precisionmedicineinitiative.atlassian.net/browse/DC-2254)
 # Any violations should be reported to the RDR team.
 
 tpl = JINJA_ENV.from_string('''
@@ -595,6 +597,7 @@ JOIN `{{project_id}}.{{new_rdr}}.concept_ancestor` ON (concept_id=ancestor_conce
 JOIN `{{project_id}}.{{new_rdr}}.observation` ON (descendant_concept_id=observation_concept_id)
 WHERE concept_class_id='Module'
 AND concept_name IN ('The Basics', 'Lifestyle', 'Overall Health') -- restrict to PPI 1-3 --
+AND NOT (observation_id >= 1000000000000 AND value_as_concept_id = 903096) -- exclude records from backfill pmi skip --
 AND questionnaire_response_id IS NULL
 GROUP BY 1
 ''')

--- a/data_steward/analytics/cdr_ops/rdr_export_qc.py
+++ b/data_steward/analytics/cdr_ops/rdr_export_qc.py
@@ -592,11 +592,8 @@ tpl = JINJA_ENV.from_string('''
 SELECT  
     person_id, 
     STRING_AGG(observation_source_value) AS observation_source_value
-FROM `{{project_id}}.{{new_rdr}}.concept` 
-JOIN `{{project_id}}.{{new_rdr}}.concept_ancestor` ON (concept_id=ancestor_concept_id)
-JOIN `{{project_id}}.{{new_rdr}}.observation` ON (descendant_concept_id=observation_concept_id)
-WHERE concept_class_id='Module'
-AND concept_name IN ('The Basics', 'Lifestyle', 'Overall Health') -- restrict to PPI 1-3 --
+FROM `{{project_id}}.{{new_rdr}}.observation`
+WHERE observation_type_concept_id = 45905771 -- is a survey response --
 AND NOT (observation_id >= 1000000000000 AND value_as_concept_id = 903096) -- exclude records from backfill pmi skip --
 AND questionnaire_response_id IS NULL
 GROUP BY 1

--- a/data_steward/cdr_cleaner/cleaning_rules/backfill_pmi_skip_codes.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/backfill_pmi_skip_codes.py
@@ -8,121 +8,156 @@ LOGGER = logging.getLogger(__name__)
 OBSERVATION_TABLE_NAME = 'observation'
 
 PMI_SKIP_FIX_QUERY = """
-    SELECT 
-       coalesce(obs.observation_id,
-         ques.observation_id) AS observation_id,
-       coalesce(obs.person_id,
-         ques.person_id) AS person_id,
-       coalesce(obs.observation_concept_id,
-         ques.observation_concept_id) AS observation_concept_id,
-       coalesce(obs.observation_date,
-         ques.default_observation_date) AS observation_date,
-       coalesce(obs.observation_datetime,
-         ques.default_observation_datetime) AS observation_datetime,
-       coalesce(obs.observation_type_concept_id,
-         ques.observation_type_concept_id) AS observation_type_concept_id,
-       value_as_number,
-       value_as_string,
-       coalesce(obs.value_as_concept_id,
-         903096) AS value_as_concept_id,
-       coalesce(obs.qualifier_concept_id,
-         0) AS qualifier_concept_id,
-       coalesce(obs.unit_concept_id,
-         0) AS unit_concept_id,
-       provider_id,
-       visit_occurrence_id,
-       visit_detail_id,
-       coalesce(obs.observation_source_value,
-         ques.observation_source_value) AS observation_source_value,
-       coalesce(obs.observation_source_concept_id,
-         ques.observation_source_concept_id) AS observation_source_concept_id,
-       unit_source_value,
-       qualifier_source_value,
-       coalesce(obs.value_source_concept_id,
-         903096) AS value_source_concept_id,
-     case 
-     when obs.value_source_concept_id = 903096 Then 'PMI_Skip' 
-     when value_source_concept_id = 903096 Then 'PMI_Skip' 
-     else obs.value_source_value 
-     end as value_source_value, 
-       questionnaire_response_id 
-     FROM
-       `{project}.{dataset}.observation` AS obs
-      FULL OUTER JOIN (
-       WITH
-         per AS (
-         SELECT
-           DISTINCT obs.person_id,
-           per.gender_concept_id
-         FROM
-           `{project}.{dataset}.observation` obs
-         JOIN
-           `{project}.{dataset}.person` AS per
-         ON
-           obs.person_id = per.person_id
-         WHERE
-           observation_source_concept_id IN (1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889,
-          1585890, 1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 1585886, 1585857, 1586166, 1586174,
-          1586182, 1586190, 1586198, 1585636, 1585766, 1585772, 1585778, 1585711, 1585717, 1585723, 1585729,
-          1585735, 1585741, 1585747, 1585748, 1585754, 1585760, 1585803, 1585815, 1585784)
-          ),
-         obs AS (
-         SELECT
-           DISTINCT observation_concept_id,
-           observation_source_concept_id,
-           observation_source_value,
-           observation_type_concept_id
-         FROM
-           `{project}.{dataset}.observation`
-         WHERE
-           observation_source_concept_id IN (1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889,
-          1585890, 1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 1585886, 1585857, 1586166, 1586174,
-          1586182, 1586190, 1586198, 1585636, 1585766, 1585772, 1585778, 1585711, 1585717, 1585723, 1585729,
-          1585735, 1585741, 1585747, 1585748, 1585754, 1585760, 1585803, 1585815, 1585784)
-          ),
-         dte AS (
-         SELECT
-           person_id,
-           MAX(observation_date) AS default_observation_date,
-           MAX(observation_datetime) AS default_observation_datetime
-         FROM
-           `{project}.{dataset}.observation`
-         WHERE
-           observation_source_concept_id IN (1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889,
-          1585890, 1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 1585886, 1585857, 1586166, 1586174,
-          1586182, 1586190, 1586198, 1585636, 1585766, 1585772, 1585778, 1585711, 1585717, 1585723, 1585729,
-          1585735, 1585741, 1585747, 1585748, 1585754, 1585760, 1585803, 1585815, 1585784)
-         GROUP BY
-           person_id)
-       SELECT
-         ROW_NUMBER() OVER() + 1000000000000 AS observation_id,
-         cartesian.*,
-         dte.default_observation_date,
-         dte.default_observation_datetime
-       FROM (
-         SELECT
-           per.person_id,
-           observation_concept_id,
-           observation_source_concept_id,
-           observation_source_value,
-           observation_type_concept_id
-         FROM
-           per,
-           obs
-         WHERE
-           (observation_source_concept_id != 1585784)
-           OR (per.gender_concept_id = 8532
-             AND observation_source_concept_id = 1585784) 
-           ) cartesian
-       JOIN
-         dte
-       ON
-         cartesian.person_id = dte.person_id
-       ORDER BY
-         cartesian.person_id ) AS ques
+  SELECT 
+    coalesce(
+      obs.observation_id,
+      ques.observation_id
+      ) AS observation_id,
+    coalesce(
+      obs.person_id,
+      ques.person_id
+      ) AS person_id,
+    coalesce(
+      obs.observation_concept_id,
+      ques.observation_concept_id
+      ) AS observation_concept_id,
+    coalesce(
+      obs.observation_date,
+      ques.default_observation_date
+      ) AS observation_date,
+    coalesce(
+      obs.observation_datetime,
+      ques.default_observation_datetime
+      ) AS observation_datetime,
+    coalesce(
+      obs.observation_type_concept_id,
+      ques.observation_type_concept_id
+      ) AS observation_type_concept_id,
+    value_as_number,
+    value_as_string,
+    coalesce(
+      obs.value_as_concept_id, 903096
+      ) AS value_as_concept_id,
+    coalesce(
+      obs.qualifier_concept_id, 0
+      ) AS qualifier_concept_id,
+    coalesce(
+      obs.unit_concept_id, 0
+      ) AS unit_concept_id,
+    provider_id,
+    visit_occurrence_id,
+    visit_detail_id,
+    coalesce(
+      obs.observation_source_value,
+      ques.observation_source_value
+      ) AS observation_source_value,
+    coalesce(
+      obs.observation_source_concept_id,
+      ques.observation_source_concept_id
+      ) AS observation_source_concept_id,
+    unit_source_value,
+    qualifier_source_value,
+    coalesce(
+      obs.value_source_concept_id, 903096
+      ) AS value_source_concept_id,
+    case 
+      when obs.value_source_concept_id = 903096 Then 'PMI_Skip' 
+      when value_source_concept_id = 903096 Then 'PMI_Skip' 
+      else obs.value_source_value 
+      end as value_source_value, 
+    questionnaire_response_id 
+  FROM
+    `{project}.{dataset}.observation` AS obs
+  FULL OUTER JOIN (
+    WITH
+      per AS (
+        SELECT DISTINCT 
+          obs.person_id, 
+          per.gender_concept_id
+        FROM
+          `{project}.{dataset}.observation` obs
+        JOIN
+          `{project}.{dataset}.person` AS per
+        ON
+          obs.person_id = per.person_id
+        WHERE
+          observation_source_concept_id IN (
+            1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889,
+            1585890, 1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 
+            1585886, 1585857, 1586166, 1586174, 1586182, 1586190, 1586198, 
+            1585636, 1585766, 1585772, 1585778, 1585711, 1585717, 1585723, 
+            1585729, 1585735, 1585741, 1585747, 1585748, 1585754, 1585760, 
+            1585803, 1585815, 1585784
+            )
+        ),
+      obs AS (
+        SELECT DISTINCT 
+          observation_concept_id,
+          observation_source_concept_id,
+          observation_source_value,
+          observation_type_concept_id
+        FROM
+          `{project}.{dataset}.observation`
+        WHERE
+          observation_source_concept_id IN (
+            1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889,
+            1585890, 1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 
+            1585886, 1585857, 1586166, 1586174, 1586182, 1586190, 1586198, 
+            1585636, 1585766, 1585772, 1585778, 1585711, 1585717, 1585723, 
+            1585729, 1585735, 1585741, 1585747, 1585748, 1585754, 1585760, 
+            1585803, 1585815, 1585784
+            )
+        ),
+      dte AS (
+        SELECT
+          person_id,
+          MAX(observation_date) AS default_observation_date,
+          MAX(observation_datetime) AS default_observation_datetime
+        FROM
+          `{project}.{dataset}.observation`
+        WHERE
+          observation_source_concept_id IN (
+            1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889,
+            1585890, 1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 
+            1585886, 1585857, 1586166, 1586174, 1586182, 1586190, 1586198, 
+            1585636, 1585766, 1585772, 1585778, 1585711, 1585717, 1585723, 
+            1585729, 1585735, 1585741, 1585747, 1585748, 1585754, 1585760, 
+            1585803, 1585815, 1585784
+            )
+        GROUP BY
+          person_id
+        )
+    SELECT
+      ROW_NUMBER() OVER() + 1000000000000 AS observation_id,
+      cartesian.*,
+      dte.default_observation_date,
+      dte.default_observation_datetime
+    FROM (
+      SELECT
+        per.person_id,
+        observation_concept_id,
+        observation_source_concept_id,
+        observation_source_value,
+        observation_type_concept_id
+      FROM
+        per,
+        obs
+      WHERE
+        (observation_source_concept_id != 1585784)
+      OR (
+        per.gender_concept_id = 8532
+        AND observation_source_concept_id = 1585784) 
+        ) cartesian
+      JOIN
+        dte
       ON
-       obs.person_id = ques.person_id
-       AND obs.observation_concept_id = ques.observation_concept_id
+        cartesian.person_id = dte.person_id
+      ORDER BY
+        cartesian.person_id 
+      ) AS ques
+  ON
+    obs.person_id = ques.person_id
+    AND obs.observation_concept_id = ques.observation_concept_id
 """
 
 


### PR DESCRIPTION
`data_steward/cdr_cleaner/cleaning_rules/backfill_pmi_skip_codes.py` ... Only the linting for the SQL statement is updated. No change in the logic.