### PR TITLE
[DC-2630] Update truncate_rdr_using_date cleaning rule to include the survey_conduct table

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
@@ -21,14 +21,15 @@ LOGGER = logging.getLogger(__name__)
 
 TRUNCATE_TABLES = [
     common.VISIT_OCCURRENCE, common.OBSERVATION, common.MEASUREMENT,
-    common.PROCEDURE_OCCURRENCE
+    common.PROCEDURE_OCCURRENCE, common.SURVEY_CONDUCT
 ]
 
 TABLES_DATES_FIELDS = {
     common.VISIT_OCCURRENCE: 'visit_start_date',
     common.OBSERVATION: 'observation_date',
     common.MEASUREMENT: 'measurement_date',
-    common.PROCEDURE_OCCURRENCE: 'procedure_date'
+    common.PROCEDURE_OCCURRENCE: 'procedure_date',
+    common.SURVEY_CONDUCT: 'survey_start_date'
 }
 
 # Query to create tables in sandbox with the rows that will be removed per cleaning rule

--- a/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/truncate_rdr_using_date.py
@@ -86,7 +86,7 @@ class TruncateRdrData(BaseCleaningRule):
         desc = (f'All rows of data in the RDR export with dates after '
                 f'{self.cutoff_date} will be truncated.')
 
-        super().__init__(issue_numbers=['DC1009'],
+        super().__init__(issue_numbers=['DC1009', 'DC2630'],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],
                          affected_tables=TRUNCATE_TABLES,


### PR DESCRIPTION
* [DC-2630] Update truncate_rdr_using_date for survey conduct

[DC-2630]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