### PR TITLE
[DC-2216] Replace bq.get_table_schema(...) calls in data_steward/tools

### DIFF
--- a/data_steward/tools/fitbit/generate_fitbit_dataset.py
+++ b/data_steward/tools/fitbit/generate_fitbit_dataset.py
@@ -97,7 +97,7 @@ def copy_fitbit_tables_from_views(client, from_dataset, to_dataset,
     :return:
     """
     for table in FITBIT_TABLES:
-        schema_list = bq.get_table_schema(table)
+        schema_list = client.get_table_schema(table)
         fq_dest_table = f'{client.project}.{to_dataset}.{table}'
         dest_table = Table(fq_dest_table, schema=schema_list)
         dest_table = client.create_table(dest_table)

--- a/data_steward/tools/import_rdr_omop.py
+++ b/data_steward/tools/import_rdr_omop.py
@@ -79,7 +79,7 @@ def create_rdr_tables(client, rdr_dataset, bucket):
     schema_dict.update(resources.rdr_specific_schemas())
 
     for table, schema in schema_dict.items():
-        schema_list = bq.get_table_schema(table, schema)
+        schema_list = client.get_table_schema(table, schema)
         table_id = f'{client.project}.{rdr_dataset}.{table}'
         job_config = bigquery.LoadJobConfig(
             schema=schema_list,

--- a/data_steward/tools/load_archived_submission.py
+++ b/data_steward/tools/load_archived_submission.py
@@ -12,7 +12,6 @@ from gcloud.bq import BigQueryClient
 from google.cloud.exceptions import GoogleCloudError
 
 from common import AOU_REQUIRED, JINJA_ENV
-from utils.bq import get_table_schema
 import constants.bq_utils as bq_consts
 
 LOGGER = logging.getLogger(__name__)
@@ -86,7 +85,7 @@ def load_folder(dst_dataset: str, bq_client: BigQueryClient, bucket_name: str,
         if table_name not in AOU_REQUIRED:
             LOGGER.debug(f'Skipping file for {table_name}')
             continue
-        schema = get_table_schema(table_name)
+        schema = bq_client.get_table_schema(table_name)
         hpo_table_name = f'{hpo_id}_{table_name}'
         fq_hpo_table = f'{bq_client.project}.{dst_dataset}.{hpo_table_name}'
         destination = Table(fq_hpo_table, schema=schema)

--- a/tests/integration_tests/data_steward/tools/combine_ehr_rdr_test.py
+++ b/tests/integration_tests/data_steward/tools/combine_ehr_rdr_test.py
@@ -1,7 +1,6 @@
 # Python imports
 import os
 import unittest
-from io import open
 
 import mock
 

--- a/tests/integration_tests/data_steward/tools/load_vocab_test.py
+++ b/tests/integration_tests/data_steward/tools/load_vocab_test.py
@@ -1,8 +1,8 @@
 import unittest
 import os
 from pathlib import Path
-import mock
 import csv
+import mock
 
 from google.cloud import bigquery
 

--- a/tests/unit_tests/data_steward/tools/exclude_site_submission_test.py
+++ b/tests/unit_tests/data_steward/tools/exclude_site_submission_test.py
@@ -7,7 +7,7 @@ from google.cloud.bigquery import DatasetReference
 import bq_utils
 from resources import CDM_TABLES
 from tests.bq_test_helpers import list_item_from_table_id
-from tools.exclude_site_submission import exclude_site_submission, _filter_hpo_tables
+from tools.exclude_site_submission import exclude_site_submission
 
 
 class ExcludeSiteSubmissionTest(unittest.TestCase):

--- a/tests/unit_tests/data_steward/tools/generate_ehr_upload_pids_test.py
+++ b/tests/unit_tests/data_steward/tools/generate_ehr_upload_pids_test.py
@@ -1,6 +1,5 @@
 import unittest
 
-from utils import bq
 from tools import generate_ehr_upload_pids as eup
 
 


### PR DESCRIPTION
Replaces all `bq.get_table_schema(...)` calls with `BigQueryClient.get_table_schema(...)` in data_steward/tools folder files and associated unit tests.