### PR TITLE
[DC-2454] update the unit normalization rule

### DIFF
--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
@@ -141,10 +141,17 @@ class UnitNormalizationTest(BaseTest.CleaningRulesTestBase):
         """
         Tests unit_normalization for the loaded test data
         """
+        sandbox_table_name = ''
+        for table in self.fq_sandbox_table_names:
+            if MEASUREMENT in table:
+                sandbox_table_name = table
+
         # Expected results list
         tables_and_counts = [{
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{MEASUREMENT}',
+            'fq_sandbox_table_name':
+                sandbox_table_name,
             'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
             'sandboxed_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             'fields': [

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
@@ -57,7 +57,9 @@ INSERT_UNITS_RAW_DATA = JINJA_ENV.from_string("""
       (7,1,3000905,10.1,8647,4.5,11.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
       (8,1,3020630,6.2,8840,6.4,8.2,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
       (9,1,3020416,5.06,8816,4.2,5.8,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
-      (10,1,3000963,3.4,8554,0.5,5.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null)
+      (10,1,3000963,3.4,8554,0.5,5.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null),
+      -- should remain unchanged, should not be sandboxed --
+      (11,1,3000963,3.4,11,0.5,5.0,'2020-01-01', '2020-01-01 01:01:01' ,0,0,0,0,0,null,0,null,null)
 """)
 
 
@@ -143,7 +145,7 @@ class UnitNormalizationTest(BaseTest.CleaningRulesTestBase):
         tables_and_counts = [{
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{MEASUREMENT}',
-            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
             'sandboxed_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             'fields': [
                 'measurement_id', 'person_id', 'measurement_concept_id',
@@ -161,7 +163,8 @@ class UnitNormalizationTest(BaseTest.CleaningRulesTestBase):
                                (8, 1, 3020630, 0.006200000000000001, 8713,
                                 0.0064, 0.008199999999999999),
                                (9, 1, 3020416, 5060.0, 8815, 4200.0, 5800.0),
-                               (10, 1, 3000963, 0.34, 8636, 0.05, 0.5)]
+                               (10, 1, 3000963, 0.34, 8636, 0.05, 0.5),
+                               (11, 1, 3000963, 3.4, 11, 0.5, 5.0)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/unit_normalization_test.py
@@ -42,7 +42,8 @@ class UnitNormalizationTest(unittest.TestCase):
         sandbox_query[clean_consts.QUERY] = SANDBOX_UNITS_QUERY.render(
             project_id=self.project_id,
             sandbox_dataset_id=self.sandbox_id,
-            intermediary_table=self.rule_instance.get_sandbox_tablenames()[0],
+            intermediary_table=self.rule_instance.sandbox_table_for(
+                MEASUREMENT),
             dataset_id=self.dataset_id,
             unit_table_name=UNIT_MAPPING_TABLE,
             measurement_table=MEASUREMENT)
@@ -52,11 +53,10 @@ class UnitNormalizationTest(unittest.TestCase):
             project_id=self.project_id,
             dataset_id=self.dataset_id,
             sandbox_dataset_id=self.sandbox_id,
+            intermediary_table=self.rule_instance.sandbox_table_for(
+                MEASUREMENT),
             unit_table_name=UNIT_MAPPING_TABLE,
             measurement_table=MEASUREMENT)
-        update_query[clean_consts.DESTINATION_TABLE] = MEASUREMENT
-        update_query[clean_consts.DESTINATION_DATASET] = self.dataset_id
-        update_query[clean_consts.DISPOSITION] = WRITE_TRUNCATE
 
         expected_list = [sandbox_query, update_query]
 
@@ -73,7 +73,8 @@ class UnitNormalizationTest(unittest.TestCase):
         store_rows_to_be_changed = SANDBOX_UNITS_QUERY.render(
             project_id=self.project_id,
             sandbox_dataset_id=self.sandbox_id,
-            intermediary_table=self.rule_instance.get_sandbox_tablenames()[0],
+            intermediary_table=self.rule_instance.sandbox_table_for(
+                MEASUREMENT),
             dataset_id=self.dataset_id,
             unit_table_name=UNIT_MAPPING_TABLE,
             measurement_table=MEASUREMENT)
@@ -82,6 +83,8 @@ class UnitNormalizationTest(unittest.TestCase):
             project_id=self.project_id,
             dataset_id=self.dataset_id,
             sandbox_dataset_id=self.sandbox_id,
+            intermediary_table=self.rule_instance.sandbox_table_for(
+                MEASUREMENT),
             unit_table_name=UNIT_MAPPING_TABLE,
             measurement_table=MEASUREMENT)
 


### PR DESCRIPTION
* solves issues with the 5.3 upgrade by changing the write_truncate query to an update query
* adds a record that should be loaded but not modified by the integration test
* fixes any schema issues caused by this rule's use of write truncate