### PR TITLE
[DC-2658] Prep the RDR export

### DIFF
--- a/data_steward/resource_files/schemas/rdr/cdr_etl_run_code_info.json
+++ b/data_steward/resource_files/schemas/rdr/cdr_etl_run_code_info.json
@@ -1,18 +1,26 @@
 [
   {
     "type": "string",
-    "name": "codeType"
+    "name": "codeType",
+    "mode": "nullable",
+    "description": ""
   },
   {
     "type": "integer",
-    "name": "etlRunId"
+    "name": "etlRunId",
+    "mode": "nullable",
+    "description": ""
   },
   {
     "type": "string",
-    "name": "status"
+    "name": "status",
+    "mode": "nullable",
+    "description": ""
   },
   {
     "type": "string",
-    "name": "codeType"
+    "name": "codeType",
+    "mode": "nullable",
+    "description": ""
   }
 ]

--- a/data_steward/resource_files/schemas/rdr/cdr_etl_run_code_info.json
+++ b/data_steward/resource_files/schemas/rdr/cdr_etl_run_code_info.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "string",
+    "name": "codeType"
+  },
+  {
+    "type": "integer",
+    "name": "etlRunId"
+  },
+  {
+    "type": "string",
+    "name": "status"
+  },
+  {
+    "type": "string",
+    "name": "codeType"
+  }
+]

--- a/data_steward/resource_files/schemas/rdr/cdr_etl_run_info.json
+++ b/data_steward/resource_files/schemas/rdr/cdr_etl_run_info.json
@@ -1,22 +1,32 @@
 [
     {
         "type": "integer",
-        "name": "etlRunId"
+        "name": "etlRunId",
+        "mode": "nullable",
+        "description": ""
     },
     {
         "type": "string",
-        "name": "vocabularyPath"
+        "name": "vocabularyPath",
+        "mode": "nullable",
+        "description": ""
     },
     {
         "type": "date",
-        "name": "cutoffDate"
+        "name": "cutoffDate",
+        "mode": "nullable",
+        "description": ""
     },
     {
         "type": "datetime",
-        "name": "startTime"
+        "name": "startTime",
+        "mode": "nullable",
+        "description": ""
     },
     {
         "type": "datetime",
-        "name": "endTime"
+        "name": "endTime",
+        "mode": "nullable",
+        "description": ""
     }
 ]

--- a/data_steward/resource_files/schemas/rdr/cdr_etl_run_info.json
+++ b/data_steward/resource_files/schemas/rdr/cdr_etl_run_info.json
@@ -1,0 +1,22 @@
+[
+    {
+        "type": "integer",
+        "name": "etlRunId"
+    },
+    {
+        "type": "string",
+        "name": "vocabularyPath"
+    },
+    {
+        "type": "date",
+        "name": "cutoffDate"
+    },
+    {
+        "type": "datetime",
+        "name": "startTime"
+    },
+    {
+        "type": "datetime",
+        "name": "endTime"
+    }
+]

--- a/data_steward/resource_files/schemas/rdr/participant_id_mapping.json
+++ b/data_steward/resource_files/schemas/rdr/participant_id_mapping.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "integer",
+        "name": "person_id",
+        "mode": "required",
+        "description": ""
+    },
+    {
+        "type": "string",
+        "name": "id_type",
+        "mode": "required",
+        "description": ""
+    },
+    {
+        "type": "integer",
+        "name": "mapped_value",
+        "mode": "required",
+        "description": ""
+    }
+]

--- a/data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json
+++ b/data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json
@@ -1,0 +1,20 @@
+[
+    {
+        "type": "integer",
+        "name": "questionnaire_response_id",
+        "mode": "nullable",
+        "description": ""
+    },
+    {
+        "type": "string",
+        "name": "type",
+        "mode": "nullable",
+        "description": ""
+    },
+    {
+        "type": "string",
+        "name": "value",
+        "mode": "nullable",
+        "description": ""
+    }
+]


### PR DESCRIPTION
This PR adds four new RDR schemas for the Winter CDR release.

`data_steward/resource_files/schemas/rdr/cdr_etl_run_code_info.json`
`data_steward/resource_files/schemas/rdr/cdr_etl_run_info.json`
`data_steward/resource_files/schemas/rdr/participant_id_mapping.json`
`data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json`