### PR TITLE
[DC-2410] Fix the error that prevents generation of a `pipeline_tables.site_masking` record

### DIFF
--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -74,7 +74,7 @@ hpos_not_in_site_maskings AS (
     SELECT LOWER(hpo_id) FROM `{{project_id}}.{{dataset_id}}.{{table_id}}`
   )
 )
-SELECT h.hpo_id, a.src_id
+SELECT LOWER(h.hpo_id), a.src_id
 FROM available_new_src_ids AS a
 JOIN hpos_not_in_site_maskings AS h
 ON a.temp_key = h.temp_key

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -1,7 +1,7 @@
 """
 Add a new HPO site to config file and BigQuery lookup tables and updates the `pipeline_table.site_maskings`
 table with any missing hpo_sites in `lookup_tables.hpo_site_id_mappings`.
-Check out All of Us CDR Operations Playbook for when and how to use this script. 
+Check out All of Us CDR Operations Playbook for when and how to use this script.
 
 Note: GAE environment must still be set manually
 """
@@ -24,61 +24,60 @@ from common import JINJA_ENV, PIPELINE_TABLES, SITE_MASKING_TABLE_ID
 
 LOGGER = logging.getLogger(__name__)
 
-EHR_SITE_PREFIX = 'EHR site '
-RDR = 'rdr'
-PPI_PM = 'PPI/PM'
+DEFAULT_DISPLAY_ORDER = JINJA_ENV.from_string("""
+SELECT MAX(Display_Order) + 1 AS display_order 
+FROM `{{project_id}}.{{lookup_tables_dataset}}.{{hpo_site_id_mappings_table}}`
+""")
 
-DEFAULT_DISPLAY_ORDER = """
-SELECT MAX(Display_Order) + 1 AS display_order FROM {hpo_site_id_mappings_table_id}
-"""
-
-SHIFT_HPO_SITE_DISPLAY_ORDER = """
-UPDATE {hpo_site_id_mappings_table_id}
+SHIFT_HPO_SITE_DISPLAY_ORDER = JINJA_ENV.from_string("""
+UPDATE `{{project_id}}.{{lookup_tables_dataset}}.{{hpo_site_id_mappings_table}}`
 SET Display_Order = Display_Order + 1
-WHERE Display_Order >= {display_order}
-"""
+WHERE Display_Order >= {{display_order}}
+""")
 
-ADD_HPO_SITE_ID_MAPPING = """
-SELECT '{org_id}' AS Org_ID, '{hpo_id}' AS HPO_ID, '{hpo_name}' AS Site_Name, {display_order} AS Display_Order
-"""
+ADD_HPO_SITE_ID_MAPPING = JINJA_ENV.from_string("""
+SELECT
+  '{{org_id}}' AS Org_ID, 
+  '{{hpo_id}}' AS HPO_ID, 
+  '{{hpo_name}}' AS Site_Name, 
+  {{display_order}} AS Display_Order
+""")
 
