### PR TITLE
[DC-2467] The fitbit `PIDtoRID` rule does not sandbox data

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr_engine.py
+++ b/data_steward/cdr_cleaner/clean_cdr_engine.py
@@ -214,8 +214,11 @@ def infer_rule(clazz, project_id, dataset_id, sandbox_dataset_id, table_namer,
     kwargs = get_custom_kwargs(clazz, **kwargs)
     if inspect.isclass(clazz) and issubclass(clazz, BaseCleaningRule):
         try:
-            instance = clazz(project_id, dataset_id, sandbox_dataset_id,
-                             table_namer, **kwargs)
+            instance = clazz(project_id,
+                             dataset_id,
+                             sandbox_dataset_id,
+                             table_namer=table_namer,
+                             **kwargs)
         except TypeError as e:
             LOGGER.warning(f"{clazz.__name__} does not accept the "
                            f"`table_namer` property yet.")

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map.py
@@ -22,9 +22,9 @@ class FitbitPIDtoRID(PIDtoRID):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 mapping_dataset_id,
-                 mapping_table_id,
-                 table_namer=None):
+                 table_namer=None,
+                 mapping_dataset_id=None,
+                 mapping_table_id=None):
         """
         Initialize the class with proper info.
 

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map.py
@@ -22,9 +22,9 @@ class FitbitPIDtoRID(PIDtoRID):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 table_namer=None,
-                 mapping_dataset_id=None,
-                 mapping_table_id=None):
+                 mapping_dataset_id,
+                 mapping_table_id,
+                 table_namer=None):
         """
         Initialize the class with proper info.
 

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/pid_rid_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/pid_rid_map.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 SANDBOX_QUERY_TMPL = JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE
   `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` AS
-SELECT *
+SELECT DISTINCT person_id
 FROM `{{input_table.project}}.{{input_table.dataset_id}}.{{input_table.table_id}}`
 WHERE person_id NOT IN (
     SELECT person_id FROM `{{deid_map.project}}.{{deid_map.dataset_id}}.{{deid_map.table_id}}`
@@ -36,7 +36,7 @@ DELETE_PID_QUERY_TMPL = JINJA_ENV.from_string("""
 DELETE
 FROM `{{input_table.project}}.{{input_table.dataset_id}}.{{input_table.table_id}}`
 WHERE person_id IN (
-    SELECT person_id FROM `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}`
+    SELECT DISTINCT person_id FROM `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}`
 )
 """)
 

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/pid_rid_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/pid_rid_map.py
@@ -15,34 +15,38 @@ from common import JINJA_ENV, DEID_MAP, PRIMARY_PID_RID_MAPPING, PIPELINE_TABLES
 
 LOGGER = logging.getLogger(__name__)
 
-PID_RID_QUERY = """
+PID_RID_QUERY_TMPL = JINJA_ENV.from_string("""
 UPDATE `{{input_table.project}}.{{input_table.dataset_id}}.{{input_table.table_id}}` t
 SET t.person_id = d.research_id
 FROM `{{deid_map.project}}.{{deid_map.dataset_id}}.{{deid_map.table_id}}` d
 WHERE t.person_id = d.person_id
-"""
+""")
 
