### PR TITLE
[DC-2376] De-duplicate records in _mapping_person_src_hpos

### DIFF
--- a/data_steward/deid/aou.py
+++ b/data_steward/deid/aou.py
@@ -120,7 +120,7 @@ def create_person_id_src_hpo_map(client, input_dataset):
     :param input_dataset:  the input dataset to deid
     """
     map_tablename = "_mapping_person_src_hpos"
-    sql = ("select person_id, src_hpo_id "
+    sql = ("select distinct person_id, src_hpo_id "
            "from {input_dataset}._mapping_{table} "
            "join {input_dataset}.{table} "
            "using ({table}_id) "
@@ -161,7 +161,7 @@ def create_person_id_src_hpo_map(client, input_dataset):
         sql_statement.append(
             sql.format(table=table, input_dataset=input_dataset))
 
-    final_query = ' UNION ALL '.join(sql_statement)
+    final_query = ' UNION '.join(sql_statement)
 
     # create the mapping table
     if map_tablename not in dataset_table_ids:

--- a/data_steward/deid/aou.py
+++ b/data_steward/deid/aou.py
@@ -161,7 +161,7 @@ def create_person_id_src_hpo_map(client, input_dataset):
         sql_statement.append(
             sql.format(table=table, input_dataset=input_dataset))
 
-    final_query = ' UNION '.join(sql_statement)
+    final_query = ' UNION DISTINCT '.join(sql_statement)
 
     # create the mapping table
     if map_tablename not in dataset_table_ids:


### PR DESCRIPTION
The reason why it is safe to de-duplicate `_mapping_person_src_hpos`:
- `_mapping_person_src_hpos` is referenced only here in the whole DEID process -> [link to the code](https://github.com/all-of-us/curation/blob/develop/data_steward/deid/config/ids/config.json#L39)
- In the SQL above, `_mapping_person_src_hpos` is used in a `SELECT DISTINCT` statement. This DISTINCT statement returns the same result with or without `_mapping_person_src_hpos` having duplicates.


Notes:
- `_mapping_person_src_hpos` is created to deid `observation` table -> [link to the code](https://github.com/all-of-us/curation/blob/develop/data_steward/deid/aou.py#L265)
- Also, see the comment in the JIRA ticket for what I did for debugging/testing.