### PR TITLE
[DC-2632] Update remove_participant_under_18years cleaning rule to include the survey_conduct table

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/remove_participants_under_18years.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_participants_under_18years.py
@@ -24,7 +24,7 @@ LOGGER = logging.getLogger(__name__)
 
 UNDER18_PARTICIPANTS_LOOKUP_TABLE = '_under18_participants'
 
-AFFECTED_TABLES = [table for table in get_person_id_tables(common.AOU_REQUIRED)]
+AFFECTED_TABLES = [table for table in get_person_id_tables(common.CATI_TABLES)]
 
 PARTICIPANTS_UNDER_18_AT_CONSENT_QUERY = common.JINJA_ENV.from_string("""
   CREATE OR REPLACE TABLE `{{project}}.{{sandbox_dataset}}.{{under18_participant_lookup_table}}` AS (

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_participants_under_18years.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_participants_under_18years.py
@@ -98,7 +98,7 @@ class RemoveParticipantsUnder18Years(BaseCleaningRule):
             'is to be sandboxed and dropped from the CDR.')
 
         super().__init__(
-            issue_numbers=['DC1724', 'DC2260'],
+            issue_numbers=['DC1724', 'DC2260', 'DC2632'],
             description=desc,
             affected_datasets=[cdr_consts.RDR],
             affected_tables=AFFECTED_TABLES,


### PR DESCRIPTION
* [DC-2632] Update remove_participants_under_18years with CATI tables

[DC-2632]: https://precisionmedicineinitiative.atlassian.net/browse/DC-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