### PR TITLE
[DC-2595] store expected ct list in rdr sandbox dataset

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -11,6 +11,7 @@ import logging
 import cdr_cleaner.clean_cdr_engine as clean_engine
 from cdr_cleaner.cleaning_rules.backfill_pmi_skip_codes import BackfillPmiSkipCodes
 from cdr_cleaner.cleaning_rules.clean_by_birth_year import CleanByBirthYear
+from cdr_cleaner.cleaning_rules.create_expected_ct_list import StoreExpectedCTList
 import cdr_cleaner.cleaning_rules.domain_alignment as domain_alignment
 import cdr_cleaner.cleaning_rules.drop_duplicate_states as drop_duplicate_states
 import cdr_cleaner.cleaning_rules.drop_extreme_measurements as extreme_measurements
@@ -186,6 +187,7 @@ RDR_CLEANING_CLASSES = [
     (CleanByBirthYear,),
     (UpdateInvalidZipCodes,),
     (DropParticipantsWithoutAnyBasics,),
+    (StoreExpectedCTList,),
 ]
 
 COMBINED_CLEANING_CLASSES = [

--- a/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list.py
@@ -1,0 +1,160 @@
+"""
+Background
+
+The Genomics program requires predicted research IDs (RIDs) as soon as possible after
+the data cut off date.  The actual list takes some time to generate, and this is a prediction
+of what the list will be.
+
+The list here should match the participants in the CT dataset once the dataset has been created.
+"""
+# Python imports
+import logging
+
+# Third party imports
+
+# Project imports
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+from common import (JINJA_ENV, PIPELINE_TABLES, PRIMARY_PID_RID_MAPPING)
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from cdr_cleaner.cleaning_rules.clean_mapping import CleanMappingExtTables
+
+LOGGER = logging.getLogger(__name__)
+EXPECTED_CT_LIST = 'expected_ct_list'
+
+CREATE_EXPECTED_CT_LIST = JINJA_ENV.from_string("""
+create or replace table `{{project_id}}.{{sandbox_dataset_id}}.{{storage_table_name}}` as (
+-- get the list of all participants at the end of the RDR cleaning stage --
+with rdr_persons as (
+  SELECT distinct person_id
+  from `{{project_id}}.{{dataset_id}}.person` rdr)
+
+-- get list of all participants identifying as AI/AN --
+-- may be removed once the program finalizes the inclusion of AI/AN participants --
+, aian_persons as (
+  select distinct person_id
+  from `{{project_id}}.{{dataset_id}}.observation`
+  where observation_source_concept_id IN (1586140) AND value_source_concept_id IN (1586141)
+)
+
+-- get list of all participants who have completed The Basics survey --
+, has_the_basics as (
+     SELECT
+    distinct person_id
+  FROM `{{project_id}}.{{dataset_id}}.concept_ancestor`
+  INNER JOIN `{{project_id}}.{{dataset_id}}.observation` o ON observation_concept_id = descendant_concept_id
+  INNER JOIN `{{project_id}}.{{dataset_id}}.concept` d ON d.concept_id = descendant_concept_id
+  WHERE ancestor_concept_id = 1586134
+
+  UNION DISTINCT
+  SELECT
+   distinct person_id
+  FROM `{{project_id}}.{{dataset_id}}.concept`
+  JOIN `{{project_id}}.{{dataset_id}}.concept_ancestor`
+    ON (concept_id = ancestor_concept_id)
+  JOIN `{{project_id}}.{{dataset_id}}.observation`
+    ON (descendant_concept_id = observation_concept_id)
+  WHERE concept_class_id = 'Module'
+    AND concept_name IN ('The Basics')
+    AND questionnaire_response_id IS NOT NULL
+)
+
+-- get list of all participants who have not completed The Basics survey --
+-- can be used during debugging to determine who doesn't have the basics --
+, missing_the_basics as (
+  SELECT distinct person_id
+  FROM rdr_persons
+  WHERE person_id not in (SELECT distinct person_id FROM has_the_basics)
+)
+ -- get list of all participants that could be dropped due to bad birth date records --
+, bad_birthdate_records as (
+    SELECT person_id 
+    FROM `{{project_id}}.{{dataset_id}}.person` p 
+    WHERE p.year_of_birth < 1800 
+    OR p.year_of_birth > (EXTRACT(YEAR FROM CURRENT_DATE()) - 17)
+)
+
+-- store the research_id of all participants 
+select m.research_id
+from rdr_persons p
+left join `{{project_id}}.{{pipeline_lookup_tables}}.{{mapping_table}}` m
+using(person_id)
+where person_id in (select person_id from has_the_basics)
+AND person_id not in (select person_id from bad_birthdate_records)
+);""")
+
+
+class StoreExpectedCTList(BaseCleaningRule):
+    """
+    Store the expected CT participant list.
+    """
+
+    def __init__(self, project_id, dataset_id, sandbox_dataset_id, namer=None):
+        desc = (
+            f'Creates a sandbox table with expected participant research_ids '
+            f'that will be found in the controlled tier dataset.  May be used '
+            f'to help validate a particular pipeline run.  May be extended to '
+            f'update which service accounts can read the data in the table.')
+
+        super().__init__(
+            issue_numbers=['DC2595'],
+            description=desc,
+            affected_datasets=[],  # has no side effects
+            project_id=project_id,
+            dataset_id=dataset_id,
+            sandbox_dataset_id=sandbox_dataset_id,
+            depends_on=[CleanMappingExtTables],
+            table_namer=namer)
+
+    def get_query_specs(self):
+        """
+        Store the predicted CT participant list.
+
+        :return: a list of SQL strings to run
+        """
+        create_sandbox_table = CREATE_EXPECTED_CT_LIST.render(
+            project_id=self.project_id,
+            dataset_id=self.dataset_id,
+            sandbox_dataset_id=self.sandbox_dataset_id,
+            mapping_table=PRIMARY_PID_RID_MAPPING,
+            storage_table_name=EXPECTED_CT_LIST,
+            pipeline_lookup_tables=PIPELINE_TABLES)
+
+        create_sandbox_table_dict = {cdr_consts.QUERY: create_sandbox_table}
+
+        return [create_sandbox_table_dict]
+
+    def get_sandbox_tablenames(self):
+        return [EXPECTED_CT_LIST]
+
+    def setup_rule(self):
+        pass
+
+    def setup_validation(self):
+        pass
+
+    def validate_rule(self):
+        pass
+
+
+if __name__ == '__main__':
+    from utils import pipeline_logging
+
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.parse_args()
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(ARGS.project_id,
+                                                 ARGS.dataset_id,
+                                                 ARGS.sandbox_dataset_id,
+                                                 [(StoreExpectedCTList,)])
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(StoreExpectedCTList,)])