-PID_RID_QUERY_TMPL = JINJA_ENV.from_string(PID_RID_QUERY)
+SANDBOX_QUERY_TMPL = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE
+  `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` AS
+SELECT *
+FROM `{{input_table.project}}.{{input_table.dataset_id}}.{{input_table.table_id}}`
+WHERE person_id NOT IN (
+    SELECT research_id FROM `{{deid_map.project}}.{{deid_map.dataset_id}}.{{deid_map.table_id}}`
+)
+""")
 
-DELETE_PID_QUERY = """
+DELETE_PID_QUERY_TMPL = JINJA_ENV.from_string("""
 DELETE
 FROM `{{input_table.project}}.{{input_table.dataset_id}}.{{input_table.table_id}}`
-WHERE person_id NOT IN 
-(SELECT research_id
-FROM `{{deid_map.project}}.{{deid_map.dataset_id}}.{{deid_map.table_id}}`)
-"""
+WHERE person_id IN (
+    SELECT person_id FROM `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}`
+)
+""")
 
-DELETE_PID_QUERY_TMPL = JINJA_ENV.from_string(DELETE_PID_QUERY)
-
-VALIDATE_QUERY = """
+VALIDATE_QUERY_TMPL = JINJA_ENV.from_string("""
 SELECT person_id
 FROM `{{input_table.project}}.{{input_table.dataset_id}}.{{input_table.table_id}}`
 WHERE person_id NOT IN 
 (SELECT {{pid}}
 FROM `{{deid_map.project}}.{{deid_map.dataset_id}}.{{deid_map.table_id}}`)
-"""
-
-VALIDATE_QUERY_TMPL = JINJA_ENV.from_string(VALIDATE_QUERY)
+""")
 
 
 class PIDtoRID(BaseCleaningRule):
@@ -86,8 +90,7 @@ class PIDtoRID(BaseCleaningRule):
             single query and a specification for how to execute that query.
             The specifications are optional but the query is required.
         """
-        update_queries = []
-        delete_queries = []
+        update_queries, delete_queries, sandbox_queries = [], [], []
 
         for table in self.pid_tables:
             table_query = {
@@ -98,15 +101,28 @@ class PIDtoRID(BaseCleaningRule):
             update_queries.append(table_query)
             delete_query = {
                 cdr_consts.QUERY:
-                    DELETE_PID_QUERY_TMPL.render(input_table=table,
-                                                 deid_map=self.deid_map)
+                    DELETE_PID_QUERY_TMPL.render(
+                        project=self.project_id,
+                        sandbox_dataset=self.sandbox_dataset_id,
+                        sandbox_table=self.sandbox_table_for(table.table_id),
+                        input_table=table)
             }
             delete_queries.append(delete_query)
+            sandbox_query = {
+                cdr_consts.QUERY:
+                    SANDBOX_QUERY_TMPL.render(
+                        project=self.project_id,
+                        sandbox_dataset=self.sandbox_dataset_id,
+                        sandbox_table=self.sandbox_table_for(table.table_id),
+                        input_table=table,
+                        deid_map=self.deid_map)
+            }
+            sandbox_queries.append(sandbox_query)
 
-        return update_queries + delete_queries
+        return update_queries + delete_queries + sandbox_queries
 
     def get_sandbox_tablenames(self):
-        return []
+        return [self.sandbox_table_for(table) for table in self.affected_tables]
 
     def inspect_rule(self, client):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -327,7 +327,11 @@ class BaseTest:
                     # this is assuming the uniquely identifiable field name is specified
                     # first in the fields list.  this check verifies by id field
                     # that the table data loaded correctly.
-                    fields = [table_info.get('fields', [])[0]]
+                    sandbox_fields = table_info.get('sandbox_fields', [])
+                    cdm_fields = table_info.get('fields', [])
+                    fields = [
+                        sandbox_fields[0] if sandbox_fields else cdm_fields[0]
+                    ]
                     self.assertRowIDsMatch(fq_sandbox_name, fields, values)
 
         def copy_vocab_tables(self, vocabulary_id):

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/ct_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/ct_pid_rid_map_test.py
@@ -34,7 +34,11 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         cls.rule_instance = cr.CtPIDtoRID(project_id, cls.dataset_id,
                                           cls.sandbox_id)
 
-        cls.fq_sandbox_table_names = []
+        sb_table_name = cls.rule_instance.sandbox_table_for(
+            CONDITION_OCCURRENCE)
+        cls.fq_sandbox_table_names = [
+            f'{project_id}.{cls.sandbox_id}.{sb_table_name}'
+        ]
 
         cls.fq_table_names = [
             f'{project_id}.{cls.dataset_id}.{table_id}'
@@ -125,6 +129,8 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         tables_and_counts = [{
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, CONDITION_OCCURRENCE]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
             'fields': [
                 'condition_occurrence_id', 'person_id', 'condition_concept_id',
                 'condition_start_date', 'condition_start_datetime',

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/ct_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/ct_pid_rid_map_test.py
@@ -131,6 +131,7 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
                 'condition_type_concept_id'
             ],
             'loaded_ids': [50001, 50002, 50003, 50004, 50005],
+            'sandboxed_ids': [50005],
             'cleaned_values': [
                 (50001, 234, 100, datetime.fromisoformat('2020-08-17').date(),
                  datetime.fromisoformat('2020-08-17 15:00:00+00:00'), 10),

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/ct_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/ct_pid_rid_map_test.py
@@ -42,9 +42,8 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
 
         cls.fq_table_names = [
             f'{project_id}.{cls.dataset_id}.{table_id}'
-            for table_id in [CONDITION_OCCURRENCE]
-        ] + [cls.fq_deid_map_table
-            ] + [f'{project_id}.{cls.sandbox_id}.{PERSON}']
+            for table_id in [CONDITION_OCCURRENCE, PERSON]
+        ] + [cls.fq_deid_map_table]
 
         # call super to set up the client, create datasets, and create
         # empty test tables
@@ -99,7 +98,7 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             (2345, 0, 1980, 0, 0),
             (6789, 0, 1990, 0, 0),
             (3456, 0, 1965, 0, 0)""").render(
-            fq_dataset_name=f'{self.project_id}.{self.sandbox_id}')
+            fq_dataset_name=f'{self.project_id}.{self.dataset_id}')
         queries.append(pid_query)
 
         map_query = self.jinja_env.from_string("""
@@ -123,21 +122,31 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         expected_log_msg = f"{log_level}:{log_module}:{log_message}"
         with self.assertLogs(LOGGER, level='WARN') as ir:
             self.rule_instance.inspect_rule(self.client)
-        self.assertEqual(ir.output, [expected_log_msg])
+        # expected log message is seen twice because there are two tables in the dataset to clean
+        self.assertEqual(ir.output, [expected_log_msg] * 2)
+
+        person_sandbox_table = ''
+        co_sandbox_table = ''
+        for table in self.fq_sandbox_table_names:
+            if PERSON in table:
+                person_sandbox_table = table
+            elif CONDITION_OCCURRENCE in table:
+                co_sandbox_table = table
 
         # Expected results list
         tables_and_counts = [{
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, CONDITION_OCCURRENCE]),
             'fq_sandbox_table_name':
-                self.fq_sandbox_table_names[0],
+                co_sandbox_table,
             'fields': [
                 'condition_occurrence_id', 'person_id', 'condition_concept_id',
                 'condition_start_date', 'condition_start_datetime',
                 'condition_type_concept_id'
             ],
             'loaded_ids': [50001, 50002, 50003, 50004, 50005],
-            'sandboxed_ids': [50005],
+            'sandboxed_ids': [3456],
+            'sandbox_fields': ['person_id'],
             'cleaned_values': [
                 (50001, 234, 100, datetime.fromisoformat('2020-08-17').date(),
                  datetime.fromisoformat('2020-08-17 15:00:00+00:00'), 10),
@@ -148,6 +157,16 @@ class CtPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
                 (50004, 789, 800, datetime.fromisoformat('2020-08-17').date(),
                  datetime.fromisoformat('2020-08-17 12:00:00+00:00'), 13)
             ]
+        }, {
+            'fq_table_name':
+                '.'.join([self.fq_dataset_name, PERSON]),
+            'fq_sandbox_table_name':
+                person_sandbox_table,
+            'fields': ['person_id', 'year_of_birth'],
+            'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'sandboxed_ids': [3456],
+            'cleaned_values': [(234, 1960), (678, 1970), (345, 1980),
+                               (789, 1990)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
@@ -37,10 +37,13 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         })
         cls.fq_deid_map_table = f'{project_id}.{mapping_dataset_id}.{mapping_table_id}'
 
-        cls.rule_instance = pr.FitbitPIDtoRID(project_id, cls.dataset_id,
-                                              cls.sandbox_id,
-                                              mapping_dataset_id,
-                                              mapping_table_id)
+        cls.rule_instance = pr.FitbitPIDtoRID(
+            project_id,
+            cls.dataset_id,
+            cls.sandbox_id,
+            table_namer=None,
+            mapping_dataset_id=mapping_dataset_id,
+            mapping_table_id=mapping_table_id)
 
         cls.fq_sandbox_table_names = [
             f'{project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(table_id)}'

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
@@ -37,13 +37,10 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         })
         cls.fq_deid_map_table = f'{project_id}.{mapping_dataset_id}.{mapping_table_id}'
 
-        cls.rule_instance = pr.FitbitPIDtoRID(
-            project_id,
-            cls.dataset_id,
-            cls.sandbox_id,
-            table_namer=None,
-            mapping_dataset_id=mapping_dataset_id,
-            mapping_table_id=mapping_table_id)
+        cls.rule_instance = pr.FitbitPIDtoRID(project_id, cls.dataset_id,
+                                              cls.sandbox_id,
+                                              mapping_dataset_id,
+                                              mapping_table_id)
 
         cls.fq_sandbox_table_names = [
             f'{project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(table_id)}'

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
@@ -93,7 +93,8 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             (5678, 200, date('2020-08-17')),
             (2345, 500, date('2020-08-17')),
             (6789, 800, date('2020-08-17')),
-            (3456, 1000, date('2020-08-17'))""").render(
+            (3456, 1000, date('2020-08-17')),
+            (3456, 2000, date('2020-08-18'))""").render(
             fq_dataset_name=self.fq_dataset_name, fitbit_table=ACTIVITY_SUMMARY)
         queries.append(as_query)
 
@@ -105,7 +106,8 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             (5678, 50, (DATETIME '2020-08-17 15:30:00')),
             (2345, 55, (DATETIME '2020-08-17 16:00:00')),
             (6789, 40, (DATETIME '2020-08-17 16:30:00')),
-            (3456, 65, (DATETIME '2020-08-17 17:00:00'))""").render(
+            (3456, 65, (DATETIME '2020-08-17 17:00:00')),            
+            (3456, 70, (DATETIME '2020-08-18 17:00:00'))""").render(
             fq_dataset_name=self.fq_dataset_name,
             fitbit_table=HEART_RATE_MINUTE_LEVEL)
         queries.append(hr_query)
@@ -166,7 +168,7 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
             'fields': ['person_id', 'activity_calories', 'date'],
-            'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'loaded_ids': [1234, 5678, 2345, 6789, 3456, 3456],
             'sandboxed_ids': [3456],
             'cleaned_values': [
                 (234, 100, datetime.fromisoformat('2020-08-17').date()),
@@ -180,7 +182,7 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[1],
             'fields': ['person_id', 'heart_rate_value', 'datetime'],
-            'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'loaded_ids': [1234, 5678, 2345, 6789, 3456, 3456],
             'sandboxed_ids': [3456],
             'cleaned_values': [
                 (234, 60, datetime.fromisoformat('2020-08-17 15:00:00')),

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
@@ -148,8 +148,7 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             (1234, 234, 256),
             (5678, 678, 250),
             (2345, 345, 255),
-            (6789, 789, 256),
-            (3456, 456, 255)""").render(fq_table=self.fq_deid_map_table)
+            (6789, 789, 256)""").render(fq_table=self.fq_deid_map_table)
         queries.append(map_query)
 
         self.load_test_data(queries)
@@ -160,48 +159,48 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
                 '.'.join([self.fq_dataset_name, ACTIVITY_SUMMARY]),
             'fields': ['person_id', 'activity_calories', 'date'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'sandboxed_ids': [3456],
             'cleaned_values': [
                 (234, 100, datetime.fromisoformat('2020-08-17').date()),
                 (678, 200, datetime.fromisoformat('2020-08-17').date()),
                 (345, 500, datetime.fromisoformat('2020-08-17').date()),
-                (789, 800, datetime.fromisoformat('2020-08-17').date()),
-                (456, 1000, datetime.fromisoformat('2020-08-17').date())
+                (789, 800, datetime.fromisoformat('2020-08-17').date())
             ]
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, HEART_RATE_MINUTE_LEVEL]),
             'fields': ['person_id', 'heart_rate_value', 'datetime'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'sandboxed_ids': [3456],
             'cleaned_values': [
                 (234, 60, datetime.fromisoformat('2020-08-17 15:00:00')),
                 (678, 50, datetime.fromisoformat('2020-08-17 15:30:00')),
                 (345, 55, datetime.fromisoformat('2020-08-17 16:00:00')),
-                (789, 40, datetime.fromisoformat('2020-08-17 16:30:00')),
-                (456, 65, datetime.fromisoformat('2020-08-17 17:00:00'))
+                (789, 40, datetime.fromisoformat('2020-08-17 16:30:00'))
             ]
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, HEART_RATE_SUMMARY]),
             'fields': ['person_id', 'date', 'calorie_count'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'sandboxed_ids': [3456],
             'cleaned_values': [
                 (234, datetime.fromisoformat('2020-08-17').date(), 100),
                 (678, datetime.fromisoformat('2020-08-17').date(), 200),
                 (345, datetime.fromisoformat('2020-08-17').date(), 500),
-                (789, datetime.fromisoformat('2020-08-17').date(), 800),
-                (456, datetime.fromisoformat('2020-08-17').date(), 1000)
+                (789, datetime.fromisoformat('2020-08-17').date(), 800)
             ]
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, STEPS_INTRADAY]),
             'fields': ['person_id', 'datetime', 'steps'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
+            'sandboxed_ids': [3456],
             'cleaned_values': [
                 (234, datetime.fromisoformat('2020-08-17 15:00:00'), 60),
                 (678, datetime.fromisoformat('2020-08-17 15:30:00'), 50),
                 (345, datetime.fromisoformat('2020-08-17 16:00:00'), 55),
-                (789, datetime.fromisoformat('2020-08-17 16:30:00'), 40),
-                (456, datetime.fromisoformat('2020-08-17 17:00:00'), 65)
+                (789, datetime.fromisoformat('2020-08-17 16:30:00'), 40)
             ]
         }]
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/fitbit_pid_rid_map_test.py
@@ -42,7 +42,10 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
                                               mapping_dataset_id,
                                               mapping_table_id)
 
