### PR TITLE
[DC-2628] Update generate_ext_tables.py for survey_conduct_ext

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables.py
@@ -23,7 +23,7 @@ import constants.cdr_cleaner.clean_cdr as cdr_consts
 
 LOGGER = logging.getLogger(__name__)
 
-ISSUE_NUMBERS = ['DC-1351', 'DC-1500', 'DC-1640']
+ISSUE_NUMBERS = ['DC-1351', 'DC-1500', 'DC-1640', 'DC-2628']
 EXT_FIELD_TEMPLATE = [{
     "type": "integer",
     "name": "{table}_id",
@@ -104,12 +104,15 @@ class GenerateExtTables(BaseCleaningRule):
 
     def get_table_fields_str(self, table, ext_table_id):
         """
-        Generates fields for ext tables for the provided cdm table in SQL form
+        Generates fields for ext tables for the provided cdm table
 
         :param table: cdm table to generate ext fields for
         :param ext_table_id: cdm table extension name.  used to load schema
             definition if it exists as a json file
-        :return: dict containing ext fields for the cdm table in SQL form
+        :return: tuple that contains the following:
+            first item: Fields for the ext table in str format.
+                        You can use this string for the DDL "CREATE TABLE xyz (_HERE_)"
+            second item: Fields for the ext table in dict format
         """
         table_fields = []
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -118,7 +118,7 @@ class GenerateExtTablesTest(BaseTest.CleaningRulesTestBase):
     def test_generate_ext_tables(self):
         """
         Test that ext tables are created as expected.
-        For survey_conduct_ext, the columns 'language' is NULL at this point.
+        For survey_conduct_ext, the column 'language' is NULL at this point.
         The cleaning rule from DC-2627 populates these columns.
         """
         tables_and_counts = [{

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -58,7 +58,6 @@ class GenerateExtTablesTest(BaseTest.CleaningRulesTestBase):
         # call super to set up the client, create datasets, and create
         # empty test tables
         # NOTE:  does not create empty sandbox tables.
-
         super().setUpClass()
 
     def setUp(self):
@@ -119,7 +118,7 @@ class GenerateExtTablesTest(BaseTest.CleaningRulesTestBase):
     def test_generate_ext_tables(self):
         """
         Test that ext tables are created as expected.
-        For survey_conduct_ext, the columns 'type' and 'value' are NULL at this point.
+        For survey_conduct_ext, the columns 'language' is NULL at this point.
         The cleaning rule from DC-2627 populates these columns.
         """
         tables_and_counts = [{
@@ -149,16 +148,15 @@ class GenerateExtTablesTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 self.survey_conduct_ext,
-            'fields': ['survey_conduct_id', 'src_id', 'type', 'value'],
+            'fields': ['survey_conduct_id', 'src_id', 'language'],
             'loaded_ids': [],
             'tables_created_on_setup': [
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.get_sandbox_tablenames()[0]}'
             ],
             'check_preconditions':
                 False,
-            'cleaned_values': [(41, 'pi/pm', None, None),
-                               (42, 'site yum', None, None),
-                               (43, 'site bar', None, None)]
+            'cleaned_values': [(41, 'pi/pm', None), (42, 'site yum', None),
+                               (43, 'site bar', None)]
         }]
 
         # mock the PIPELINE_TABLES variable so tests on different branches

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -117,6 +117,11 @@ class GenerateExtTablesTest(BaseTest.CleaningRulesTestBase):
         self.load_test_data(queries)
 
     def test_generate_ext_tables(self):
+        """
+        Test that ext tables are created as expected.
+        For survey_conduct_ext, the columns 'type' and 'value' are NULL at this point.
+        The cleaning rule from DC-2627 populates these columns.
+        """
         tables_and_counts = [{
             'fq_table_name':
                 self.obs_ext,
@@ -144,15 +149,16 @@ class GenerateExtTablesTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 self.survey_conduct_ext,
-            'fields': ['survey_conduct_id', 'src_id'],
+            'fields': ['survey_conduct_id', 'src_id', 'type', 'value'],
             'loaded_ids': [],
             'tables_created_on_setup': [
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.get_sandbox_tablenames()[0]}'
             ],
             'check_preconditions':
                 False,
-            'cleaned_values': [(41, 'pi/pm'), (42, 'site yum'),
-                               (43, 'site bar')]
+            'cleaned_values': [(41, 'pi/pm', None, None),
+                               (42, 'site yum', None, None),
+                               (43, 'site bar', None, None)]
         }]
 
         # mock the PIPELINE_TABLES variable so tests on different branches

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -67,6 +67,8 @@ class GenerateExtTablesTest(unittest.TestCase):
                 "The provenance of the data associated with the foo_id."
         }]
 
+        # Excluding PERSON, DEATH, and FACT_RELATIONSHIP beacuse they do not
+        # have mapping tables in the combined dataset.
         mapped_table_names = [
             cdm_table for cdm_table in common.CATI_TABLES if cdm_table not in
             [common.PERSON, common.DEATH, common.FACT_RELATIONSHIP]

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -68,12 +68,12 @@ class GenerateExtTablesTest(unittest.TestCase):
         }]
 
         mapped_table_names = [
-            cdm_table for cdm_table in common.AOU_REQUIRED if cdm_table not in
+            cdm_table for cdm_table in common.CATI_TABLES if cdm_table not in
             [common.PERSON, common.DEATH, common.FACT_RELATIONSHIP]
         ]
 
         mapping_table_names = [
-            gen_ext.MAPPING_PREFIX + cdm_table
+            f"{gen_ext.MAPPING_PREFIX}{cdm_table}"
             for cdm_table in mapped_table_names
         ]
 
