### PR TITLE
[DC-2188] Relocate bq.py helper functions

### DIFF
--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -211,8 +211,59 @@ class BigQueryClient(Client):
         :return: tables contained within the requested dataset
         """
         _MAX_RESULTS_PADDING = 100
-        table_count = super(BigQueryClient,
-                            self).list_tables(dataset=dataset).num_results
+        table_count = self.get_table_count(dataset)
         return super(BigQueryClient, self).list_tables(dataset=dataset,
                                                        max_results=table_count +
                                                        _MAX_RESULTS_PADDING)
+
+    def get_table_count(self, dataset: bigquery.DatasetReference) -> int:
+        """
+        Get the number of tables currently in a specified dataset
+
+        :param client: active bigquery client
+        :param dataset: the dataset
+        :return: number of tables
+        :raises:
+            google.cloud.exceptions.GoogleCloudError:
+                If the job failed.
+            concurrent.futures.TimeoutError:
+                If the job did not complete in the given timeout.
+        """
+
+        TABLE_COUNT_TPL = JINJA_ENV.from_string(
+            "SELECT COUNT(1) table_count FROM `{{dataset.project}}.{{dataset.dataset_id}}.__TABLES__`"
+        )
+        """Query template to retrieve the number of tables in a dataset.
+        Requires parameter `dataset`: :class:`DatasetReference` and
+        yields a scalar result with column `table_count`: :class:`int`."""
+
+        q = TABLE_COUNT_TPL.render(dataset=dataset)
+        return self.to_scalar(self.query(q))
+
+    def to_scalar(
+        self, result: typing.Union[bigquery.table.RowIterator,
+                                   bigquery.QueryJob]
+    ) -> typing.Any:
+        """
+        Get a scalar query result
+
+        :param result: a query job or a resultant :class:`bigquery.table.RowIterator`
+        :return: the singular result value
+        """
+        row_iter = None
+        if isinstance(result, bigquery.table.RowIterator):
+            row_iter = result
+        elif isinstance(result, bigquery.QueryJob):
+            row_iter = result.result()
+        else:
+            raise ValueError(
+                f'Scalar result requires a RowIterator or QueryJob '
+                f'but `{type(result)}` was supplied.')
+        if row_iter.total_rows != 1:
+            raise ValueError(f'Cannot get scalar result from '
+                             f'row iterator with {row_iter.total_rows} rows.')
+        _, row = next(enumerate(row_iter))
+        if len(row_iter.schema) == 1:
+            return row[0]
+
+        return dict(row.items())

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -220,7 +220,6 @@ class BigQueryClient(Client):
         """
         Get the number of tables currently in a specified dataset
 
-        :param client: active bigquery client
         :param dataset: the dataset
         :return: number of tables
         :raises:

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -184,7 +184,7 @@ class BigQueryClient(Client):
 
         return dataset
 
-    def copy_datasets(self, input_dataset: str, output_dataset: str):
+    def copy_dataset(self, input_dataset: str, output_dataset: str):
         """
         Copies tables from source dataset to a destination datasets
 
@@ -195,7 +195,7 @@ class BigQueryClient(Client):
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         for table in tables:
-            staging_table = f'{output_dataset}.{table.table_id}'
+            staging_table = f'{self.project}.{output_dataset}.{table.table_id}'
             self.copy_table(table, staging_table)
 
     def list_tables(
@@ -205,7 +205,9 @@ class BigQueryClient(Client):
         List all tables in a dataset
 
         NOTE: Ensures all results are retrieved by first getting total
-        table count and setting max_results in list tables API call
+        table count and setting max_results in list tables API call. 
+        Without setting max_results, the API has a bug causing it to 
+        randomly return 0 tables.
 
         :param dataset: the dataset containing the tables
         :return: tables contained within the requested dataset

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -198,8 +198,8 @@ class BigQueryClient(Client):
             staging_table = f'{self.project}.{output_dataset}.{table.table_id}'
             self.copy_table(table, staging_table)
 
-    def list_dataset_tables(
-        self, dataset: bigquery.DatasetReference
+    def list_tables(
+        self, dataset: typing.Union[bigquery.DatasetReference, str]
     ) -> typing.Iterator[bigquery.table.TableListItem]:
         """
         List all tables in a dataset
