### PR TITLE
[DC-2273] [P1] `ethnicity_source_concept_id` and `ethnicity_source_value` values are not broken down in controlled tier

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
@@ -16,6 +16,7 @@ concepts are in the race class such mappings do not exist in concept_relationshi
 multiple race responses, we replace the multiple responses with a generalized concept 2000000008 
 (WhatRaceEthnicity_GeneralizedMultPopulations). 
 
+TODO update this paragraph
 Ethnicity: "Hispanic or Latino" is one of the responses in "what is your race/ethnicity?" question. 
 Participants can only indicate their ethnicity to be "Hispanic or Latino" but doesn't have the 
 option to indicate they are "Not Hispanic or Latino". We manually map the PPI response 1586147 to 

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
@@ -65,21 +65,32 @@ GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE = 'GenderIdentity_GeneralizedDiffGender
 RACE_CONCEPT_ID = 1586140
 GENERALIZED_RACE_CONCEPT_ID = 2000000008
 GENERALIZED_RACE_SOURCE_VALUE = 'WhatRaceEthnicity_GeneralizedMultPopulations'
+
 # Hispanic or Latino response concept id
 HISPANIC_LATINO_CONCEPT_ID = 1586147
 HISPANIC_LATINO_CONCEPT_SOURCE_VALUE = 'WhatRaceEthnicity_Hispanic'
 HISPANIC_LATINO_STANDARD_CONCEPT_ID = 38003563
+HISPANIC_LATINO_STANDARD_SOURCE_VALUE = "Hispanic"
 
+# Prefer not to answer
 PNA_CONCEPT_ID = 903079
+PNA_CONCEPT_SOURCE_VALUE = 'PMI_PreferNotToAnswer'
+
+# None of these
 NONE_OF_THESE_CONCEPT_ID = 1586148
+NONE_OF_THESE_CONCEPT_SOURCE_VALUE = 'WhatRaceEthnicity_RaceEthnicityNoneOfThese'
+
+# Non hispanic
 NON_HISPANIC_LATINO_CONCEPT_ID = 38003564
 NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE = "Not Hispanic"
+
 # OMOP non matching concept id
 NO_MATCHING_CONCEPT_ID = 0
 NO_MATCHING_SOURCE_VALUE = 'No matching concept'
 
 # Skip concept
 SKIP_CONCEPT_ID = 903096
+SKIP_CONCEPT_SOURCE_VALUE = "PMI_Skip"
 
 # Observation fields
 OBSERVATION_SOURCE_CONCEPT_ID = 'observation_source_concept_id'
@@ -231,11 +242,11 @@ FROM
             CASE 
                 WHEN race_ob.value_source_concept_id = {{no_matching_concept_id}} THEN "{{no_matching_source_value}}"
                 WHEN race_ob.value_source_concept_id IS NULL THEN "{{no_matching_source_value}}"
-                WHEN race_ob.value_source_concept_id = {{pna_concept_id}} THEN race_ob.value_source_value
-                WHEN race_ob.value_source_concept_id = {{skip_concept_id}} THEN race_ob.value_source_value
-                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN race_ob.value_source_value
+                WHEN race_ob.value_source_concept_id = {{pna_concept_id}} THEN "{{pna_concept_source_value}}"
+                WHEN race_ob.value_source_concept_id = {{skip_concept_id}} THEN "{{skip_concept_source_value}}"
+                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN "{{none_of_these_concept_source_value}}"
             ELSE "{{non_hispanic_latino_concept_source_value}}" END,
-            ethnicity_ob.value_source_value
+            "{{hispanic_latino_standard_source_value}}"
         ) AS ethnicity_source_value,
         DENSE_RANK() OVER(PARTITION BY p.person_id ORDER BY ethnicity_ob.observation_datetime DESC, ethnicity_ob.observation_id DESC) AS rank_order
     FROM `{{project}}.{{dataset}}.person` AS p
@@ -382,14 +393,20 @@ class RepopulatePersonControlledTier(AbstractRepopulatePerson):
             no_matching_concept_id=NO_MATCHING_CONCEPT_ID,
             no_matching_source_value=NO_MATCHING_SOURCE_VALUE,
             skip_concept_id=SKIP_CONCEPT_ID,
+            skip_concept_source_value=SKIP_CONCEPT_SOURCE_VALUE,
             pna_concept_id=PNA_CONCEPT_ID,
+            pna_concept_source_value=PNA_CONCEPT_SOURCE_VALUE,
             none_of_these_concept_id=NONE_OF_THESE_CONCEPT_ID,
