### PR TITLE
[DC-2475] Account for text answers when assigning the invalid code for '1333023'.

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
@@ -23,14 +23,14 @@ pd.options.display.max_rows = 120
 
 # + tags=["parameters"]
 project_id = ""
-deid_cdr=""
+deid_cdr = ""
 # deid_clean=""
 com_cdr = ""
 run_as = ""
 # -
 
 # df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+df = pd.DataFrame(columns=['query', 'result'])
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -45,14 +45,14 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 #
 # Expected result:
 #
-# Null is the value poplulated in the value_as_number fields 
+# Null is the value poplulated in the value_as_number fields
 #
 # AND 2000000012, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field  in the deid table.
 #
-# Per Francis, the other two values are valid. so it is pass. 
+# Per Francis, the other two values are valid. so it is pass.
 
 # +
-query=f''' 
+query = f''' 
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM `{project_id}.{deid_cdr}.observation`
@@ -60,14 +60,22 @@ WHERE
   observation_source_concept_id = 1585890
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
 '''
-df1=execute(client, query)  
+df1 = execute(client, query)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query1 observation_source_concept_id 1585890', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query1 observation_source_concept_id 1585890',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query1 observation_source_concept_id 1585890', 'result' : ''},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query1 observation_source_concept_id 1585890',
+            'result': ''
+        },
+        ignore_index=True)
 df1
 # -
 
@@ -79,10 +87,9 @@ df1
 #
 # AND 2000000012, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 #
-# ## one row had error in new cdr
 
 # +
-query=f''' 
+query = f''' 
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM `{project_id}.{deid_cdr}.observation`
@@ -90,18 +97,26 @@ WHERE
   observation_source_concept_id = 1333023
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
 '''
-df1=execute(client, query)  
+df1 = execute(client, query)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query2 observation_source_concept_id 1333023', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query2 observation_source_concept_id 1333023',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query2 observation_source_concept_id 1333023', 'result' : ''},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query2 observation_source_concept_id 1333023',
+            'result': ''
+        },
+        ignore_index=True)
 df1
 # -
 
-query=f''' 
+query = f''' 
 
 SELECT *
 FROM `{project_id}.{deid_cdr}.observation`
@@ -109,7 +124,7 @@ WHERE
   observation_source_concept_id = 1333023
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
 '''
-df1=execute(client, query)  
+df1 = execute(client, query)
 df1
 
 # # 3 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585889,  the value_as_concept_id field in de-id table should populate : 2000000013
@@ -118,12 +133,12 @@ df1
 #
 # expected results:
 #
-# Null is the value poplulated in the value_as_number fields 
+# Null is the value poplulated in the value_as_number fields
 #
 # AND 2000000013, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 
 # +
-query=f''' 
+query = f''' 
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM  `{project_id}.{deid_cdr}.observation`
@@ -131,31 +146,39 @@ WHERE
   observation_source_concept_id = 1585889
   AND value_as_concept_id NOT IN (2000000013,2000000010,903096)
 '''
-df1=execute(client, query)  
+df1 = execute(client, query)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query3 observation_source_concept_id 1585889', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query3 observation_source_concept_id 1585889',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query3 observation_source_concept_id 1585889', 'result' : ''},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query3 observation_source_concept_id 1585889',
+            'result': ''
+        },
+        ignore_index=True)
 df1
 # -
 
 # # 4 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1333015,  the value_as_concept_id field in de-id table should populate : 2000000013
 #
-# Generalization Rules for reference 
+# Generalization Rules for reference
 #
 # Living Situation: COPE survey Generalize household size >10
 #
 # expected results:
 #
-# Null is the value poplulated in the value_as_number fields 
+# Null is the value poplulated in the value_as_number fields
 #
 # AND 2000000013, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 
 # +
