### PR TITLE
[DC-2128] Integration test bug fix

### DIFF
--- a/tests/integration_tests/data_steward/tools/delete_stale_test_buckets_test.py
+++ b/tests/integration_tests/data_steward/tools/delete_stale_test_buckets_test.py
@@ -43,6 +43,3 @@ class DeleteStaleTestBucketsTest(TestCase):
             # Assert: Bucket is stale (2: Empty(=no blobs))
             self.assertEqual(
                 len(list(self.storage_client.list_blobs(bucket_name))), 0)
-
-            # Assert: Bucket is stale (3: label 'do_not_delete':'true' is NOT attached)
-            self.assertEqual(bucket_labels, {})

--- a/tests/integration_tests/data_steward/tools/delete_stale_test_datasets_test.py
+++ b/tests/integration_tests/data_steward/tools/delete_stale_test_datasets_test.py
@@ -42,6 +42,3 @@ class DeleteStaleTestDatasetsTest(TestCase):
             # Assert: Dataset is stale (2: Empty(=no tables))
             self.assertEqual(
                 len(list(self.bq_client.list_tables(dataset_name))), 0)
-
-            # Assert: Dataset is stale (3: label 'do_not_delete':'true' is NOT attached)
-            self.assertEqual(dataset_labels, {})


### PR DESCRIPTION
- Removed the `assert` for labels: the logic looks at the real datasets/buckets in the test environment. And the tests do not have full control over what labels are attached to each of the datasets/buckets. I am removing those `assert` statements altogether.
- The logic is tested in the unit tests, so this change does not affect code coverage.