### PR TITLE
[DC-2480] [P0] Remove `DropParticipantsWithoutPPI` from the RT and CT cleaning lists #2

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr.py
@@ -54,7 +54,7 @@ WHERE person_id NOT IN
     ON (concept_id = ancestor_concept_id)
   JOIN `{{project}}.{{dataset}}.observation`
     ON (descendant_concept_id = observation_concept_id)
-  JOIN `{{project}}.{{mapping_dataset}}._mapping_observation`
+  JOIN `{{project}}.{{dataset}}._mapping_observation`
     USING (observation_id)
   WHERE concept_class_id = 'Module'
     AND concept_name IN ('The Basics')
@@ -72,12 +72,9 @@ class DropParticipantsWithoutPPI(DropMissingParticipants):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 mapping_dataset_id,
                  namer='stage_less'):
         desc = (f'Sandbox and remove PIDs with no PPI basics or EHR data.'
                 f'Use drop missing participants CR to remove their records.')
-
-        self.mapping_dataset_id = mapping_dataset_id
 
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
@@ -111,7 +108,6 @@ class DropParticipantsWithoutPPI(DropMissingParticipants):
             query_type=select_stmt,
             project=self.project_id,
             dataset=self.dataset_id,
-            mapping_dataset=self.mapping_dataset_id,
             basics_concept_id=BASICS_MODULE_CONCEPT_ID)
         queries.append({cdr_consts.QUERY: select_query})
 
@@ -119,7 +115,6 @@ class DropParticipantsWithoutPPI(DropMissingParticipants):
             query_type="DELETE",
             project=self.project_id,
             dataset=self.dataset_id,
-            mapping_dataset=self.mapping_dataset_id,
             basics_concept_id=BASICS_MODULE_CONCEPT_ID)
         queries.append({cdr_consts.QUERY: delete_query})
 
@@ -132,33 +127,17 @@ if __name__ == '__main__':
     import cdr_cleaner.args_parser as parser
     import cdr_cleaner.clean_cdr_engine as clean_engine
 
-    mapping_dataset_arg = {
-        parser.SHORT_ARGUMENT:
-            '-m',
-        parser.LONG_ARGUMENT:
-            '--mapping_dataset_id',
-        parser.ACTION:
-            'store',
-        parser.DEST:
-            'mapping_dataset_id',
-        parser.HELP:
-            'Identifies the dataset containing mapping tables (e.g. combined dataset)',
-        parser.REQUIRED:
-            True
-    }
-
-    ARGS = parser.default_parse_args([mapping_dataset_arg])
+    ARGS = parser.parse_args()
 
     if ARGS.list_queries:
         clean_engine.add_console_logging()
         query_list = clean_engine.get_query_list(
             ARGS.project_id, ARGS.dataset_id, ARGS.sandbox_dataset_id,
-            ARGS.mapping_dataset_id, [(DropParticipantsWithoutPPI,)])
+            [(DropParticipantsWithoutPPI,)])
         for query in query_list:
             LOGGER.info(query)
     else:
         clean_engine.add_console_logging(ARGS.console_log)
         clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
                                    ARGS.sandbox_dataset_id,
-                                   ARGS.mapping_dataset_id,
                                    [(DropParticipantsWithoutPPI,)])

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/drop_participants_without_ppi_or_ehr_test.py
@@ -33,11 +33,9 @@ class DropParticipantsWithoutPPITest(BaseTest.CleaningRulesTestBase):
         cls.dataset_id = os.environ.get('COMBINED_DATASET_ID')
         cls.sandbox_id = f'{cls.dataset_id}_sandbox'
         cls.vocabulary_id = os.environ.get('VOCABULARY_DATASET')
-        cls.kwargs.update({'mapping_dataset_id': cls.dataset_id})
         cls.rule_instance = DropParticipantsWithoutPPI(cls.project_id,
                                                        cls.dataset_id,
-                                                       cls.sandbox_id,
-                                                       cls.dataset_id)
+                                                       cls.sandbox_id)
 
         cls.affected_tables = [
             common.PERSON, common.OBSERVATION, common.DRUG_EXPOSURE


### PR DESCRIPTION
Revert changes from DC-2379.