### PR TITLE
[DC-2458] Update gcloud/bq/__init__.py copy_dataset to expect project as part of input_dataset and output_dataset parameters

### DIFF
--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -194,8 +194,8 @@ class BigQueryClient(Client):
         """
         Copies tables from source dataset to a destination datasets
 
-        :param input_dataset: name of the input dataset
-        :param output_dataset: name of the output dataset
+        :param input_dataset: name of the input(source) dataset
+        :param output_dataset: name of the output(destination) dataset
         :return:
         """
         # Copy input dataset tables to backup and staging datasets

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -194,8 +194,8 @@ class BigQueryClient(Client):
         """
         Copies tables from source dataset to a destination datasets
 
-        :param input_dataset: name of the input(source) dataset
-        :param output_dataset: name of the output(destination) dataset
+        :param input_dataset: fully qualified name of the input(source) dataset
+        :param output_dataset: fully qualified name of the output(destination) dataset
         :return:
         """
         # Copy input dataset tables to backup and staging datasets

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -201,7 +201,7 @@ class BigQueryClient(Client):
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         for table in tables:
-            staging_table = f'{self.project}.{output_dataset}.{table.table_id}'
+            staging_table = f'{output_dataset}.{table.table_id}'
             self.copy_table(table, staging_table)
 
     def list_tables(

--- a/data_steward/tools/create_tier.py
+++ b/data_steward/tools/create_tier.py
@@ -209,7 +209,8 @@ def create_tier(credentials_filepath, project_id, tier, input_dataset,
     # Create intermediary datasets and copy tables from input dataset to newly created dataset
     datasets = create_datasets(bq_client, final_dataset_name, input_dataset,
                                tier, release_tag)
-    bq_client.copy_dataset(input_dataset, datasets[consts.STAGING])
+    bq_client.copy_dataset(f'{project_id}.{input_dataset}',
+                           f'{project_id}.{datasets[consts.STAGING]}')
 
     # Run cleaning rules
     cleaning_args = [

--- a/data_steward/tools/fitbit/generate_fitbit_dataset.py
+++ b/data_steward/tools/fitbit/generate_fitbit_dataset.py
@@ -232,8 +232,9 @@ def main(raw_args=None):
                                   args.fitbit_dataset,
                                   fitbit_datasets[consts.BACKUP],
                                   table_prefix='v_')
-    bq_client.copy_dataset(fitbit_datasets[consts.BACKUP],
-                           fitbit_datasets[consts.STAGING])
+    bq_client.copy_dataset(
+        f'{args.project_id}.{fitbit_datasets[consts.BACKUP]}',
+        f'{args.project_id}.{fitbit_datasets[consts.STAGING]}')
 
     common_cleaning_args = [
         '-p',

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -10,7 +10,7 @@ from google.cloud import bigquery
 from google.cloud.bigquery import TableReference, DatasetReference
 from google.cloud.bigquery.table import TableListItem
 from google.cloud.exceptions import NotFound
-from mock import patch, MagicMock, Mock
+from mock import patch, MagicMock, Mock, call
 
 # Project imports
 from gcloud.bq import BigQueryClient
@@ -257,6 +257,15 @@ class BQCTest(TestCase):
         mock_list_tables.assert_called_once_with(
             f'{self.client.project}.{self.dataset_id}')
         self.assertEqual(mock_copy_table.call_count, len(list_tables_results))
+        expected_calls = []
+        for table_object in list_tables_results:
+            table_id = table_object.table_id
+            expected_calls.append(
+                call(
+                    table_object,
+                    f'{self.client.project}.{self.dataset_id}_snapshot.{table_id}'
+                ))
+        mock_copy_table.assert_has_calls(expected_calls)
 
     @patch.object(BigQueryClient, 'get_dataset')
     @patch.object(BigQueryClient, 'get_table_count')

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -251,8 +251,11 @@ class BQCTest(TestCase):
         ]
         mock_list_tables.return_value = list_tables_results
 
-        self.client.copy_dataset(self.dataset_id, f'{self.dataset_id}_snapshot')
-        mock_list_tables.assert_called_once_with(self.dataset_id)
+        self.client.copy_dataset(
+            f'{self.client.project}.{self.dataset_id}',
+            f'{self.client.project}.{self.dataset_id}_snapshot')
+        mock_list_tables.assert_called_once_with(
+            f'{self.client.project}.{self.dataset_id}')
         self.assertEqual(mock_copy_table.call_count, len(list_tables_results))
 
     @patch.object(BigQueryClient, 'get_dataset')

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -257,14 +257,12 @@ class BQCTest(TestCase):
         mock_list_tables.assert_called_once_with(
             f'{self.client.project}.{self.dataset_id}')
         self.assertEqual(mock_copy_table.call_count, len(list_tables_results))
-        expected_calls = []
-        for table_object in list_tables_results:
-            table_id = table_object.table_id
-            expected_calls.append(
-                call(
-                    table_object,
-                    f'{self.client.project}.{self.dataset_id}_snapshot.{table_id}'
-                ))
+        expected_calls = [
+            call(
+                table_object,
+                f'{self.client.project}.{self.dataset_id}_snapshot.{table_object.table_id}'
+            ) for table_object in list_tables_results
+        ]
         mock_copy_table.assert_has_calls(expected_calls)
 
     @patch.object(BigQueryClient, 'get_dataset')

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -395,7 +395,8 @@ class CreateTierTest(unittest.TestCase):
                                                 self.release_tag)
 
         self.mock_bq_client.copy_dataset.assert_called_with(
-            self.input_dataset, datasets[consts.STAGING])
+            f'{self.project_id}.{self.input_dataset}',
+            f'{self.project_id}.{datasets[consts.STAGING]}')
 
         mock_add_kwargs.assert_called_with(controlled_tier_cleaning_args,
                                            kwargs)

--- a/tests/unit_tests/data_steward/tools/create_tier_test.py
+++ b/tests/unit_tests/data_steward/tools/create_tier_test.py
@@ -275,7 +275,7 @@ class CreateTierTest(unittest.TestCase):
                           self.tier, self.release_tag,
                           incorrect_deid_stage_param)
 
-    def test_create_dataset(self):
+    def test_create_datasets(self):
         # Preconditions
         mocked_labels = [{
             'de-identified': 'true',


### PR DESCRIPTION
This was the branch that updated the `bq.copy_dataset` calls: #1212 