@@ -213,6 +213,7 @@ class BigQueryClient(Client):
         :return: tables contained within the requested dataset
         """
         _MAX_RESULTS_PADDING = 100
+        dataset = self.get_dataset(dataset)
         table_count = self.get_table_count(dataset)
         return super(BigQueryClient, self).list_tables(dataset=dataset,
                                                        max_results=table_count +

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -2,7 +2,6 @@
 Interact with Google Cloud BigQuery
 """
 # Python stl imports
-import os
 import typing
 
 # Third-party imports
@@ -184,3 +183,36 @@ class BigQueryClient(Client):
         dataset.location = "US"
 
         return dataset
+
+    def copy_datasets(self, input_dataset: str, output_dataset: str):
+        """
+        Copies tables from source dataset to a destination datasets
+
+        :param input_dataset: name of the input dataset
+        :param output_dataset: name of the output dataset
+        :return:
+        """
+        # Copy input dataset tables to backup and staging datasets
+        tables = super(BigQueryClient, self).list_tables(input_dataset)
+        for table in tables:
+            staging_table = f'{output_dataset}.{table.table_id}'
+            self.copy_table(table, staging_table)
+
+    def list_tables(
+        self, dataset: bigquery.DatasetReference
+    ) -> typing.Iterator[bigquery.table.TableListItem]:
+        """
+        List all tables in a dataset
+
+        NOTE: Ensures all results are retrieved by first getting total
+        table count and setting max_results in list tables API call
+
+        :param dataset: the dataset containing the tables
+        :return: tables contained within the requested dataset
+        """
+        _MAX_RESULTS_PADDING = 100
+        table_count = super(BigQueryClient,
+                            self).list_tables(dataset=dataset).num_results
+        return super(BigQueryClient, self).list_tables(dataset=dataset,
+                                                       max_results=table_count +
+                                                       _MAX_RESULTS_PADDING)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -198,7 +198,7 @@ class BigQueryClient(Client):
             staging_table = f'{self.project}.{output_dataset}.{table.table_id}'
             self.copy_table(table, staging_table)
 
