### PR TITLE
[DC-2315] Replace bq.copy_datasets(...) calls in data_steward/tools

### DIFF
--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -205,8 +205,8 @@ class BigQueryClient(Client):
         List all tables in a dataset
 
         NOTE: Ensures all results are retrieved by first getting total
-        table count and setting max_results in list tables API call. 
-        Without setting max_results, the API has a bug causing it to 
+        table count and setting max_results in list tables API call.
+        Without setting max_results, the API has a bug causing it to
         randomly return 0 tables.
 
         :param dataset: the dataset containing the tables

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -160,14 +160,14 @@ if __name__ == '__main__':
         f'Copying fitbit tables from dataset {args.src_project_id}.{args.fitbit_dataset_id} to {args.src_project_id}.{args.src_dataset_id}...'
     )
 
-    bq_client.copy_datasets(f'{args.src_project_id}.{args.fitbit_dataset_id}',
-                            f'{args.src_project_id}.{args.src_dataset_id}')
+    bq_client.copy_dataset(f'{args.src_project_id}.{args.fitbit_dataset_id}',
+                           f'{args.src_project_id}.{args.src_dataset_id}')
 
     #Copy tables from source to output-prod
     LOGGER.info(
         f'Copying tables from dataset {args.src_project_id}.{args.src_dataset_id} to {args.output_prod_project_id}.{output_dataset_name}...'
     )
-    bq_client.copy_datasets(
+    bq_client.copy_dataset(
         f'{args.src_project_id}.{args.src_dataset_id}',
         f'{args.output_prod_project_id}.{output_dataset_name}')
 

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -160,16 +160,16 @@ if __name__ == '__main__':
         f'Copying fitbit tables from dataset {args.src_project_id}.{args.fitbit_dataset_id} to {args.src_project_id}.{args.src_dataset_id}...'
     )
 
-    bq.copy_datasets(bq_client,
-                     f'{args.src_project_id}.{args.fitbit_dataset_id}',
-                     f'{args.src_project_id}.{args.src_dataset_id}')
+    bq_client.copy_datasets(f'{args.src_project_id}.{args.fitbit_dataset_id}',
+                            f'{args.src_project_id}.{args.src_dataset_id}')
 
     #Copy tables from source to output-prod
     LOGGER.info(
         f'Copying tables from dataset {args.src_project_id}.{args.src_dataset_id} to {args.output_prod_project_id}.{output_dataset_name}...'
     )