-query=f''' 
+query = f''' 
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM  `{project_id}.{deid_cdr}.observation`
@@ -163,14 +186,22 @@ WHERE
   observation_source_concept_id = 1333015
   AND value_as_concept_id NOT IN (2000000013,2000000010,903096)
 '''
-df1=execute(client, query)  
+df1 = execute(client, query)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query4 observation_source_concept_id 1333015', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query4 observation_source_concept_id 1333015',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query4 observation_source_concept_id 1333015', 'result' : ''},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query4 observation_source_concept_id 1333015',
+            'result': ''
+        },
+        ignore_index=True)
 df1
 # -
 
@@ -184,26 +215,26 @@ df1
 #
 # step1:
 #
-# 1. query with the condition 
+# 1. query with the condition
 # observation_source_concept_id = 1585249
-# 2. verify that none value_source_concept_id listed in J show up in the results.  
+# 2. verify that none value_source_concept_id listed in J show up in the results.
 #
 # expected results:
 #
-# 1. value_source_concept_id of the States that are not generalized show up AND 
+# 1. value_source_concept_id of the States that are not generalized show up AND
 #
-# 2.only one row displays the generalized value_source_concept_id :  2000000011. 
-#  
-# step2 
+# 2.only one row displays the generalized value_source_concept_id :  2000000011.
+#
+# step2
 #
 # 1. query using the listed value_source_concept_id as condition
 #
-# 2. these are the states that are generalized. 
+# 2. these are the states that are generalized.
 #
-# expected results: returns no results 
+# expected results: returns no results
 
 # +
-query=f''' 
+query = f''' 
 WITH df1 AS (
 SELECT distinct deid.value_source_concept_id
 FROM
@@ -235,19 +266,26 @@ OR com.value_source_concept_id =        1585275)
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE value_source_concept_id !=2000000011
 '''
-df1=execute(client, query)  
+df1 = execute(client, query)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query5_state_generalization', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append({
+        'query': 'Query5_state_generalization',
+        'result': 'PASS'
+    },
+                   ignore_index=True)
 else:
- df = df.append({'query' : 'Query5_state_generalization', 'result' : ''},  
-                ignore_index = True) 
+    df = df.append({
+        'query': 'Query5_state_generalization',
+        'result': ''
+    },
+                   ignore_index=True)
 df1
 # -
 
 # # Summary_deid_household AND state generalization
 
 # if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null','']))
-df.style.highlight_null(null_color='red').set_properties(**{'text-align': 'left'})
+df = df.mask(df.isin(['Null', '']))
+df.style.highlight_null(null_color='red').set_properties(
+    **{'text-align': 'left'})

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -2,7 +2,7 @@
 Apply value ranges to ensure that values are reasonable and to minimize the likelihood
 of sensitive information (like phone numbers) within the free text fields.
 
-Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487
+Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475
 
 The intent is to ensure that numeric free-text fields that are not manipulated by de-id
 have value range restrictions applied to the value_as_number field across the entire dataset.
@@ -154,14 +154,15 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
             'Sets value_as_number to NULL and value_as_concept_id and value_as_number '
             'to new AOU custom concept 2000000012 for households with 6 or more individuals '
             'under the age of 18')
-        super().__init__(
-            issue_numbers=['DC1058', 'DC1061', 'DC827', 'DC502', 'DC487'],
-            description=desc,
-            affected_datasets=[cdr_consts.RDR],
-            affected_tables=['observation'],
-            project_id=project_id,
-            dataset_id=dataset_id,
-            sandbox_dataset_id=sandbox_dataset_id)
+        super().__init__(issue_numbers=[
+            'DC1058', 'DC1061', 'DC827', 'DC502', 'DC487', 'DC2475'
+        ],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         affected_tables=['observation'],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id)
 
     def get_query_specs(self):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -47,7 +47,9 @@ OR
     (observation_concept_id IN (1333015, 1585889) AND (value_as_number < 0 OR value_as_number > 10))
 OR
     -- from dc1058: sandbox any participant data who have 6 or more members under 18 in their household --
-    (observation_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5)))
+    (observation_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5))
+OR
+    (observation_concept_id = 1333023 AND value_as_number IS NULL AND value_as_string IS NOT NULL))
 """)
 
 CLEAN_INVALID_VALUES_QUERY = JINJA_ENV.from_string("""
@@ -70,9 +72,17 @@ CASE
   ELSE value_as_number
 END AS
     value_as_number,
-    value_as_string,
+    CASE WHEN observation_concept_id = 1333023 AND value_as_number IS NULL AND value_as_string IS NOT NULL THEN NULL
+    ELSE value_as_string
+    END AS value_as_string,
 CASE