@@ -112,7 +112,7 @@ class GenerateExtTablesTest(unittest.TestCase):
 
         fields_str = ','.join(fields_list)
         table = 'foo'
-        ext_table = f'foo{gen_ext.EXT_TABLE_SUFFIX}'
+        ext_table = f'{table}{gen_ext.EXT_TABLE_SUFFIX}'
 
         # test
         with self.assertLogs(level='INFO') as cm:
@@ -129,10 +129,10 @@ class GenerateExtTablesTest(unittest.TestCase):
         Get table fields when a schema file is defined.
         """
         # pre-conditions
-        table = common.OBSERVATION
-        ext_table = common.OBSERVATION + gen_ext.EXT_TABLE_SUFFIX
+        table = common.SURVEY_CONDUCT
+        ext_table = f"{table}{gen_ext.EXT_TABLE_SUFFIX}"
         table_path = os.path.join(fields_path, 'extension_tables',
-                                  ext_table + '.json')
+                                  f"{ext_table}.json")
         with open(table_path, 'r') as schema:
             expected = json.load(schema)
 
@@ -162,9 +162,9 @@ class GenerateExtTablesTest(unittest.TestCase):
         mock_client = mock.Mock()
         mock_client.list_tables.return_value = self.mapping_table_objs
         expected = []
-        for cdm_table in common.AOU_REQUIRED:
+        for cdm_table in common.CATI_TABLES:
             ext_table_fields_str, _ = self.rule_instance.get_table_fields_str(
-                cdm_table, (cdm_table + gen_ext.EXT_TABLE_SUFFIX))
+                cdm_table, f"{cdm_table}{gen_ext.EXT_TABLE_SUFFIX}")
 
             additional_fields = _get_field_names(
                 f'{cdm_table}{common.EXT_SUFFIX}')

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -75,7 +75,7 @@ class GenerateExtTablesTest(unittest.TestCase):
         ]
 
         mapping_table_names = [
-            f"{gen_ext.MAPPING_PREFIX}{cdm_table}"
+            f"{common.MAPPING_PREFIX}{cdm_table}"
             for cdm_table in mapped_table_names
         ]
 
@@ -114,7 +114,7 @@ class GenerateExtTablesTest(unittest.TestCase):
 
         fields_str = ','.join(fields_list)
         table = 'foo'
-        ext_table = f'{table}{gen_ext.EXT_TABLE_SUFFIX}'
+        ext_table = f'{table}{common.EXT_SUFFIX}'
 
         # test
         with self.assertLogs(level='INFO') as cm:
@@ -132,7 +132,7 @@ class GenerateExtTablesTest(unittest.TestCase):
         """
         # pre-conditions
         table = common.SURVEY_CONDUCT
-        ext_table = f"{table}{gen_ext.EXT_TABLE_SUFFIX}"
+        ext_table = f"{table}{common.EXT_SUFFIX}"
         table_path = os.path.join(fields_path, 'extension_tables',
                                   f"{ext_table}.json")
         with open(table_path, 'r') as schema:
@@ -166,7 +166,7 @@ class GenerateExtTablesTest(unittest.TestCase):
         expected = []
         for cdm_table in common.CATI_TABLES:
             ext_table_fields_str, _ = self.rule_instance.get_table_fields_str(
-                cdm_table, f"{cdm_table}{gen_ext.EXT_TABLE_SUFFIX}")
+                cdm_table, f"{cdm_table}{common.EXT_SUFFIX}")
 
             additional_fields = _get_field_names(
                 f'{cdm_table}{common.EXT_SUFFIX}')
@@ -185,15 +185,15 @@ class GenerateExtTablesTest(unittest.TestCase):
                 query[cdr_consts.QUERY] = gen_ext.REPLACE_SRC_QUERY.render(
                     project_id=self.project_id,
                     dataset_id=self.dataset_id,
-                    ext_table=cdm_table + gen_ext.EXT_TABLE_SUFFIX,
+                    ext_table=f"{cdm_table}{common.EXT_SUFFIX}",
                     ext_table_fields=ext_table_fields_str,
                     cdm_table_id=cdm_table,
                     additional_fields=additional_fields,
                     mapping_fields=mapping_fields,
                     mapping_dataset_id=self.mapping_dataset_id,
-                    mapping_table_id=gen_ext.MAPPING_PREFIX + cdm_table,
+                    mapping_table_id=f"{common.MAPPING_PREFIX}{cdm_table}",
                     shared_sandbox_id=self.sandbox_dataset_id,
-                    site_maskings_table_id=gen_ext.SITE_TABLE_ID)
+                    site_maskings_table_id=common.SITE_MASKING_TABLE_ID)
                 expected.append(query)
 
         # Test


### PR DESCRIPTION
**1. `data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables.py`:**
- No logic update is necessary because it gets the list of mapping tables in the dataset and creates ext tables for them. -> As long as `_mapping_survey_conduct` exists, `survey_conduct_ext` will be created with this CR.
- Updated the docstring for `get_table_fields_str()` so it better represents what it does.
- Removed the local constants and use the constants from `common` instead.


**2. `tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py` and
3. `tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py`:**
- Added test cases for `survery_conduct` to make sure this CR works with it as expected.