-ADD_HPO_ID_BUCKET_NAME = """
-SELECT '{hpo_id}' AS hpo_id, '{bucket_name}' AS bucket_name, '{service}' AS service
-"""
+ADD_HPO_ID_BUCKET_NAME = JINJA_ENV.from_string("""
+SELECT
+  '{{hpo_id}}' AS hpo_id, 
+  '{{bucket_name}}' AS bucket_name, 
+  '{{service}}' AS service
+""")
 
 UPDATE_SITE_MASKING_QUERY = JINJA_ENV.from_string("""
-INSERT INTO
-   `{{project_id}}.{{dataset_id}}.{{table_id}}` (hpo_id, src_id)
-     WITH random_ids AS
- (
- -- Generates the random EHR site id for the new hpo_site --
+INSERT INTO `{{project_id}}.{{dataset_id}}.{{table_id}}` (hpo_id, src_id)
+WITH available_new_src_ids AS (
+  SELECT 
+    ROW_NUMBER() OVER(ORDER BY GENERATE_UUID()) AS temp_key,
+    CONCAT('EHR site ', new_id) AS src_id
+  FROM UNNEST(GENERATE_ARRAY(100, 999)) AS new_id
+  WHERE new_id NOT IN (
+    SELECT CAST(SUBSTR(src_id, -3) AS INT64) 
+    FROM `{{project_id}}.{{dataset_id}}.{{table_id}}`
+    WHERE hpo_id != 'rdr'
+  )
+),
+hpos_not_in_site_maskings AS (
   SELECT
-    CONCAT('EHR site ', new_id) AS hpo_id,
-    ROW_NUMBER() OVER(ORDER BY GENERATE_UUID()) AS row_id
-  FROM
-    UNNEST(GENERATE_ARRAY(100, 999)) AS new_id
+    ROW_NUMBER() OVER() AS temp_key,
+    m.hpo_id
+  FROM `{{project_id}}.{{lookup_tables_dataset}}.{{hpo_site_id_mappings_table}}` AS m
+  WHERE m.HPO_ID IS NOT NULL 
+  AND m.HPO_ID != '' 
+  AND LOWER(m.HPO_ID) NOT IN (
+    SELECT LOWER(hpo_id) FROM `{{project_id}}.{{dataset_id}}.{{table_id}}`
+  )
 )
-SELECT
-    LOWER(m.hpo_id) as hpo_id,
-    r.hpo_id as src_id
-  FROM
-(
-  -- Selects the hpo_sites that are located in the hpo_site_id_mappings table but not the --
-  -- sandboxed site masking table --
-   SELECT
-     m.*,
-     ROW_NUMBER() OVER(ORDER BY GENERATE_UUID()) AS row_id
-   FROM `{{project_id}}.{{lookup_tables_dataset}}.{{hpo_site_id_mappings_table}}` AS m
-   WHERE m.HPO_ID IS NOT NULL AND m.HPO_ID != '' AND m.HPO_ID NOT IN (
-   SELECT hpo_id FROM `{{project_id}}.{{sandbox_id}}.{{table_id}}`)
- ) AS m
- JOIN random_ids AS r
-USING (row_id)
-UNION ALL
--- Adds rdr record if one does not already exist in the sandboxed site_maskings table --
-SELECT 'rdr' AS hpo_id, 'PPI/PM' AS src_id FROM `{{project_id}}.{{dataset_id}}.{{table_id}}` WHERE
- 'rdr' NOT IN (
-SELECT hpo_id FROM `{{project_id}}.{{sandbox_id}}.{{table_id}}`)
+SELECT h.hpo_id, a.src_id
+FROM available_new_src_ids AS a
+JOIN hpos_not_in_site_maskings AS h
+ON a.temp_key = h.temp_key
 """)
 
 
@@ -160,8 +159,13 @@ def get_last_display_order():
     gets the display order from hpo_site_id_mappings table
     :return:
     """
-    q = DEFAULT_DISPLAY_ORDER.format(
-        hpo_site_id_mappings_table_id=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)
+    project_id = app_identity.get_application_id()
+
+    q = DEFAULT_DISPLAY_ORDER.render(
+        project_id=project_id,
+        lookup_tables_dataset=bq_consts.LOOKUP_TABLES_DATASET_ID,
+        hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)
+
     query_response = bq_utils.query(q)
     rows = bq_utils.response2rows(query_response)
     row = rows[0]
@@ -175,9 +179,14 @@ def shift_display_orders(at_display_order):
     :param at_display_order: index where the display order
     :return:
     """
-    q = SHIFT_HPO_SITE_DISPLAY_ORDER.format(
-        display_order=at_display_order,
-        hpo_site_id_mappings_table_id=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)
+    project_id = app_identity.get_application_id()
+
+    q = SHIFT_HPO_SITE_DISPLAY_ORDER.render(
+        project_id=project_id,
+        lookup_tables_dataset=bq_consts.LOOKUP_TABLES_DATASET_ID,
+        hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID,
+        display_order=at_display_order)
+
     LOGGER.info(f'Shifting lookup with the following query:\n {q}\n')
     query_response = bq_utils.query(q)
     return query_response
@@ -192,7 +201,7 @@ def add_hpo_mapping(hpo_id, hpo_name, org_id, display_order):
     :param display_order: index number in which hpo should be added in table
     :return:
     """
-    q = ADD_HPO_SITE_ID_MAPPING.format(hpo_id=hpo_id,
+    q = ADD_HPO_SITE_ID_MAPPING.render(hpo_id=hpo_id,
                                        hpo_name=hpo_name,
                                        org_id=org_id,
                                        display_order=display_order)
@@ -211,7 +220,7 @@ def add_hpo_bucket(hpo_id, bucket_name, service='default'):
     :param bucket_name: bucket name assigned to hpo
     :return:
     """
