### PR TITLE
[DC-2625] remove type and name fields, add language field

### DIFF
--- a/data_steward/resource_files/schemas/extension_tables/survey_conduct_ext.json
+++ b/data_steward/resource_files/schemas/extension_tables/survey_conduct_ext.json
@@ -12,15 +12,9 @@
         "description": "The provenance of the data associated with the survey_conduct_id."
     },
     {
-        "type": "string",
-        "name": "type",
+        "type": "",
+        "name": "language",
         "mode": "nullable",
-        "description": "Response type relating to the survey_conduct_id.  Should be one of [NON_PARTICIPANT_AUTHOR_INDICATOR, LANGUAGE]."
-    },
-    {
-        "type": "string",
-        "name": "value",
-        "mode": "nullable",
-        "description": "Response value associated with survey_conduct_id and type.  If type is LANGUAGE, should be one of [en, es].  If type is NON_PARTICIPANT_AUTHOR_INDICATOR, should be [CATI]."
+        "description": ""
     }
 ]


### PR DESCRIPTION
@molly-giddings , This PR includes the changes requested for the `conduct_survey_ext` table.  It removed `name` and `value` fields, and added `language` of type string.