-    bq.copy_datasets(bq_client, f'{args.src_project_id}.{args.src_dataset_id}',
-                     f'{args.output_prod_project_id}.{output_dataset_name}')
+    bq_client.copy_datasets(
+        f'{args.src_project_id}.{args.src_dataset_id}',
+        f'{args.output_prod_project_id}.{output_dataset_name}')
 
     #Append extra columns to person table
     LOGGER.info(f'Appending extract columns to the person table...')

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -211,7 +211,7 @@ def create_tier(credentials_filepath, project_id, tier, input_dataset,
     # Create intermediary datasets and copy tables from input dataset to newly created dataset
     datasets = create_datasets(bq_client, final_dataset_name, input_dataset,
                                tier, release_tag)
-    bq.copy_datasets(bq_client, input_dataset, datasets[consts.STAGING])
+    bq_client.copy_datasets(input_dataset, datasets[consts.STAGING])
 
     # Run cleaning rules
     cleaning_args = [

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -211,7 +211,7 @@ def create_tier(credentials_filepath, project_id, tier, input_dataset,
     # Create intermediary datasets and copy tables from input dataset to newly created dataset
     datasets = create_datasets(bq_client, final_dataset_name, input_dataset,
                                tier, release_tag)
-    bq_client.copy_datasets(input_dataset, datasets[consts.STAGING])
+    bq_client.copy_dataset(input_dataset, datasets[consts.STAGING])
 
     # Run cleaning rules
     cleaning_args = [

--- a/data_steward/tools/fitbit/generate_fitbit_dataset.py
+++ b/data_steward/tools/fitbit/generate_fitbit_dataset.py
@@ -233,8 +233,8 @@ def main(raw_args=None):
                                   args.fitbit_dataset,
                                   fitbit_datasets[consts.BACKUP],
                                   table_prefix='v_')
-    bq.copy_datasets(bq_client, fitbit_datasets[consts.BACKUP],
-                     fitbit_datasets[consts.STAGING])
+    bq_client.copy_datasets(fitbit_datasets[consts.BACKUP],
+                            fitbit_datasets[consts.STAGING])
 
     common_cleaning_args = [
         '-p',

--- a/data_steward/tools/fitbit/generate_fitbit_dataset.py
+++ b/data_steward/tools/fitbit/generate_fitbit_dataset.py
@@ -233,8 +233,8 @@ def main(raw_args=None):
                                   args.fitbit_dataset,
                                   fitbit_datasets[consts.BACKUP],
                                   table_prefix='v_')
-    bq_client.copy_datasets(fitbit_datasets[consts.BACKUP],
-                            fitbit_datasets[consts.STAGING])
+    bq_client.copy_dataset(fitbit_datasets[consts.BACKUP],
+                           fitbit_datasets[consts.STAGING])
 
     common_cleaning_args = [
         '-p',

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
@@ -9,6 +9,8 @@ all domain tables """
 # Python Imports
 import os
 
+from google.cloud.bigquery import Table
+
 # Project Imports
 from common import CONDITION_OCCURRENCE, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -47,11 +47,11 @@ class DummyClient(BigQueryClient):
 
     def list_item_from_table_id(self, fq_table_id: str) -> TableListItem:
         """
-        Get a table list item as returned by :meth:`bigquery.Client.list_tables` 
+        Get a table list item as returned by :meth:`bigquery.Client.list_tables`
         from a fully qualified table ID
-        
-        :param table_id: A fully qualified table ID that includes project ID, dataset ID, and table ID, 
-        each separated by ``.``. 
+
+        :param table_id: A fully qualified table ID that includes project ID, dataset ID, and table ID,
+        each separated by ``.``.
         :return: a table list item
         """
         resource = {
@@ -68,8 +68,8 @@ class DummyClient(BigQueryClient):
         from rows represented as a list of dictionaries
 
         :param rows: A list of dictionaries representing result rows
-        :param key_order: If `rows` refers to a list of dict rather than OrderedDict, 
-            specifies how fields are ordered in the result schema. This parameter is 
+        :param key_order: If `rows` refers to a list of dict rather than OrderedDict,
+            specifies how fields are ordered in the result schema. This parameter is
             ignored if `rows` refers to a list of OrderedDict.
         :return: a mock RowIterator
         """
@@ -106,7 +106,7 @@ class DummyClient(BigQueryClient):
 
         :param row: the dictionary to infer schema for
         :return: list of schema field objects
-        
+
         Example:
             >>> from tests import bq_test_helpers
             >>> d = {'item': 'book', 'qty': 2, 'price': 1.99}
@@ -124,7 +124,7 @@ class DummyClient(BigQueryClient):
                               value: Any) -> bigquery.SchemaField:
         """
         Get a schema field object from a key and value
-        
+
         :param key: name of the field
         :param value: value of the field
         :return: an appropriate schema field object

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -399,7 +399,7 @@ class CreateTierTest(unittest.TestCase):
                                                 self.input_dataset, self.tier,
                                                 self.release_tag)
 
-        self.mock_bq_client.copy_datasets.assert_called_with(
+        self.mock_bq_client.copy_dataset.assert_called_with(
             self.input_dataset, datasets[consts.STAGING])
 
         mock_add_kwargs.assert_called_with(controlled_tier_cleaning_args,

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -351,7 +351,6 @@ class CreateTierTest(unittest.TestCase):
     @mock.patch('tools.create_tier.create_schemaed_snapshot_dataset')
     @mock.patch('tools.create_tier.clean_cdr.main')
     @mock.patch('tools.create_tier.add_kwargs_to_args')
-    @mock.patch('tools.create_tier.bq.copy_datasets')
     @mock.patch('tools.create_tier.create_datasets')
     @mock.patch('tools.create_tier.get_dataset_name')
     @mock.patch('tools.create_tier.BigQueryClient')
@@ -359,7 +358,7 @@ class CreateTierTest(unittest.TestCase):
     @mock.patch('tools.create_tier.validate_create_tier_args')
     def test_create_tier(self, mock_validate_args, mock_impersonate_credentials,
                          mock_client, mock_dataset_name, mock_create_datasets,
-                         mock_copy_datasets, mock_add_kwargs, mock_cdr_main,
+                         mock_add_kwargs, mock_cdr_main,
                          mock_create_schemaed_snapshot):
         final_dataset_name = f"{self.tier[0].upper()}{self.release_tag}_{self.deid_stage}"
         datasets = {
@@ -375,7 +374,7 @@ class CreateTierTest(unittest.TestCase):
         ]
         mock_dataset_name.return_value = final_dataset_name
         mock_create_datasets.return_value = datasets
-        client = mock_client.return_value = self.mock_bq_client
+        mock_client.return_value = self.mock_bq_client
         cleaning_args = mock_add_kwargs.return_value = controlled_tier_cleaning_args
         kwargs = {}
 
@@ -395,12 +394,13 @@ class CreateTierTest(unittest.TestCase):
         mock_dataset_name.assert_called_with(self.tier, self.release_tag,
                                              self.deid_stage)
 
-        mock_create_datasets.asserd_called_with(client, final_dataset_name,
+        mock_create_datasets.asserd_called_with(self.mock_bq_client,
+                                                final_dataset_name,
                                                 self.input_dataset, self.tier,
                                                 self.release_tag)
 
-        mock_copy_datasets.assert_called_with(client, self.input_dataset,
-                                              datasets[consts.STAGING])
+        self.mock_bq_client.copy_datasets.assert_called_with(
+            self.input_dataset, datasets[consts.STAGING])
 
         mock_add_kwargs.assert_called_with(controlled_tier_cleaning_args,
                                            kwargs)


### PR DESCRIPTION
- Replaces all `bq.copy_datasets(...)` calls with `BigQueryClient.copy_dataset(...)` in data_steward/tools folder.
- Updates associated tests.