-    WHEN observation_concept_id IN (1585890, 1333023, 1333015, 1585889) AND (value_as_number < 0 OR value_as_number >= 20) THEN 2000000010
+    WHEN observation_concept_id IN (1585890, 1333023, 1333015, 1585889) 
+        AND (
+            value_as_number < 0 
+            OR value_as_number >= 20 
+            OR (value_as_number IS NULL AND value_as_string IS NOT NULL)
+        )
+        THEN 2000000010
     WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
     WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
     
@@ -96,7 +106,13 @@ END AS
     unit_source_value,
     qualifier_source_value,
     CASE
-        WHEN observation_concept_id IN (1585890, 1333023, 1333015, 1585889) AND (value_as_number < 0 OR value_as_number >= 20) THEN 2000000010
+        WHEN observation_concept_id IN (1585890, 1333023, 1333015, 1585889) 
+            AND (
+                value_as_number < 0 
+                OR value_as_number >= 20 
+                OR (value_as_number IS NULL AND value_as_string IS NOT NULL)
+            )
+            THEN 2000000010
         WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
         WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
     

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -4,7 +4,7 @@ Integration test for clean_ppi_numeric_fields_using_parameters module
 Apply value ranges to ensure that values are reasonable and to minimize the likelihood
 of sensitive information (like phone numbers) within the free text fields.
 
-Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487
+Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475
 
 The intent is to ensure that numeric free-text fields that are not manipulated by de-id
 have value range restrictions applied to the value_as_number field across the entire dataset.

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -85,18 +85,19 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
             """
             INSERT INTO `{{fq_dataset_name}}.observation`
             (observation_id, person_id, observation_concept_id, observation_date,
-             observation_type_concept_id, value_as_number, value_as_concept_id, value_source_concept_id)
+             observation_type_concept_id, value_as_number, value_as_string, value_as_concept_id, value_source_concept_id)
             VALUES
                 -- invalid values test setup --
-                (103, 3, 1585795, date('2015-07-15'), 0, 100, 1234567, 1234567),
-                (104, 4, 1585802, date('2015-07-15'), 0, -100, 1234567, 1234567),
-                (105, 5, 1585820, date('2015-07-15'), 0, 256, 1234567, 1234567),
-                (106, 6, 1585820, date('2015-07-15'), 0, -256, 1234567, 1234567),
-                (107, 7, 1585864, date('2015-07-15'), 0, 100, 1234567, 1234567),
-                (108, 8, 1585870, date('2015-07-15'), 0, -100, 1234567, 1234567),
-                (109, 9, 1585873, date('2015-07-15'), 0, 15, 7654321, 7654321),
-                (110, 10, 1586159, date('2015-07-15'), 0, 16, 7654321, 7654321),
-                (111, 11, 1586162, date('2015-07-15'), 0, 17, 7654321, 7654321)"""
+                (103, 3, 1585795, date('2015-07-15'), 0, 100, NULL, 1234567, 1234567),
+                (104, 4, 1585802, date('2015-07-15'), 0, -100, NULL, 1234567, 1234567),
+                (105, 5, 1585820, date('2015-07-15'), 0, 256, NULL, 1234567, 1234567),
+                (106, 6, 1585820, date('2015-07-15'), 0, -256, NULL, 1234567, 1234567),
+                (107, 7, 1585864, date('2015-07-15'), 0, 100, NULL, 1234567, 1234567),
+                (108, 8, 1585870, date('2015-07-15'), 0, -100, NULL, 1234567, 1234567),
+                (109, 9, 1585873, date('2015-07-15'), 0, 15, NULL, 7654321, 7654321),
+                (110, 10, 1586159, date('2015-07-15'), 0, 16, NULL, 7654321, 7654321),
+                (111, 11, 1586162, date('2015-07-15'), 0, 17, NULL, 7654321, 7654321),
+                (122, 22, 1333023, date('2015-07-15'), 0, NULL, 'test', 7654321, 7654321)"""
         ).render(fq_dataset_name=self.fq_dataset_name)
         queries.append(invalid_values_tmpl)
 
@@ -140,57 +141,66 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
                 self.fq_sandbox_table_names[0],
             'loaded_ids': [
                 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-                116, 117, 118, 119, 120, 121
+                116, 117, 118, 119, 120, 121, 122
             ],
             'sandboxed_ids': [
                 103, 104, 105, 106, 107, 108, 112, 113, 115, 116, 118, 119, 120,
-                121
+                121, 122
             ],
             'fields': [
                 'observation_id', 'observation_concept_id', 'value_as_number',
-                'value_as_concept_id', 'value_source_concept_id'
+                'value_as_string', 'value_as_concept_id',
+                'value_source_concept_id'
             ],
             'cleaned_values': [
                 # invalid values tests
-                (103, 1585795, None, self.invalid_values_value_as_concept_id,
+                (103, 1585795, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (104, 1585802, None, self.invalid_values_value_as_concept_id,
+                (104, 1585802, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (105, 1585820, None, self.invalid_values_value_as_concept_id,
+                (105, 1585820, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (106, 1585820, None, self.invalid_values_value_as_concept_id,
+                (106, 1585820, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (107, 1585864, None, self.invalid_values_value_as_concept_id,
+                (107, 1585864, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (108, 1585870, None, self.invalid_values_value_as_concept_id,
+                (108, 1585870, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (109, 1585873, 15, 7654321, 7654321),
-                (110, 1586159, 16, 7654321, 7654321),
-                (111, 1586162, 17, 7654321, 7654321),
+                (109, 1585873, 15, None, 7654321, 7654321),
+                (110, 1586159, 16, None, 7654321, 7654321),
+                (111, 1586162, 17, None, 7654321, 7654321),
+                (122, 1333023, None, None,
+                 self.invalid_values_value_as_concept_id,
+                 self.invalid_values_value_as_concept_id),
                 # 11+ values tests
-                (112, 1333015, None, self.invalid_values_value_as_concept_id,
+                (112, 1333015, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (113, 1585889, None, self.eleven_plus_value_as_concept_id,
+                (113, 1585889, None, None, self.eleven_plus_value_as_concept_id,
                  self.eleven_plus_value_as_concept_id),
-                (114, 1333015, 10, 7654321, 7654321),
-                (118, 1585889, None, self.invalid_values_value_as_concept_id,
+                (114, 1333015, 10, None, 7654321, 7654321),
+                (118, 1585889, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (121, 1333015, None, self.eleven_plus_value_as_concept_id,
+                (121, 1333015, None, None, self.eleven_plus_value_as_concept_id,
                  self.eleven_plus_value_as_concept_id),
                 # 6+ values tests
-                (115, 1333023, None, self.invalid_values_value_as_concept_id,
+                (115, 1333023, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (
-                    116,
-                    1585890,
-                    None,
-                    self.six_plus_value_as_concept_id,
-                    self.six_plus_value_as_concept_id,
-                ),
-                (117, 1333023, 5, 7654321, 7654321),
-                (119, 1585890, None, self.invalid_values_value_as_concept_id,
+                (116, 1585890, None, None, self.six_plus_value_as_concept_id,
+                 self.six_plus_value_as_concept_id),
+                (117, 1333023, 5, None, 7654321, 7654321),
+                (119, 1585890, None, None,
+                 self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (120, 1333023, None, self.six_plus_value_as_concept_id,
+                (120, 1333023, None, None, self.six_plus_value_as_concept_id,
                  self.six_plus_value_as_concept_id)
             ]
         }]

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -4,7 +4,7 @@ Unit test for clean_ppi_numeric_fields_using_parameters module
 Apply value ranges to ensure that values are reasonable and to minimize the likelihood
 of sensitive information (like phone numbers) within the free text fields.
 
-Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487
+Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475
 
 The intent is to ensure that numeric free-text fields that are not manipulated by de-id
 have value range restrictions applied to the value_as_number field across the entire dataset.


### PR DESCRIPTION
-  `cdr_deid_qa_report8_household_state_genera.py` has lots of changes because of `pylint`, but the only notable change is removing [this comment](https://github.com/all-of-us/curation/pull/1330/files#diff-bfc8a31439776b1f1be946f98df34a8a06a6911ecced825491ce2c1029d33b1cL82) that will be no longer relevant after this PR
- `observation_id=122` is added to cover the updated logic in the integration test.