### PR TITLE
[DC-2318] Replace bq.get_create_or_replace_table_ddl(...) calls in cleaning_rules folder

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/ppi_branching.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ppi_branching.py
@@ -319,7 +319,6 @@ class PpiBranching(BaseCleaningRule):
         query = BACKUP_ROWS_QUERY.render(lookup_table=self.lookup_table,
                                          src_table=self.observation_table)
         return self.bq_client.get_create_or_replace_table_ddl(
-            project_id=self.backup_table.project,
             dataset_id=self.backup_table.dataset_id,
             table_id=self.backup_table.table_id,
             schema=observation_schema,
@@ -338,7 +337,6 @@ class PpiBranching(BaseCleaningRule):
         query = CLEANED_ROWS_QUERY.render(src=self.observation_table,
                                           backup=self.backup_table)
         return self.bq_client.get_create_or_replace_table_ddl(
-            project_id=self.stage_table.project,
             dataset_id=self.stage_table.dataset_id,
             table_id=self.stage_table.table_id,
             schema=observation_schema,
@@ -364,7 +362,6 @@ class PpiBranching(BaseCleaningRule):
         stage = self.stage_table
         query = f'''SELECT * FROM `{stage.project}.{stage.dataset_id}.{stage.table_id}`'''
         return self.bq_client.get_create_or_replace_table_ddl(
-            project_id=self.observation_table.project,
             dataset_id=self.observation_table.dataset_id,
             schema=observation_schema,
             table_id=self.observation_table.table_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/ppi_branching.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ppi_branching.py
@@ -337,7 +337,7 @@ class PpiBranching(BaseCleaningRule):
         observation_schema = self.bq_client.get_table_schema(OBSERVATION)
         query = CLEANED_ROWS_QUERY.render(src=self.observation_table,
                                           backup=self.backup_table)
-        return bq.get_create_or_replace_table_ddl(
+        return self.bq_client.get_create_or_replace_table_ddl(
             project_id=self.stage_table.project,
             dataset_id=self.stage_table.dataset_id,
             table_id=self.stage_table.table_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/ppi_branching.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/ppi_branching.py
@@ -318,7 +318,7 @@ class PpiBranching(BaseCleaningRule):
         observation_schema = self.bq_client.get_table_schema(OBSERVATION)
         query = BACKUP_ROWS_QUERY.render(lookup_table=self.lookup_table,
                                          src_table=self.observation_table)
-        return bq.get_create_or_replace_table_ddl(
+        return self.bq_client.get_create_or_replace_table_ddl(
             project_id=self.backup_table.project,
             dataset_id=self.backup_table.dataset_id,
             table_id=self.backup_table.table_id,
@@ -363,7 +363,7 @@ class PpiBranching(BaseCleaningRule):
         observation_schema = self.bq_client.get_table_schema(OBSERVATION)
         stage = self.stage_table
         query = f'''SELECT * FROM `{stage.project}.{stage.dataset_id}.{stage.table_id}`'''
-        return bq.get_create_or_replace_table_ddl(
+        return self.bq_client.get_create_or_replace_table_ddl(
             project_id=self.observation_table.project,
             dataset_id=self.observation_table.dataset_id,
             schema=observation_schema,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/explicit_identifier_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/explicit_identifier_suppression_test.py
@@ -18,9 +18,6 @@ The concept_ids to suppress can be determined from the vocabulary with the follo
 # Python Imports
 import os
 
-# Third Party Imports
-from google.cloud.bigquery import Table
-
 # Project Imports
 from common import OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/motor_vehicle_accident_suppression_test.py
@@ -9,8 +9,6 @@ all domain tables """
 # Python Imports
 import os
 
-from google.cloud.bigquery import Table
-
 # Project Imports
 from common import CONDITION_OCCURRENCE, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
@@ -8,6 +8,8 @@ from pandas import DataFrame
 from cdr_cleaner.cleaning_rules.ppi_branching import OBSERVATION_BACKUP_TABLE_ID
 from cdr_cleaner.cleaning_rules.ppi_branching import PPI_BRANCHING_RULE_PATHS
 from cdr_cleaner.cleaning_rules.ppi_branching import PpiBranching, OBSERVATION, BACKUP_ROWS_QUERY, RULES_LOOKUP_TABLE_ID
+from common import JINJA_ENV
+from constants.utils import bq as consts
 
 
 def _get_csv_row_count() -> int:
@@ -46,9 +48,6 @@ def _get_create_or_replace_table_ddl(project,
                                      cluster_by_cols=None,
                                      as_query: str = None,
                                      **table_options) -> str:
-
-    from common import JINJA_ENV
-    from constants.utils import bq as consts
 
     def _to_standard_sql_type(field_type) -> str:
         upper_field_type = field_type.upper()

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/ppi_branching_test.py
@@ -152,9 +152,8 @@ class PpiBranchingTest(unittest.TestCase):
                 for field in self.observation_schema))
 
     def test_get_observation_replace_query(self):
-        OBSERVATION_STAGE_TABLE_ID = '_ppi_branching_observation_stage'
         stage = bigquery.TableReference(self.sandbox_dataset_ref,
-                                        OBSERVATION_STAGE_TABLE_ID)
+                                        '_ppi_branching_observation_stage')
         query = f'''SELECT * FROM `{stage.project}.{stage.dataset_id}.{stage.table_id}`'''
         self.mock_client.get_create_or_replace_table_ddl.return_value = _get_create_or_replace_table_ddl(
             project=self.observation_table.project,


### PR DESCRIPTION
- Replaces all `bq.dataset_columns_query(...)`  calls by invoking the function using the new `BigQueryClient()`.
- Updates associated tests.