### PR TITLE
[DC-2351] Change order of `DropParticipantsWithoutPPI` cleaning rule

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -204,7 +204,6 @@ COMBINED_CLEANING_CLASSES = [
     # setup_query_execution function to load dependencies before query execution
     (
         domain_alignment.domain_alignment,),
-    (DropParticipantsWithoutPPI,),
     (clean_years.get_year_of_birth_queries,),
     (NegativeAges,),
     # Valid Death dates needs to be applied before no data after death as running no data after death is
@@ -231,6 +230,8 @@ COMBINED_CLEANING_CLASSES = [
     (RemoveParticipantDataPastDeactivationDate,),
     (validate_missing_participants.delete_records_for_non_matching_participants,
     ),
+    (DropParticipantsWithoutPPI,
+    ),  # dependent on RemoveParticipantDataPastDeactivationDate
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
@@ -295,6 +296,8 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (CancerConceptSuppression,),  # Should run after any data remapping rules
     (AggregateZipCodes,),
     (SectionParticipationConceptSuppression,),
+    (DropParticipantsWithoutPPI,
+    ),  # dependent on RemoveParticipantDataPastDeactivationDate
     (RemoveExtraTables,),  # Should be last cleaning rule to be run
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
@@ -338,6 +341,8 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),
     (CancerConceptSuppression,),
+    (DropParticipantsWithoutPPI,
+    ),  # dependent on RemoveParticipantDataPastDeactivationDate
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
@@ -17,6 +17,8 @@ As part of this effort, the condition for dropping has been modified to particip
 """
 import logging
 
+from cdr_cleaner.cleaning_rules.remove_participant_data_past_deactivation_date import \
+    RemoveParticipantDataPastDeactivationDate
 from common import JINJA_ENV, PERSON
 from cdr_cleaner.cleaning_rules.drop_rows_for_missing_persons import DropMissingParticipants
 from constants.cdr_cleaner import clean_cdr as cdr_consts
@@ -81,7 +83,8 @@ class DropParticipantsWithoutPPI(DropMissingParticipants):
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id,
-                         namer=namer)
+                         namer=namer,
+                         depends_on=[RemoveParticipantDataPastDeactivationDate])
 
     def get_query_specs(self):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/drop_rows_for_missing_persons.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_rows_for_missing_persons.py
@@ -43,9 +43,16 @@ class DropMissingParticipants(BaseCleaningRule):
     Drops participant data for pids missing from the person table
     """
 
-    def __init__(self, issue_numbers, description, affected_datasets,
-                 affected_tables, project_id, dataset_id, sandbox_dataset_id,
-                 namer):
+    def __init__(self,
+                 issue_numbers,
+                 description,
+                 affected_datasets,
+                 affected_tables,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 namer,
+                 depends_on=None):
         desc = f'Sandbox and remove rows for PIDs missing from the person table.'
 
         super().__init__(
@@ -56,6 +63,7 @@ class DropMissingParticipants(BaseCleaningRule):
             project_id=project_id,
             dataset_id=dataset_id,
             sandbox_dataset_id=sandbox_dataset_id,
+            depends_on=depends_on,
             table_namer=namer)
 
     def get_query_specs(self):


### PR DESCRIPTION
* [DC-2351] Update order of CR and add depends_on

[DC-2351]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