### PR TITLE
[DC-2627] Create a cleaning rule that will populate the `survey_conduct_ext` table

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -21,6 +21,7 @@ from cdr_cleaner.cleaning_rules.drop_participants_without_any_basics import Drop
 import cdr_cleaner.cleaning_rules.drug_refills_days_supply as drug_refills_supply
 from cdr_cleaner.cleaning_rules.maps_to_value_ppi_vocab_update import MapsToValuePpiVocabUpdate
 import cdr_cleaner.cleaning_rules.populate_route_ids as populate_routes
+from cdr_cleaner.cleaning_rules.populate_survey_conduct_ext import PopulateSurveyConductExt
 import \
     cdr_cleaner.cleaning_rules.remove_invalid_procedure_source_records as invalid_procedure_source
 from cdr_cleaner.cleaning_rules.remove_non_matching_participant import RemoveNonMatchingParticipant
@@ -248,6 +249,7 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     (GenerateExtTables,),
     (COPESurveyVersionTask,
     ),  # Should run after GenerateExtTables and before CleanMappingExtTables
+    (PopulateSurveyConductExt,),
 
     # Data generalizations
     ####################################
@@ -314,6 +316,7 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (GenerateExtTables,),
     (COPESurveyVersionTask,
     ),  # Should run after GenerateExtTables and before CleanMappingExtTables
+    (PopulateSurveyConductExt,),
     (CancerConceptSuppression,),  # Should run after any data remapping rules
     (SectionParticipationConceptSuppression,),
     (StringFieldsSuppression,),

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -22,14 +22,16 @@ AS
     SELECT sce.* FROM `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
     JOIN `{{project_id}}.{{dataset_id}}.questionnaire_response_additional_info` AS qrai
     ON sce.survey_conduct_id = qrai.questionnaire_response_id
-    WHERE sce.type IS NULL OR sce.value IS NULL OR sce.type != qrai.type OR sce.value != qrai.value
+    WHERE (sce.language IS NULL OR sce.language != qrai.value)
+    AND qrai.type = 'LANGUAGE'
 """)
 
 UPDATE_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
-SET type = qrai.type, value = qrai.value
+SET language = qrai.value
 FROM `{{project_id}}.{{dataset_id}}.questionnaire_response_additional_info` AS qrai
 WHERE sce.survey_conduct_id = qrai.questionnaire_response_id
+AND qrai.type = 'LANGUAGE'
 """)
 
 

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -23,7 +23,7 @@ AS
     JOIN `{{project_id}}.{{dataset_id}}.questionnaire_response_additional_info` AS qrai
     ON sce.survey_conduct_id = qrai.questionnaire_response_id
     WHERE (sce.language IS NULL OR sce.language != qrai.value)
-    AND qrai.type = 'LANGUAGE'
+    AND UPPER(qrai.type) = 'LANGUAGE'
 """)
 
 UPDATE_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
@@ -31,7 +31,7 @@ UPDATE `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
 SET language = qrai.value
 FROM `{{project_id}}.{{dataset_id}}.questionnaire_response_additional_info` AS qrai
 WHERE sce.survey_conduct_id = qrai.questionnaire_response_id
-AND qrai.type = 'LANGUAGE'
+AND UPPER(qrai.type) = 'LANGUAGE'
 """)
 
 

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -1,5 +1,5 @@
 """
-Populates survey_conduct_ext table with the language and versioning information
+Populates survey_conduct_ext table with the language information
 as provided in the questionnaire_response_additional_info table.
 
 Original issue: DC-2627
@@ -49,8 +49,8 @@ class PopulateSurveyConductExt(BaseCleaningRule):
         Initialize the class with proper information.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