-        cls.fq_sandbox_table_names = []
+        cls.fq_sandbox_table_names = [
+            f'{project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(table_id)}'
+            for table_id in pr.FITBIT_TABLES
+        ]
 
         cls.fq_table_names = [
             f'{project_id}.{cls.dataset_id}.{table_id}'
@@ -157,6 +160,8 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         tables_and_counts = [{
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, ACTIVITY_SUMMARY]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
             'fields': ['person_id', 'activity_calories', 'date'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
             'sandboxed_ids': [3456],
@@ -169,6 +174,8 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, HEART_RATE_MINUTE_LEVEL]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[1],
             'fields': ['person_id', 'heart_rate_value', 'datetime'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
             'sandboxed_ids': [3456],
@@ -181,6 +188,8 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, HEART_RATE_SUMMARY]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[2],
             'fields': ['person_id', 'date', 'calorie_count'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
             'sandboxed_ids': [3456],
@@ -193,6 +202,8 @@ class FitbitPIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, STEPS_INTRADAY]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[3],
             'fields': ['person_id', 'datetime', 'steps'],
             'loaded_ids': [1234, 5678, 2345, 6789, 3456],
             'sandboxed_ids': [3456],


### PR DESCRIPTION
- To enable `table_namer`, I needed to change the order of the arguments and make `mapping_dataset_id` and `mapping_table_id` kwarg. This is because `infer_rule` assumes the fourth argument to be `table_namer` -> https://github.com/all-of-us/curation/blob/develop/data_steward/cdr_cleaner/clean_cdr_engine.py#L218