+            none_of_these_concept_source_value=
+            NONE_OF_THESE_CONCEPT_SOURCE_VALUE,
             non_hispanic_latino_concept_id=NON_HISPANIC_LATINO_CONCEPT_ID,
             non_hispanic_latino_concept_source_value=
             NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE,
             hispanic_latino_concept_id=HISPANIC_LATINO_CONCEPT_ID,
             hispanic_latino_standard_concept_id=
             HISPANIC_LATINO_STANDARD_CONCEPT_ID,
+            hispanic_latino_standard_source_value=
+            HISPANIC_LATINO_STANDARD_SOURCE_VALUE,
             translate_source_concepts=self.get_ethnicity_manual_translation())
 
         return {

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
@@ -203,43 +203,38 @@ FROM
 (
     SELECT
         p.person_id,
-        IF
-        (ethnicity_ob.value_as_concept_id IS NULL,
+        IF (
+            ethnicity_ob.value_as_concept_id IS NULL,
             CASE 
                 WHEN race_ob.value_source_concept_id = {{no_matching_concept_id}} THEN {{no_matching_concept_id}}
                 WHEN race_ob.value_source_concept_id IS NULL THEN {{no_matching_concept_id}}
                 WHEN race_ob.value_source_concept_id = {{pna_concept_id}} THEN {{pna_concept_id}}
                 WHEN race_ob.value_source_concept_id = {{skip_concept_id}} THEN {{skip_concept_id}}
-                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN {{none_of_these_concept_id}}            
-            ELSE {{non_hispanic_latino_concept_id}}
-            END,
+                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN {{none_of_these_concept_id}}
+            ELSE {{non_hispanic_latino_concept_id}} END,
             {{hispanic_latino_concept_id}}
         ) AS ethnicity_concept_id,
-        COALESCE(
-            ethnicity_ob.value_source_concept_id, 
+        IF (
+            ethnicity_ob.value_as_concept_id IS NULL,
             CASE 
                 WHEN race_ob.value_source_concept_id = {{no_matching_concept_id}} THEN {{no_matching_concept_id}}
                 WHEN race_ob.value_source_concept_id IS NULL THEN {{no_matching_concept_id}}
                 WHEN race_ob.value_source_concept_id = {{pna_concept_id}} THEN {{pna_concept_id}}
                 WHEN race_ob.value_source_concept_id = {{skip_concept_id}} THEN {{skip_concept_id}}
-                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN {{none_of_these_concept_id}}            
-            ELSE {{non_hispanic_latino_concept_id}}
-            END,
-            {{no_matching_concept_id}}
+                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN {{none_of_these_concept_id}}
+            ELSE {{non_hispanic_latino_concept_id}} END,
+            ethnicity_ob.value_source_concept_id
         ) AS ethnicity_source_concept_id,
-        COALESCE(
-            ethnicity_ob.value_source_value,
-            IF (
-                race_ob.value_source_concept_id IN ({{pna_concept_id}}, {{skip_concept_id}}, {{none_of_these_concept_id}}),
-                race_ob.value_source_value,
-                NULL
-            ),
-            IF (
-                race_ob.value_source_concept_id = {{no_matching_concept_id}} OR race_ob.value_source_concept_id IS NULL,
-                "{{no_matching_source_value}}",
-                NULL
-            ),
-            "{{non_hispanic_latino_concept_source_value}}"
+        IF (
+            ethnicity_ob.value_as_concept_id IS NULL,
+            CASE 
+                WHEN race_ob.value_source_concept_id = {{no_matching_concept_id}} THEN "{{no_matching_source_value}}"
+                WHEN race_ob.value_source_concept_id IS NULL THEN "{{no_matching_source_value}}"
+                WHEN race_ob.value_source_concept_id = {{pna_concept_id}} THEN race_ob.value_source_value
+                WHEN race_ob.value_source_concept_id = {{skip_concept_id}} THEN race_ob.value_source_value
+                WHEN race_ob.value_source_concept_id = {{none_of_these_concept_id}} THEN race_ob.value_source_value
+            ELSE "{{non_hispanic_latino_concept_source_value}}" END,
+            ethnicity_ob.value_source_value
         ) AS ethnicity_source_value,
         DENSE_RANK() OVER(PARTITION BY p.person_id ORDER BY ethnicity_ob.observation_datetime DESC, ethnicity_ob.observation_id DESC) AS rank_order
     FROM `{{project}}.{{dataset}}.person` AS p

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier.py
@@ -16,16 +16,10 @@ concepts are in the race class such mappings do not exist in concept_relationshi
 multiple race responses, we replace the multiple responses with a generalized concept 2000000008 
 (WhatRaceEthnicity_GeneralizedMultPopulations). 
 
-TODO update this paragraph
 Ethnicity: "Hispanic or Latino" is one of the responses in "what is your race/ethnicity?" question. 
 Participants can only indicate their ethnicity to be "Hispanic or Latino" but doesn't have the 
 option to indicate they are "Not Hispanic or Latino". We manually map the PPI response 1586147 to 
-the standard OMOP concept 38003563. For those participants who didn't check this option, we will set 
-their ethnicity_concept_id = 2100000001, ethnicity_source_concept_id = 2100000001, 
-and ethnicity_source_value = ‘AoUDRC_NoneIndicated’
-
-Per ticket DC-1664, the ethnicity_concept_id and ethnicity_source_concept_id are no longer set to
-2100000001 and the and ethnicity_source_value is no longer set to ‘AoUDRC_NoneIndicated’. Instead,
+the standard OMOP concept 38003563. For those participants who didn't check this option, 
 non-Hispanic options are expanded as done in the registered tier repopulation.
 
 Gender: the standard OMOP gender concepts are very limiting and the PPI gender concepts are used 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
@@ -4,7 +4,8 @@ Integration test for repopulate_person_controlled_tier module
 Original Issues: DC-1439
 
 The intent is to repopulate the person table using the PPI responses based on the controlled tier
-privacy requirements """
+privacy requirements.
+"""
 
 # Python Imports
 import os
@@ -14,7 +15,7 @@ from dateutil import parser
 from common import PERSON, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.repopulate_person_controlled_tier import \
-    RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
+    NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
     GENERALIZED_GENDER_IDENTITY_CONCEPT_ID, GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE, \
     HISPANIC_LATINO_CONCEPT_ID, HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, NON_HISPANIC_LATINO_CONCEPT_ID, \
     NO_MATCHING_CONCEPT_ID, NO_MATCHING_SOURCE_VALUE, SKIP_CONCEPT_ID
@@ -156,8 +157,9 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
                  GENERALIZED_RACE_CONCEPT_ID, NON_HISPANIC_LATINO_CONCEPT_ID,
                  None, None, None, 'person_source_value',
                  'GenderIdentity_Woman', 1585840, GENERALIZED_RACE_SOURCE_VALUE,
-                 GENERALIZED_RACE_CONCEPT_ID, NO_MATCHING_SOURCE_VALUE,
-                 NO_MATCHING_CONCEPT_ID),
+                 GENERALIZED_RACE_CONCEPT_ID,
+                 NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE,
+                 NON_HISPANIC_LATINO_CONCEPT_ID),
                 (2, GENERALIZED_GENDER_IDENTITY_CONCEPT_ID, 1980, None, None,
                  parser.parse('1980-06-15 00:00:00 UTC'), 8515, 38003563, 1, 1,
                  1, 'person_source_value',
@@ -170,7 +172,7 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
                  parser.parse('1970-06-15 00:00:00 UTC'), SKIP_CONCEPT_ID,
                  SKIP_CONCEPT_ID, None, None, None, 'person_source_value',
                  'GenderIdentity_Woman', 1585840, 'PMI_Skip', 903096,
-                 'PMI_Skip', NO_MATCHING_CONCEPT_ID),
+                 'PMI_Skip', SKIP_CONCEPT_ID),
             ]
         }]
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
@@ -15,10 +15,10 @@ from dateutil import parser
 from common import PERSON, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.repopulate_person_controlled_tier import \