--- a/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list.py
@@ -88,7 +88,11 @@ class StoreExpectedCTList(BaseCleaningRule):
     Store the expected CT participant list.
     """
 
-    def __init__(self, project_id, dataset_id, sandbox_dataset_id, namer=None):
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 table_namer=None):
         desc = (
             f'Creates a sandbox table with expected participant research_ids '
             f'that will be found in the controlled tier dataset.  May be used '
@@ -103,7 +107,7 @@ class StoreExpectedCTList(BaseCleaningRule):
             dataset_id=dataset_id,
             sandbox_dataset_id=sandbox_dataset_id,
             depends_on=[CleanMappingExtTables],
-            table_namer=namer)
+            table_namer=table_namer)
 
     def get_query_specs(self):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list.py
@@ -73,7 +73,7 @@ with rdr_persons as (
     OR p.year_of_birth > (EXTRACT(YEAR FROM CURRENT_DATE()) - 17)
 )
 
--- store the research_id of all participants 
+-- store the research_id of all participants --
 select m.research_id
 from rdr_persons p
 left join `{{project_id}}.{{pipeline_lookup_tables}}.{{mapping_table}}` m
@@ -116,7 +116,7 @@ class StoreExpectedCTList(BaseCleaningRule):
             dataset_id=self.dataset_id,
             sandbox_dataset_id=self.sandbox_dataset_id,
             mapping_table=PRIMARY_PID_RID_MAPPING,
-            storage_table_name=EXPECTED_CT_LIST,
+            storage_table_name=self.sandbox_table_for(EXPECTED_CT_LIST),
             pipeline_lookup_tables=PIPELINE_TABLES)
 
         create_sandbox_table_dict = {cdr_consts.QUERY: create_sandbox_table}
@@ -124,9 +124,9 @@ class StoreExpectedCTList(BaseCleaningRule):
         return [create_sandbox_table_dict]
 
     def get_sandbox_tablenames(self):
-        return [EXPECTED_CT_LIST]
+        return [self.sandbox_table_for(EXPECTED_CT_LIST)]
 
-    def setup_rule(self):
+    def setup_rule(self, client):
         pass
 
     def setup_validation(self):

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list_test.py
@@ -1,0 +1,179 @@
+from datetime import datetime
+import os
+
+import mock
+from dateutil import parser
+
+from app_identity import get_application_id
+from common import (OBSERVATION, PERSON, PRIMARY_PID_RID_MAPPING)
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+from cdr_cleaner.cleaning_rules.create_expected_ct_list import StoreExpectedCTList
+
+
+class StoreExpectedCTListTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        cls.project_id = get_application_id()
+
+        # set the expected test datasets
+        cls.dataset_id = os.getenv('RDR_DATASET_ID')
+        cls.sandbox_id = f'{cls.dataset_id}_sandbox'
+        cls.vocabulary_dataset = os.getenv('VOCABULARY_DATASET')
+
+        cls.rule_instance = StoreExpectedCTList(cls.project_id, cls.dataset_id,
+                                                cls.sandbox_id)
+
+        sb_table_names = cls.rule_instance.get_sandbox_tablenames()
+        for table_name in sb_table_names:
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.{table_name}')
+
+        # This will normally be the PIPELINE_TABLES dataset, but is being
+        # mocked for this test
+        cls.stable_map_name = f'{cls.project_id}.{cls.dataset_id}.{PRIMARY_PID_RID_MAPPING}'
+        cls.fq_table_names = [
+            f'{cls.project_id}.{cls.dataset_id}.{table}'
+            for table in [OBSERVATION, PERSON, PRIMARY_PID_RID_MAPPING]
+        ]
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+        self.copy_vocab_tables(self.vocabulary_dataset)
+        # pre-conditions
+        person_tmpl = self.jinja_env.from_string("""
+            INSERT INTO `{{project}}.{{dataset}}.{{table}}`
+                (person_id, year_of_birth,
+                gender_concept_id, race_concept_id, ethnicity_concept_id)
+            VALUES
+                -- should not be included in sandbox table because of bad birth year --
+                (100, 1799, 5, 5, 5),
+                -- should be kept --
+                (200, 1801, 5, 5, 5),
+                -- should not be included in sandbox table because of bad birth year --
+                (300, 2020, 5, 5, 5),
+                -- should be kept --
+                (400, 2000, 5, 5, 5),
+                -- should be kept.  added for ai/an checks --
+                (500, 1990, 5, 5, 5),
+                (600, 1980, 5, 5, 5),
+                -- should not be included in sandbox table for not having the basics --
+                (700, 1985, 5, 5, 5),
+                -- kept for having the basics --
+                (800, 1985, 5, 5, 5)
+        """).render(project=self.project_id,
+                    dataset=self.dataset_id,
+                    table=PERSON)
+
+        primary_map_tmpl = self.jinja_env.from_string("""
+        INSERT INTO `{{project}}.{{dataset}}.{{table}}`
+            (person_id, research_id, shift, import_date)
+        VALUES
+            (100, 90, 50, '2020-01-01'),
+            (200, 80, 40, '2020-01-01'),
+            (300, 70, 30, '2020-01-01'),
+            (400, 60, 20, '2020-01-01'),
+            (500, 50, 10, '2020-01-01'),
+            (600, 40, 60, '2020-01-01'),
+            (700, 30, 70, '2020-01-01'),
+            (800, 20, 80, '2020-01-01')
+        """).render(project=self.project_id,
+                    dataset=self.dataset_id,
+                    table=PRIMARY_PID_RID_MAPPING)
+
+        observation_tmpl = self.jinja_env.from_string("""
+        INSERT INTO `{{project}}.{{dataset}}.{{table}}`
+          (observation_id, person_id, observation_source_concept_id, value_source_concept_id,
+          observation_concept_id, observation_date, observation_type_concept_id)
+        VALUES
+          -- should not be included in sandbox table due to ai/an answer --
+          (10, 500, 1586140, 1586141, 1586140, '1900-01-01', 0),
+          (20, 500, 1586140, 1586147, 1586140, '1900-01-01', 0),
+          -- keep because not ai/an --
+          (30, 600, 1586140, 1586145, 1586140, '1900-01-01', 0),
+          -- should not be included in sandbox table.  does not have the basics --
+          (40, 700, 1000, 0, 1000, '1900-01-01', 0),
+          -- does have the basics --
+          (50, 800, 1585838, 1585840, 1585838, '1900-01-01', 0),
+          (60, 200, 1585838, 1585840, 1585838, '1900-01-01', 0),
+          (70, 400, 1585838, 1585840, 1585838, '1900-01-01', 0)
+        """).render(project=self.project_id,
+                    dataset=self.dataset_id,
+                    table=OBSERVATION)
+        queries = [
+            observation_tmpl,
+            person_tmpl,
+            primary_map_tmpl,
+        ]
+        self.load_test_data(queries)
+
+    def test_store_expected_ct_list(self):
+        self.maxDiff = None
+        obs_date = parser.parse('1900-01-01').date()
+        tables_and_counts = [
+            {
+                'fq_table_name':
+                    f'{self.project_id}.{self.dataset_id}.{PERSON}',
+                'fields': [
+                    'person_id', 'year_of_birth', 'gender_concept_id',
+                    'race_concept_id', 'ethnicity_concept_id'
+                ],
+                'loaded_ids': [100, 200, 300, 400, 500, 600, 700, 800],
+                'cleaned_values': [
+                    # No changes should be made
+                    (100, 1799, 5, 5, 5),
+                    (200, 1801, 5, 5, 5),
+                    (300, 2020, 5, 5, 5),
+                    (400, 2000, 5, 5, 5),
+                    (500, 1990, 5, 5, 5),
+                    (600, 1980, 5, 5, 5),
+                    (700, 1985, 5, 5, 5),
+                    (800, 1985, 5, 5, 5),
+                ]
+            },
+            {
+                'fq_table_name':
+                    f'{self.project_id}.{self.dataset_id}.{OBSERVATION}',
+                'fields': [
+                    'observation_id', 'person_id',
+                    'observation_source_concept_id', 'value_source_concept_id',
+                    'observation_concept_id', 'observation_date',
+                    'observation_type_concept_id'
+                ],
+                'loaded_ids': [10, 20, 30, 40, 50, 60, 70],
+                'cleaned_values': [
+                    # No changes should be made
+                    (10, 500, 1586140, 1586141, 1586140, obs_date, 0),
+                    (20, 500, 1586140, 1586147, 1586140, obs_date, 0),
+                    (30, 600, 1586140, 1586145, 1586140, obs_date, 0),
+                    (40, 700, 1000, 0, 1000, obs_date, 0),
+                    (50, 800, 1585838, 1585840, 1585838, obs_date, 0),
+                    (60, 200, 1585838, 1585840, 1585838, obs_date, 0),
+                    (70, 400, 1585838, 1585840, 1585838, obs_date, 0)
+                ],  # verifying the correct fields and data are sandboxed here
+                'fq_sandbox_table_name':
+                    self.fq_sandbox_table_names[0],
+                'sandbox_fields': ['research_id'],
+                'sandboxed_ids': [80, 60, 50, 40, 20]
+            }
+        ]
+
+        # mock the PIPELINE_TABLES variable so tests on different branches
+        # don't overwrite each other.  Just changes the value of the string variable
+        with mock.patch(
+                'cdr_cleaner.cleaning_rules.create_expected_ct_list.PIPELINE_TABLES',
+                self.dataset_id):
+            self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list_test.py
@@ -5,7 +5,8 @@ import mock
 from dateutil import parser
 
 from app_identity import get_application_id
-from common import (OBSERVATION, PERSON, PRIMARY_PID_RID_MAPPING)
+from common import (OBSERVATION, PERSON, PRIMARY_PID_RID_MAPPING,
+                    VOCABULARY_TABLES)
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from cdr_cleaner.cleaning_rules.create_expected_ct_list import StoreExpectedCTList
 
@@ -41,7 +42,8 @@ class StoreExpectedCTListTest(BaseTest.CleaningRulesTestBase):
         cls.stable_map_name = f'{cls.project_id}.{cls.dataset_id}.{PRIMARY_PID_RID_MAPPING}'
         cls.fq_table_names = [
             f'{cls.project_id}.{cls.dataset_id}.{table}'
-            for table in [OBSERVATION, PERSON, PRIMARY_PID_RID_MAPPING]
+            for table in [OBSERVATION, PERSON, PRIMARY_PID_RID_MAPPING] +
+            VOCABULARY_TABLES
         ]
 
         # call super to set up the client, create datasets, and create

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/create_expected_ct_list_test.py
@@ -61,18 +61,18 @@ class StoreExpectedCTListTest(BaseTest.CleaningRulesTestBase):
             VALUES
                 -- should not be included in sandbox table because of bad birth year --
                 (100, 1799, 5, 5, 5),
-                -- should be kept --
+                -- should be included --
                 (200, 1801, 5, 5, 5),
                 -- should not be included in sandbox table because of bad birth year --
                 (300, 2020, 5, 5, 5),
-                -- should be kept --
+                -- should be included --
                 (400, 2000, 5, 5, 5),
-                -- should be kept.  added for ai/an checks --
+                -- should be included.  added for ai/an regression checks --
                 (500, 1990, 5, 5, 5),
                 (600, 1980, 5, 5, 5),
                 -- should not be included in sandbox table for not having the basics --
                 (700, 1985, 5, 5, 5),
-                -- kept for having the basics --
+                -- included for having the basics --
                 (800, 1985, 5, 5, 5)
         """).render(project=self.project_id,
                     dataset=self.dataset_id,
@@ -99,10 +99,10 @@ class StoreExpectedCTListTest(BaseTest.CleaningRulesTestBase):
           (observation_id, person_id, observation_source_concept_id, value_source_concept_id,
           observation_concept_id, observation_date, observation_type_concept_id)
         VALUES
-          -- should not be included in sandbox table due to ai/an answer --
+          -- should be included in sandbox table.  ai/an regression check --
           (10, 500, 1586140, 1586141, 1586140, '1900-01-01', 0),
           (20, 500, 1586140, 1586147, 1586140, '1900-01-01', 0),
-          -- keep because not ai/an --
+          -- include because not ai/an --
           (30, 600, 1586140, 1586145, 1586140, '1900-01-01', 0),
           -- should not be included in sandbox table.  does not have the basics --
           (40, 700, 1000, 0, 1000, '1900-01-01', 0),


### PR DESCRIPTION
* store curation's expected CT participant list in the rdr sandbox after all the RDR cleaning rules have executed
* intended to help automate the generation of this list for the genomics team
* can be used to identify errors earlier, when lists at combined or CT data stages drop expected participants according to this table