-        desc = ('Populates survey_conduct_ext table with the language and '
-                'versioning information as provided in the '
+        desc = ('Populates survey_conduct_ext table with the language '
+                'information as provided in the '
                 'questionnaire_response_additional_info table.')
 
         super().__init__(issue_numbers=['DC2627'],
@@ -68,8 +68,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
 
     def get_query_specs(self):
         """
-        Runs the query which adds skipped questions to observation table.
-        No sandbox table since this is only insert.
+        Return a list of dictionary query specifications.
         """
         sandbox_query = SANDBOX_SURVEY_CONDUCT_EXT_QUERY.render(
             project_id=self.project_id,

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -1,0 +1,127 @@
+"""
+Populates survey_conduct_ext table with the language and versioning information
+as provided in the questionnaire_response_additional_info table.
+
+Original issue: DC-2627
+"""
+# Python imports
+import logging
+
+# Project imports
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from cdr_cleaner.cleaning_rules.generate_ext_tables import GenerateExtTables
+from cdr_cleaner.manual_cleaning_rules.survey_version_info import COPESurveyVersionTask
+from common import EXT_SUFFIX, JINJA_ENV, SURVEY_CONDUCT
+
+LOGGER = logging.getLogger(__name__)
+
+SANDBOX_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
+CREATE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}`
+AS
+    SELECT sce.* FROM `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
+    JOIN `{{project_id}}.{{dataset_id}}.questionnaire_response_additional_info` AS qrai
+    ON sce.survey_conduct_id = qrai.questionnaire_response_id
+    WHERE sce.type IS NULL OR sce.value IS NULL OR sce.type != qrai.type OR sce.value != qrai.value
+""")
+
+UPDATE_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
+UPDATE `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
+SET type = qrai.type, value = qrai.value
+FROM `{{project_id}}.{{dataset_id}}.questionnaire_response_additional_info` AS qrai
+WHERE sce.survey_conduct_id = qrai.questionnaire_response_id
+""")
+
+
+class PopulateSurveyConductExt(BaseCleaningRule):
+    """
+    Populates survey_conduct_ext table with the language and versioning information.
+    """
+
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 table_namer=None):
+        """
+        Initialize the class with proper information.
+        DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
+        """
+        desc = ('Populates survey_conduct_ext table with the language and '
+                'versioning information as provided in the '
+                'questionnaire_response_additional_info table.')
+
+        super().__init__(issue_numbers=['DC2627'],
+                         description=desc,
+                         affected_datasets=[
+                             cdr_consts.REGISTERED_TIER_DEID,
+                             cdr_consts.CONTROLLED_TIER_DEID
+                         ],
+                         affected_tables=[f"{SURVEY_CONDUCT}{EXT_SUFFIX}"],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         depends_on=[GenerateExtTables, COPESurveyVersionTask],
+                         table_namer=table_namer)
+
+    def get_query_specs(self):
+        """
+        Runs the query which adds skipped questions to observation table.
+        No sandbox table since this is only insert.
+        """
+        sandbox_query = SANDBOX_SURVEY_CONDUCT_EXT_QUERY.render(
+            project_id=self.project_id,
+            dataset_id=self.dataset_id,
+            sandbox_dataset_id=self.sandbox_dataset_id,
+            sandbox_table=self.sandbox_table_for(
+                f"{SURVEY_CONDUCT}{EXT_SUFFIX}"))
+
+        insert_query = UPDATE_SURVEY_CONDUCT_EXT_QUERY.render(
+            project_id=self.project_id, dataset_id=self.dataset_id)
+
+        sandbox_query_dict = {cdr_consts.QUERY: sandbox_query}
+        insert_query_dict = {cdr_consts.QUERY: insert_query}
+
+        return [sandbox_query_dict, insert_query_dict]
+
+    def setup_rule(self, client):
+        """
+        Function to run any data upload options before executing a query.
+        """
+        pass
+
+    def setup_validation(self, client):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def get_sandbox_tablenames(self):
+        return [self.sandbox_table_for(table) for table in self.affected_tables]
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.parse_args()
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(ARGS.project_id,
+                                                 ARGS.dataset_id,
+                                                 ARGS.sandbox_dataset_id,
+                                                 [(PopulateSurveyConductExt,)])
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(PopulateSurveyConductExt,)])