-    NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
+    RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
     GENERALIZED_GENDER_IDENTITY_CONCEPT_ID, GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE, \
     HISPANIC_LATINO_CONCEPT_ID, HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, NON_HISPANIC_LATINO_CONCEPT_ID, \
-    NO_MATCHING_CONCEPT_ID, NO_MATCHING_SOURCE_VALUE, SKIP_CONCEPT_ID
+    SKIP_CONCEPT_ID, NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import \
     BaseTest
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
@@ -17,8 +17,8 @@ from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.repopulate_person_controlled_tier import \
     RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
     GENERALIZED_GENDER_IDENTITY_CONCEPT_ID, GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE, \
-    HISPANIC_LATINO_CONCEPT_ID, HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, NON_HISPANIC_LATINO_CONCEPT_ID, \
-    SKIP_CONCEPT_ID, NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE
+    HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, NON_HISPANIC_LATINO_CONCEPT_ID, \
+    SKIP_CONCEPT_ID, NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, HISPANIC_LATINO_STANDARD_CONCEPT_ID
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import \
     BaseTest
 
@@ -161,13 +161,14 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
                  NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE,
                  NON_HISPANIC_LATINO_CONCEPT_ID),
                 (2, GENERALIZED_GENDER_IDENTITY_CONCEPT_ID, 1980, None, None,
-                 parser.parse('1980-06-15 00:00:00 UTC'), 8515, 38003563, 1, 1,
-                 1, 'person_source_value',
+                 parser.parse('1980-06-15 00:00:00 UTC'), 8515,
+                 HISPANIC_LATINO_STANDARD_CONCEPT_ID, 1, 1, 1,
+                 'person_source_value',
                  GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE,
                  GENERALIZED_GENDER_IDENTITY_CONCEPT_ID,
                  'WhatRaceEthnicity_Asian', 1586142,
                  HISPANIC_LATINO_CONCEPT_SOURCE_VALUE,
-                 HISPANIC_LATINO_CONCEPT_ID),
+                 HISPANIC_LATINO_STANDARD_CONCEPT_ID),
                 (3, 45878463, 1970, None, None,
                  parser.parse('1970-06-15 00:00:00 UTC'), SKIP_CONCEPT_ID,
                  SKIP_CONCEPT_ID, None, None, None, 'person_source_value',

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/repopulate_person_controlled_tier_test.py
@@ -1,7 +1,7 @@
 """
 Integration test for repopulate_person_controlled_tier module
 
-Original Issues: DC-1439
+Original Issues: DC-1439, DC-2273
 
 The intent is to repopulate the person table using the PPI responses based on the controlled tier
 privacy requirements.
@@ -15,10 +15,13 @@ from dateutil import parser
 from common import PERSON, OBSERVATION, VOCABULARY_TABLES
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.repopulate_person_controlled_tier import \
-    RepopulatePersonControlledTier, GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
+    RepopulatePersonControlledTier, \
+    NONE_OF_THESE_CONCEPT_ID, NONE_OF_THESE_CONCEPT_SOURCE_VALUE, SKIP_CONCEPT_SOURCE_VALUE, \
+    GENERALIZED_RACE_CONCEPT_ID, GENERALIZED_RACE_SOURCE_VALUE, \
     GENERALIZED_GENDER_IDENTITY_CONCEPT_ID, GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE, \
-    HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, NON_HISPANIC_LATINO_CONCEPT_ID, \
-    SKIP_CONCEPT_ID, NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, HISPANIC_LATINO_STANDARD_CONCEPT_ID
+    NON_HISPANIC_LATINO_CONCEPT_ID, SKIP_CONCEPT_ID, NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE, \
+    HISPANIC_LATINO_STANDARD_CONCEPT_ID, HISPANIC_LATINO_STANDARD_SOURCE_VALUE, \
+    PNA_CONCEPT_ID, PNA_CONCEPT_SOURCE_VALUE, NO_MATCHING_CONCEPT_ID, NO_MATCHING_SOURCE_VALUE
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import \
     BaseTest
 
@@ -63,13 +66,10 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
 
     def setUp(self):
         """
-        Create empty tables for the rule to run on
+        Setting up tables before running the tests.
         """
-        # Create domain tables required for the test
         super().setUp()
 
-        # Load the test data
-        # Load the test data
         person_data_template = self.jinja_env.from_string("""
             INSERT INTO `{{project_id}}.{{dataset_id}}.person`
             (
@@ -95,8 +95,13 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
             VALUES
             (1, 0, 1990, 1, 1, '1990-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
             (2, 0, 1980, 1, 1, '1980-01-01T00:00:01', 0, 0, 1, 1, 1, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
-            (3, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0)
-        """)
+            (3, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
+            (4, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
+            (5, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
+            (6, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
+            (7, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0),
+            (8, 0, 1970, 1, 1, '1970-01-01T00:00:01', 0, 0, NULL, NULL, NULL, 'person_source_value', 'gender_source_value', 0, 'race_source_value', 0, 'ethnicity', 0)
+       """)
 
         observation_data_template = self.jinja_env.from_string("""
             INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
@@ -112,36 +117,61 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
                 observation_type_concept_id
             )
             VALUES
-                (1, 1, 45877987, 1586140, 1586146, 'WhatRaceEthnicity_White', '2020-01-01', 0, 0),
-                (2, 1, 1586143, 1586140, 1586143, 'WhatRaceEthnicity_Black', '2020-01-01', 0, 0),
-                (3, 2, 45879439, 1586140, 1586142, 'WhatRaceEthnicity_Asian', '2020-01-01', 0, 0),
-                (4, 2, 1586147, 1586140, 1586147, 'WhatRaceEthnicity_Hispanic', '2020-01-01', 0, 0),
-                (5, 1, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
-                (6, 2, 45880669, 1585838, 1585839, 'GenderIdentity_Man', '2020-01-01', 0, 0),
-                (7, 2, 1585841, 1585838, 1585841, 'GenderIdentity_NonBinary', '2020-01-01', 0, 0),
-                (8, 1, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
-                (9, 2, 45880669, 1585845, 1585846, 'SexAtBirth_Male', '2020-01-01', 0, 0),
-                (10, 3, 903096, 1586140, 903096, 'PMI_Skip', '2020-01-01', 0, 0),
-                (11, 3, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
-                (12, 3, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0)
-
+                (11, 1, 45877987, 1586140, 1586146, 'WhatRaceEthnicity_White', '2020-01-01', 0, 0),
+                (12, 1, 1586143, 1586140, 1586143, 'WhatRaceEthnicity_Black', '2020-01-01', 0, 0),
+                (13, 1, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (14, 1, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
+                (21, 2, 45879439, 1586140, 1586142, 'WhatRaceEthnicity_Asian', '2020-01-01', 0, 0),
+                (22, 2, 1586147, 1586140, 1586147, 'WhatRaceEthnicity_Hispanic', '2020-01-01', 0, 0),
+                (23, 2, 45880669, 1585838, 1585839, 'GenderIdentity_Man', '2020-01-01', 0, 0),
+                (24, 2, 1585841, 1585838, 1585841, 'GenderIdentity_NonBinary', '2020-01-01', 0, 0),
+                (25, 2, 45880669, 1585845, 1585846, 'SexAtBirth_Male', '2020-01-01', 0, 0),
+                (31, 3, 903096, 1586140, 903096, 'PMI_Skip', '2020-01-01', 0, 0),
+                (32, 3, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (33, 3, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
+                (41, 4, 903079, 1586140, 903079, 'PMI_PreferNotToAnswer', '2020-01-01', 0, 0),
+                (42, 4, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (43, 4, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
+                (51, 5, 1586148, 1586140, 1586148, 'WhatRaceEthnicity_RaceEthnicityNoneOfThese', '2020-01-01', 0, 0),
+                (52, 5, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (53, 5, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
+                (61, 6, 45877987, 1586140, 1586146, 'WhatRaceEthnicity_White', '2020-01-01', 0, 0),
+                (62, 6, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (63, 6, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
+                (71, 7, 0, 1586140, 0, NULL, '2020-01-01', 0, 0),
+                (72, 7, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (73, 7, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0),
+                (82, 8, 45878463, 1585838, 1585840, 'GenderIdentity_Woman', '2020-01-01', 0, 0),
+                (83, 8, 45878463, 1585845, 1585847, 'SexAtBirth_Female', '2020-01-01', 0, 0)
         """)
+
         insert_person_query = person_data_template.render(
             project_id=self.project_id, dataset_id=self.dataset_id)
         insert_observation_query = observation_data_template.render(
             project_id=self.project_id, dataset_id=self.dataset_id)
 
-        # Load test data
         self.load_test_data(
             [f'{insert_person_query}', f'{insert_observation_query}'])
 
     def test_repopulate_person_controlled_tier(self):
+        """
+        Test cases
+        1 - Race: White and Black,     Ethnicity: Non-hispanic, Gender Identity: Woman,              Sex at Birth: Female,
+        2 - Race: Asian,               Ethnicity: Hispanic,     Gender Identity: Man and Non-binary, Sex at Birth: Male,
+        3 - Race and Ethnicity: Skipped,                        Gender Identity: Woman,              Sex at Birth: Female,
+        4 - Race and Ethnicity: Prefer not to answer,           Gender Identity: Woman,              Sex at Birth: Female,
+        5 - Race and Ethnicity: None of these,                  Gender Identity: Woman,              Sex at Birth: Female,
+        6 - Race: White,               Ethnicity: Non-hispanic, Gender Identity: Woman,              Sex at Birth: Female,
+        7 - Race and Ethnicity: No matching concept,            Gender Identity: Woman,              Sex at Birth: Female,
+        8 - Race and Ethnicity: No record,                      Gender Identity: Woman,              Sex at Birth: Female,
+        """
 
-        # Expected results list
+        self.maxDiff = None
+
         tables_and_counts = [{
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.person',
-            'loaded_ids': [1, 2, 3],
+            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8],
             'fields': [
                 'person_id', 'gender_concept_id', 'year_of_birth',
                 'month_of_birth', 'day_of_birth', 'birth_datetime',
@@ -167,13 +197,43 @@ class RepopulatePersonControlledTierTestBase(BaseTest.CleaningRulesTestBase):
                  GENERALIZED_GENDER_IDENTITY_SOURCE_VALUE,
                  GENERALIZED_GENDER_IDENTITY_CONCEPT_ID,
                  'WhatRaceEthnicity_Asian', 1586142,
-                 HISPANIC_LATINO_CONCEPT_SOURCE_VALUE,
+                 HISPANIC_LATINO_STANDARD_SOURCE_VALUE,
                  HISPANIC_LATINO_STANDARD_CONCEPT_ID),
                 (3, 45878463, 1970, None, None,
                  parser.parse('1970-06-15 00:00:00 UTC'), SKIP_CONCEPT_ID,
                  SKIP_CONCEPT_ID, None, None, None, 'person_source_value',
-                 'GenderIdentity_Woman', 1585840, 'PMI_Skip', 903096,
-                 'PMI_Skip', SKIP_CONCEPT_ID),
+                 'GenderIdentity_Woman', 1585840, SKIP_CONCEPT_SOURCE_VALUE,
+                 SKIP_CONCEPT_ID, SKIP_CONCEPT_SOURCE_VALUE, SKIP_CONCEPT_ID),
+                (4, 45878463, 1970, None, None,
+                 parser.parse('1970-06-15 00:00:00 UTC'), PNA_CONCEPT_ID,
+                 PNA_CONCEPT_ID, None, None, None, 'person_source_value',
+                 'GenderIdentity_Woman', 1585840, PNA_CONCEPT_SOURCE_VALUE,
+                 PNA_CONCEPT_ID, PNA_CONCEPT_SOURCE_VALUE, PNA_CONCEPT_ID),
+                (5, 45878463, 1970, None, None,
+                 parser.parse('1970-06-15 00:00:00 UTC'),
+                 NONE_OF_THESE_CONCEPT_ID, NONE_OF_THESE_CONCEPT_ID, None, None,
+                 None, 'person_source_value', 'GenderIdentity_Woman', 1585840,
+                 NONE_OF_THESE_CONCEPT_SOURCE_VALUE, NONE_OF_THESE_CONCEPT_ID,
+                 NONE_OF_THESE_CONCEPT_SOURCE_VALUE, NONE_OF_THESE_CONCEPT_ID),
+                (6, 45878463, 1970, None, None,
+                 parser.parse('1970-06-15 00:00:00 UTC'), 8527,
+                 NON_HISPANIC_LATINO_CONCEPT_ID, None, None, None,
+                 'person_source_value', 'GenderIdentity_Woman', 1585840,
+                 'WhatRaceEthnicity_White', 1586146,
+                 NON_HISPANIC_LATINO_CONCEPT_SOURCE_VALUE,
+                 NON_HISPANIC_LATINO_CONCEPT_ID),
+                (7, 45878463, 1970, None, None,
+                 parser.parse('1970-06-15 00:00:00 UTC'), 2100000001,
+                 NO_MATCHING_CONCEPT_ID, None, None, None,
+                 'person_source_value', 'GenderIdentity_Woman', 1585840,
+                 'AoUDRC_NoneIndicated', NO_MATCHING_CONCEPT_ID,
+                 NO_MATCHING_SOURCE_VALUE, NO_MATCHING_CONCEPT_ID),
+                (8, 45878463, 1970, None, None,
+                 parser.parse('1970-06-15 00:00:00 UTC'), 2100000001,
+                 NO_MATCHING_CONCEPT_ID, None, None, None,
+                 'person_source_value', 'GenderIdentity_Woman', 1585840,
+                 'AoUDRC_NoneIndicated', NO_MATCHING_CONCEPT_ID,
+                 NO_MATCHING_SOURCE_VALUE, NO_MATCHING_CONCEPT_ID),
             ]
         }]
 


### PR DESCRIPTION
On top of adding more test cases to the integration test, I tested the updated logic is working against the DEID data from the past. Please see the JIRA ticket's comment section.