### PR TITLE
[DC-2624] Add `questionnaire_response_additional_info` table schema to rdr schema files

### DIFF
--- a/data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json
+++ b/data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json
@@ -15,6 +15,6 @@
     "type": "string",
     "name": "value",
     "mode": "nullable",
-    "description": "Values in { LANGUAGE: [en, es], NON_PARTICIPANT_AUTHOR_INDICATOR: [CATI]}, CODE: [surveys - 91 listed]"
+    "description": "Values in { LANGUAGE: [en, es], NON_PARTICIPANT_AUTHOR_INDICATOR: [CATI]}, CODE: [survey taken]"
   }
 ]

--- a/data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json
+++ b/data_steward/resource_files/schemas/rdr/questionnaire_response_additional_info.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "integer",
+    "name": "questionnaire_response_id",
+    "mode": "nullable",
+    "description": ""
+  },
+  {
+    "type": "string",
+    "name": "type",
+    "mode": "nullable",
+    "description": "Response type in [NON_PARTICIPANT_AUTHOR_INDICATOR, CODE, LANGUAGE]"
+  },
+  {
+    "type": "string",
+    "name": "value",
+    "mode": "nullable",
+    "description": "Values in { LANGUAGE: [en, es], NON_PARTICIPANT_AUTHOR_INDICATOR: [CATI]}, CODE: [surveys - 91 listed]"
+  }
+]


### PR DESCRIPTION
This adds an additional RDR schema, questionnaire_additional_info