-    q = ADD_HPO_ID_BUCKET_NAME.format(hpo_id=hpo_id,
+    q = ADD_HPO_ID_BUCKET_NAME.render(hpo_id=hpo_id,
                                       bucket_name=bucket_name,
                                       service=service)
     LOGGER.info(f'Adding bucket lookup with the following query:\n {q}\n')
@@ -285,6 +294,11 @@ def update_site_masking_table():
 
     query_job = bq_client.query(update_site_maskings_query)
 
+    if query_job.errors:
+        raise RuntimeError(
+            f"Failed to update site_masking table. Error message: {query_job.errors}"
+        )
+
     return query_job
 
 
@@ -317,6 +331,11 @@ def main(hpo_id, org_id, hpo_name, bucket_name, display_order, addition_type,
                 f'hpo_site_id_mappings table successfully updated. Updating `{bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID}` '
                 f'table')
             update_site_masking_table()
+
+        else:
+            raise RuntimeError(
+                f'{addition_type} was skipped because the bucket {bucket_name} is inaccessible.'
+            )
 
 
 if __name__ == '__main__':

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -1,6 +1,7 @@
 """
 Add a new HPO site to config file and BigQuery lookup tables and updates the `pipeline_table.site_maskings`
-    table with any missing hpo_sites in `lookup_tables.hpo_site_id_mappings`
+table with any missing hpo_sites in `lookup_tables.hpo_site_id_mappings`.
+Check out All of Us CDR Operations Playbook for when and how to use this script. 
 
 Note: GAE environment must still be set manually
 """

--- a/data_steward/tools/add_hpo.py
+++ b/data_steward/tools/add_hpo.py
@@ -276,14 +276,11 @@ def update_site_masking_table():
     """
 
     project_id = app_identity.get_application_id()
-    sandbox_id = PIPELINE_TABLES + '_sandbox'
-
     bq_client = BigQueryClient(project_id)
 
     update_site_maskings_query = UPDATE_SITE_MASKING_QUERY.render(
         project_id=project_id,
         dataset_id=PIPELINE_TABLES,
-        sandbox_id=sandbox_id,
         table_id=SITE_MASKING_TABLE_ID,
         lookup_tables_dataset=bq_consts.LOOKUP_TABLES_DATASET_ID,
         hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)

--- a/tests/unit_tests/data_steward/tools/add_hpo_test.py
+++ b/tests/unit_tests/data_steward/tools/add_hpo_test.py
@@ -85,14 +85,13 @@ class AddHPOTest(TestCase):
     def test_update_site_masking_table(self, mock_bq_client):
         # Preconditions
         project_id = app_identity.get_application_id()
-        sandbox_id = PIPELINE_TABLES + '_sandbox'
-
         mock_query = mock_bq_client.return_value.query
 
         # Mocks the job return
         query_job_reference_results = mock.MagicMock(
             name="query_job_reference_results")
         query_job_reference_results.return_value = query_job_reference_results
+        query_job_reference_results.errors = []
         mock_query.side_effect = query_job_reference_results
 
         # Test
@@ -102,7 +101,6 @@ class AddHPOTest(TestCase):
         update_site_masking_query = add_hpo.UPDATE_SITE_MASKING_QUERY.render(
             project_id=project_id,
             dataset_id=PIPELINE_TABLES,
-            sandbox_id=sandbox_id,
             table_id=SITE_MASKING_TABLE_ID,
             lookup_tables_dataset=bq_consts.LOOKUP_TABLES_DATASET_ID,
             hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)

--- a/tests/unit_tests/data_steward/tools/add_hpo_test.py
+++ b/tests/unit_tests/data_steward/tools/add_hpo_test.py
@@ -100,8 +100,8 @@ class AddHPOTest(TestCase):
         # Post conditions
         update_site_masking_query = add_hpo.UPDATE_SITE_MASKING_QUERY.render(
             project_id=project_id,
-            dataset_id=PIPELINE_TABLES,
-            table_id=SITE_MASKING_TABLE_ID,
+            pipeline_tables_dataset=PIPELINE_TABLES,
+            site_maskings_table=SITE_MASKING_TABLE_ID,
             lookup_tables_dataset=bq_consts.LOOKUP_TABLES_DATASET_ID,
             hpo_site_id_mappings_table=bq_consts.HPO_SITE_ID_MAPPINGS_TABLE_ID)
 


### PR DESCRIPTION
- I ran the updated script for DC2409 and confirmed that `site_maskings` is updated as expected.
- I added the exceptions for clarity.
- I updated the insert logic since `pipeline_tables_sandbox` does not exist in our dataset.
- I updated the playbook to specify what we need to do in each step.
- Please see the comment section in the JIRA ticket DC2410 for details.