-    def list_tables(
+    def list_dataset_tables(
         self, dataset: bigquery.DatasetReference
     ) -> typing.Iterator[bigquery.table.TableListItem]:
         """

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -536,7 +536,10 @@ def query_sheet_linked_bq_table(project_id, table_content_query,
 
     return result_df
 
-
+@deprecated(
+    reason=
+    'Use gcloud.bq.BigQueryClient.to_scalar(self, result: typing.Union[bigquery.table.RowIterator,bigquery.QueryJob]) instead'
+)
 def to_scalar(
     result: typing.Union[bigquery.table.RowIterator, bigquery.QueryJob]
 ) -> typing.Any:
@@ -563,7 +566,10 @@ def to_scalar(
 
     return dict(row.items())
 
-
+@deprecated(
+    reason=
+    'Use gcloud.bq.BigQueryClient.get_table_count(self, dataset: bigquery.DatasetReference) instead'
+)
 def get_table_count(client: bigquery.Client,
                     dataset: bigquery.DatasetReference) -> int:
     """

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -614,7 +614,7 @@ def list_tables(
 
 @deprecated(
     reason=
-    'Use gcloud.bq.BigQueryClient.copy_datasets(self, input_dataset, output_dataset) instead'
+    'Use gcloud.bq.BigQueryClient.copy_dataset(self, input_dataset, output_dataset) instead'
 )
 def copy_datasets(client: bigquery.Client, input_dataset, output_dataset):
     """

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -536,6 +536,7 @@ def query_sheet_linked_bq_table(project_id, table_content_query,
 
     return result_df
 
+
 @deprecated(
     reason=
     'Use gcloud.bq.BigQueryClient.to_scalar(self, result: typing.Union[bigquery.table.RowIterator,bigquery.QueryJob]) instead'
@@ -565,6 +566,7 @@ def to_scalar(
         return row[0]
 
     return dict(row.items())
+
 
 @deprecated(
     reason=

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -592,7 +592,7 @@ def get_table_count(client: bigquery.Client,
 
 @deprecated(
     reason=
-    'Use gcloud.bq.BigQueryClient.list_tables(self, dataset: bigquery.DatasetReference) instead'
+    'Use gcloud.bq.BigQueryClient.list_dataset_tables(self, dataset: bigquery.DatasetReference) instead'
 )
 def list_tables(
     client: bigquery.Client, dataset: bigquery.DatasetReference

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -592,7 +592,7 @@ def get_table_count(client: bigquery.Client,
 
 @deprecated(
     reason=
-    'Use gcloud.bq.BigQueryClient.list_dataset_tables(self, dataset: bigquery.DatasetReference) instead'
+    'Use gcloud.bq.BigQueryClient.list_tables(self, dataset: bigquery.DatasetReference) instead'
 )
 def list_tables(
     client: bigquery.Client, dataset: bigquery.DatasetReference

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -581,6 +581,7 @@ def get_table_count(client: bigquery.Client,
     q = TABLE_COUNT_TPL.render(dataset=dataset)
     return to_scalar(client.query(q))
 
+
 @deprecated(
     reason=
     'Use gcloud.bq.BigQueryClient.list_tables(self, dataset: bigquery.DatasetReference) instead'
@@ -601,6 +602,7 @@ def list_tables(
     table_count = get_table_count(client, dataset)
     return client.list_tables(dataset=dataset,
                               max_results=table_count + _MAX_RESULTS_PADDING)
+
 
 @deprecated(
     reason=

--- a/data_steward/utils/bq.py
+++ b/data_steward/utils/bq.py
@@ -203,7 +203,7 @@ def _to_sql_field(field: bigquery.SchemaField) -> bigquery.SchemaField:
                                                                   bigquery.SchemaField] = None,
                                                                   cluster_by_cols: typing.List[str] = None,
                                                                   as_query: str = None,
-                                                                  **table_options) 
+                                                                  **table_options)
                                                                 instead
     """)
 def get_create_or_replace_table_ddl(project_id: str,
@@ -581,7 +581,10 @@ def get_table_count(client: bigquery.Client,
     q = TABLE_COUNT_TPL.render(dataset=dataset)
     return to_scalar(client.query(q))
 
-
+@deprecated(
+    reason=
+    'Use gcloud.bq.BigQueryClient.list_tables(self, dataset: bigquery.DatasetReference) instead'
+)
 def list_tables(
     client: bigquery.Client, dataset: bigquery.DatasetReference
 ) -> typing.Iterator[bigquery.table.TableListItem]:
@@ -599,7 +602,10 @@ def list_tables(
     return client.list_tables(dataset=dataset,
                               max_results=table_count + _MAX_RESULTS_PADDING)
 
-
+@deprecated(
+    reason=
+    'Use gcloud.bq.BigQueryClient.copy_datasets(self, input_dataset, output_dataset) instead'
+)
 def copy_datasets(client: bigquery.Client, input_dataset, output_dataset):
     """
     Copies tables from source dataset to a destination datasets

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
@@ -9,8 +9,6 @@ all domain tables """
 # Python Imports
 import os
 
-from google.cloud.bigquery import Table
-
 # Project Imports
 from common import CONDITION_OCCURRENCE, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
@@ -9,6 +9,8 @@ all domain tables """
 # Python Imports
 import os
 
+from google.cloud.bigquery import Table
+
 # Project Imports
 from common import CONDITION_OCCURRENCE, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/domain_alignment_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/domain_alignment_test.py
@@ -109,7 +109,7 @@ class DomainAlignmentTest(BaseTest.CleaningRulesTestBase):
         """
         # Copy vocab tables over to the test dataset
         vocabulary_dataset = cls.client.get_dataset(vocabulary_id)
-        for src_table in bq.list_tables(cls.client, vocabulary_dataset):
+        for src_table in cls.client.list_tables(vocabulary_dataset):
             schema = cls.client.get_table_schema(src_table.table_id)
             destination = f'{cls.project_id}.{cls.dataset_id}.{src_table.table_id}'
             dst_table = cls.client.create_table(Table(destination,

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -256,7 +256,7 @@ class BQCTest(TestCase):
 
     @patch.object(BigQueryClient, 'get_table_count')
     @patch('gcloud.bq.Client.list_tables')
-    def test_list_tables(self, mock_list_tables, mock_get_table_count):
+    def test_list_dataset_tables(self, mock_list_tables, mock_get_table_count):
         #pre conditions
         table_ids = ['table_1', 'table_2']
         table_count = len(table_ids)
@@ -264,7 +264,7 @@ class BQCTest(TestCase):
         _MAX_RESULTS_PADDING = 100
         expected_max_results = table_count + _MAX_RESULTS_PADDING
 
-        self.client.list_tables(self.dataset_ref)
+        self.client.list_dataset_tables(self.dataset_ref)
         #post conditions
         mock_list_tables.assert_called_with(dataset=self.dataset_ref,
                                             max_results=expected_max_results)

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -1,12 +1,13 @@
 # Python imports
+import datetime
 from unittest import TestCase
 import os
-import typing
-from unittest.mock import MagicMock
+from typing import FrozenSet, List, Union, Dict, Iterable, Any
+from collections import OrderedDict
 
 # Third party imports
 from google.cloud import bigquery
-from mock import patch
+from mock import patch, MagicMock, Mock
 from google.cloud.bigquery import TableReference
 from google.cloud.bigquery.table import TableListItem
 from google.cloud.bigquery import DatasetReference
@@ -25,7 +26,7 @@ class DummyClient(BigQueryClient):
     def __init__(self):
         self.project: str = 'bar_project'
 
-    def _get_all_field_types(self,) -> typing.FrozenSet[str]:
+    def _get_all_field_types(self,) -> FrozenSet[str]:
         """
         Helper to get all field types referenced in fields (json) files
 
@@ -59,6 +60,94 @@ class DummyClient(BigQueryClient):
                 TableReference.from_string(table_id).to_api_repr()
         }
         return TableListItem(resource)
+
+    def mock_query_result(self,
+                          rows: List[Union[Dict, OrderedDict]],
+                          key_order: Iterable[Any] = None):
+        """
+        Create a mock RowIterator as returned by :meth:`bigquery.QueryJob.result`
+        from rows represented as a list of dictionaries
+
+        :param rows: A list of dictionaries representing result rows
+        :param key_order: If `rows` refers to a list of dict rather than OrderedDict, 
+            specifies how fields are ordered in the result schema. This parameter is 
+            ignored if `rows` refers to a list of OrderedDict.
+        :return: a mock RowIterator
+        """
+        mock_row_iter = MagicMock(spec=bigquery.table.RowIterator)
+        mock_row_iter.total_rows = len(rows)
+        row0 = rows[0]
+        if isinstance(row0, OrderedDict):
+            _rows = rows
+        else:
+            _rows = [self._to_ordered_dict(row, key_order) for row in rows]
+            row0 = _rows[0]
+
+        mock_row_iter.schema = list(self.fields_from_dict(row0))
+        field_to_index = {key: i for i, key in enumerate(row0.keys())}
+        mock_row_iter.__iter__ = Mock(return_value=iter([
+            bigquery.table.Row(list(row.values()), field_to_index)
+            for row in _rows
+        ]))
+        return mock_row_iter
+
+    def _to_ordered_dict(self, d: dict, key_order: Iterable[Any] = None):
+        """
+        Convert a dict to OrderedDict with a specified order
+        :param d: instance to convert
+        :param key_order: specifies how items are ordered in the result
+        :return: the ordered dict
+        """
+        if len(d) == 1:
+            return OrderedDict(d)
+        else:
+            if key_order is None:
+                raise ValueError(
+                    'Parameter key_order is required in order to convert'
+                    ' a dict with multiple items to OrderedDict')
+        return OrderedDict((key, d[key]) for key in key_order)
+
+    def fields_from_dict(self, row):
+        """
+        Get schema fields from a row represented as a dictionary
+
+        :param row: the dictionary to infer schema for
+        :return: list of schema field objects
+        
+        Example:
+            >>> from tests import bq_test_helpers
+            >>> d = {'item': 'book', 'qty': 2, 'price': 1.99}
+            >>> bq_test_helpers.fields_from_dict(d)
+                [SchemaField('item', 'STRING', 'NULLABLE', None, ()),
+                SchemaField('qty', 'INT64', 'NULLABLE', None, ()),
+                SchemaField('price', 'FLOAT64', 'NULLABLE', None, ())]
+        """
+        return [
+            self._field_from_key_value(key, value)
+            for key, value in row.items()
+        ]
+
+    def _field_from_key_value(self, key: str,
+                              value: Any) -> bigquery.SchemaField:
+        """
+        Get a schema field object from a key and value
+        
+        :param key: name of the field
+        :param value: value of the field
+        :return: an appropriate schema field object
+        """
+        _TYPE_TO_FIELD_TYPE = {
+            str(int): 'INT64',
+            str(str): 'STRING',
+            str(float): 'FLOAT64',
+            str(datetime.date): 'DATE',
+            str(datetime.datetime): 'TIMESTAMP'
+        }
+        tpe = str(type(value))
+        field_type = _TYPE_TO_FIELD_TYPE.get(tpe)
+        if not field_type:
+            raise NotImplementedError(f'The type for {value} is not supported')
+        return bigquery.SchemaField(name=key, field_type=field_type)
 
 
 class BQCTest(TestCase):
@@ -173,17 +262,47 @@ class BQCTest(TestCase):
         mock_list_tables.assert_called_once_with(self.dataset_id)
         self.assertEqual(mock_copy_table.call_count, len(list_tables_results))
 
+    @patch.object(BigQueryClient, 'get_table_count')
     @patch('gcloud.bq.Client.list_tables')
-    def test_list_tables(self, mock_list_tables):
+    def test_list_tables(self, mock_list_tables, mock_get_table_count):
         #pre conditions
         table_ids = ['table_1', 'table_2']
         table_count = len(table_ids)
+        mock_get_table_count.return_value = table_count
         _MAX_RESULTS_PADDING = 100
         expected_max_results = table_count + _MAX_RESULTS_PADDING
-        mock_list_results = MagicMock()
-        mock_list_tables.side_effect = [mock_list_results, mock_list_tables]
-        mock_list_results.num_results = table_count
+
         self.client.list_tables(self.dataset_ref)
-        #post condition
+        #post conditions
         mock_list_tables.assert_called_with(dataset=self.dataset_ref,
                                             max_results=expected_max_results)
+
+    def test_to_scalar(self):
+        scalar_int = dict(num=100)
+        mock_iter = self.client.mock_query_result([scalar_int])
+        result = self.client.to_scalar(mock_iter)
+        self.assertEqual(100, result)
+
+        today = datetime.date.today()
+        scalar_date = dict(today=today)
+        mock_iter = self.client.mock_query_result([scalar_date])
+        result = self.client.to_scalar(mock_iter)
+        self.assertEqual(today, result)
+
+        now = datetime.datetime.now()
+        scalar_datetime = dict(now=now)
+        mock_iter = self.client.mock_query_result([scalar_datetime])
+        result = self.client.to_scalar(mock_iter)
+        self.assertEqual(now, result)
+
+        scalar_struct = dict(num_1=100, num_2=200)
+        scalar_struct_iter = self.client.mock_query_result([scalar_struct],
+                                                           ['num_2', 'num_1'])
+        result = self.client.to_scalar(scalar_struct_iter)
+        self.assertDictEqual(scalar_struct, result)
+
+        scalar_int_1 = dict(num=1)
+        scalar_int_2 = dict(num=2)
+        mock_iter = self.client.mock_query_result([scalar_int_1, scalar_int_2])
+        with self.assertRaises(ValueError) as c:
+            self.client.to_scalar(mock_iter)

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -254,17 +254,20 @@ class BQCTest(TestCase):
         mock_list_tables.assert_called_once_with(self.dataset_id)
         self.assertEqual(mock_copy_table.call_count, len(list_tables_results))
 
+    @patch.object(BigQueryClient, 'get_dataset')
     @patch.object(BigQueryClient, 'get_table_count')
     @patch('gcloud.bq.Client.list_tables')
-    def test_list_dataset_tables(self, mock_list_tables, mock_get_table_count):
+    def test_list_tables(self, mock_list_tables, mock_get_table_count,
+                         mock_get_dataset):
         #pre conditions
         table_ids = ['table_1', 'table_2']
         table_count = len(table_ids)
         mock_get_table_count.return_value = table_count
+        mock_get_dataset.return_value = self.dataset_ref
         _MAX_RESULTS_PADDING = 100
         expected_max_results = table_count + _MAX_RESULTS_PADDING
 
-        self.client.list_dataset_tables(self.dataset_ref)
+        self.client.list_tables(self.dataset_ref)
         #post conditions
         mock_list_tables.assert_called_with(dataset=self.dataset_ref,
                                             max_results=expected_max_results)

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -8,9 +8,8 @@ from collections import OrderedDict
 # Third party imports
 from google.cloud import bigquery
 from mock import patch, MagicMock, Mock
-from google.cloud.bigquery import TableReference
+from google.cloud.bigquery import TableReference, DatasetReference
 from google.cloud.bigquery.table import TableListItem
-from google.cloud.bigquery import DatasetReference
 
 # Project imports
 from gcloud.bq import BigQueryClient


### PR DESCRIPTION
- Relocates `to_scalar(...)`, `get_table_count(...)`, `list_tables(...)`, and `copy_datasets(...)` helper functions from data_steward/utils/bq.py to be methods of the new `BigQueryClient`.