--- a/data_steward/common.py
+++ b/data_steward/common.py
@@ -50,6 +50,7 @@ AOU_REQUIRED = [
 # CATI Tables
 SURVEY_CONDUCT = 'survey_conduct'
 CATI_TABLES = AOU_REQUIRED + [SURVEY_CONDUCT]
+QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = 'questionnaire_response_additional_info'
 
 # Standardized clinical data tables in OMOP. All should contain a person_id column. See
 # https://github.com/OHDSI/CommonDataModel/wiki/Standardized-Clinical-Data-Tables

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -46,18 +46,13 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
 
         super().initialize_class_vars()
 
-        # set the test project identifier
-        project_id = os.environ.get(PROJECT_ID)
-        cls.project_id = project_id
-
-        # set the expected test datasets
-        dataset_id = os.environ.get('RDR_DATASET_ID')
-        cls.dataset_id = dataset_id
-        sandbox_id = dataset_id + '_sandbox'
+        cls.project_id = os.environ.get(PROJECT_ID)
+        cls.dataset_id = os.environ.get('RDR_DATASET_ID')
+        sandbox_id = f"{cls.dataset_id}_sandbox"
         cls.sandbox_id = sandbox_id
 
-        cls.rule_instance = PopulateSurveyConductExt(project_id, dataset_id,
-                                                     sandbox_id)
+        cls.rule_instance = PopulateSurveyConductExt(cls.project_id,
+                                                     cls.dataset_id, sandbox_id)
 
         sb_table_name = cls.rule_instance.sandbox_table_for(
             f"{SURVEY_CONDUCT}{EXT_SUFFIX}")
@@ -67,8 +62,8 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
         ]
 
         cls.fq_table_names = [
-            f'{project_id}.{dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
-            f'{project_id}.{dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
+            f'{cls.project_id}.{cls.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
+            f'{cls.project_id}.{cls.dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
         ]
 
         super().setUpClass()

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -1,0 +1,109 @@
+"""
+Integration test for PopulateSurveyConductExt.
+"""
+
+# Python Imports
+import os
+
+# Third party imports
+
+# Project imports
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.populate_survey_conduct_ext import PopulateSurveyConductExt
+from common import EXT_SUFFIX, JINJA_ENV, QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO, SURVEY_CONDUCT
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
+    INSERT INTO `{{project}}.{{dataset}}.survey_conduct_ext` 
+        (survey_conduct_id, src_id, type, value)
+    VALUES
+        (11, 'pi/pm', NULL, NULL),
+        (12, 'site foo', NULL, NULL),
+        (13, 'site foo', NULL, NULL),
+        (14, 'site bar', NULL, NULL)
+""")
+
+INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
+    INSERT INTO `{{project}}.{{dataset}}.questionnaire_response_additional_info` 
+        (questionnaire_response_id, type, value)
+    VALUES
+        (11, 'LANGUAGE', 'en'),
+        (12, 'LANGUAGE', 'es'),
+        (13, 'NON_PARTICIPANT_AUTHOR_INDICATOR', 'CATI'),
+        (14, 'CODE', 'TheBasics')
+""")
+
+
+class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        # set the test project identifier
+        project_id = os.environ.get(PROJECT_ID)
+        cls.project_id = project_id
+
+        # set the expected test datasets
+        dataset_id = os.environ.get('RDR_DATASET_ID')
+        cls.dataset_id = dataset_id
+        sandbox_id = dataset_id + '_sandbox'
+        cls.sandbox_id = sandbox_id
+
+        cls.rule_instance = PopulateSurveyConductExt(project_id, dataset_id,
+                                                     sandbox_id)
+
+        sb_table_name = cls.rule_instance.sandbox_table_for(
+            f"{SURVEY_CONDUCT}{EXT_SUFFIX}")
+
+        cls.fq_sandbox_table_names = [
+            f'{cls.project_id}.{cls.sandbox_id}.{sb_table_name}'
+        ]
+
+        cls.fq_table_names = [
+            f'{project_id}.{dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
+            f'{project_id}.{dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
+        ]
+
+        super().setUpClass()
+
+    def setUp(self):
+        super().setUp()
+
+        insert_survey_conduct_ext = INSERT_SURVEY_CONDUCT_EXT.render(
+            project=self.project_id, dataset=self.dataset_id)
+        insert_questionnaire_response_additional_info = INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO.render(
+            project=self.project_id, dataset=self.dataset_id)
+
+        queries = [
+            insert_survey_conduct_ext,
+            insert_questionnaire_response_additional_info
+        ]
+        self.load_test_data(queries)
+
+    def test_populate_survey_conduct_ext(self):
+        """
+        Tests that the queries perform as designed.
+        """
+
+        tables_and_counts = [{
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
+            'fields': ['survey_conduct_id', 'src_id', 'type', 'value'],
+            'loaded_ids': [11, 12, 13, 14],
+            'sandboxed_ids': [11, 12, 13, 14],
+            'cleaned_values': [
+                (11, 'pi/pm', 'LANGUAGE', 'en'),
+                (12, 'site foo', 'LANGUAGE', 'es'),
+                (13, 'site foo', 'NON_PARTICIPANT_AUTHOR_INDICATOR', 'CATI'),
+                (14, 'site bar', 'CODE', 'TheBasics'),
+            ]
+        }]
+
+        self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -15,12 +15,12 @@ from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_te
 
 INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
     INSERT INTO `{{project}}.{{dataset}}.survey_conduct_ext` 
-        (survey_conduct_id, src_id, type, value)
+        (survey_conduct_id, src_id, language)
     VALUES
-        (11, 'pi/pm', NULL, NULL),
-        (12, 'site foo', NULL, NULL),
-        (13, 'site foo', NULL, NULL),
-        (14, 'site bar', NULL, NULL)
+        (11, 'pi/pm', NULL),
+        (12, 'site foo', NULL),
+        (13, 'site foo', NULL),
+        (14, 'site bar', NULL)
 """)
 
 INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
@@ -28,6 +28,8 @@ INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
         (questionnaire_response_id, type, value)
     VALUES
         (11, 'LANGUAGE', 'en'),
+        (11, 'NON_PARTICIPANT_AUTHOR_INDICATOR', 'CATI'),
+        (11, 'CODE', 'TheBasics'),
         (12, 'LANGUAGE', 'es'),
         (13, 'NON_PARTICIPANT_AUTHOR_INDICATOR', 'CATI'),
         (14, 'CODE', 'TheBasics')
@@ -95,14 +97,14 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
             'fq_sandbox_table_name':
                 self.fq_sandbox_table_names[0],
-            'fields': ['survey_conduct_id', 'src_id', 'type', 'value'],
+            'fields': ['survey_conduct_id', 'src_id', 'language'],
             'loaded_ids': [11, 12, 13, 14],
-            'sandboxed_ids': [11, 12, 13, 14],
+            'sandboxed_ids': [11, 12],
             'cleaned_values': [
-                (11, 'pi/pm', 'LANGUAGE', 'en'),
-                (12, 'site foo', 'LANGUAGE', 'es'),
-                (13, 'site foo', 'NON_PARTICIPANT_AUTHOR_INDICATOR', 'CATI'),
-                (14, 'site bar', 'CODE', 'TheBasics'),
+                (11, 'pi/pm', 'en'),
+                (12, 'site foo', 'es'),
+                (13, 'site foo', None),
+                (14, 'site bar', None),
             ]
         }]
 


### PR DESCRIPTION
- See the comment in the JIRA ticket for DC-2627. This new cleaning rule assumes `survey_conduct_ext` and `questionnaire_response_additional_info` can be joined on `survey_conduct_id = questionnaire_response_id`.