### PR TITLE
[DC-2637] Update questionnaire_response_id_map cleaning rule to include the survey_conduct table

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
@@ -108,7 +108,7 @@ class QRIDtoRID(BaseCleaningRule):
     def get_query_specs(self, *args, **keyword_args):
         """
         Return a list of dictionary query specifications.
-        
+
         :return:  A list of dictionaries.  Each dictionary contains a
             single query and a specification for how to execute that query.
             The specifications are optional but the query is required.

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
@@ -1,11 +1,21 @@
 """
-Maps questionnaire_response_ids from the observation table to the research_response_id in the
+Maps questionnaire_response_id to research_response_id.
+Questionnaire_response_id exists in the following two tables:
+    1. observation table, as column questionnaire_response_id
+    2. survey_conduct table, as column survey_conduct_id
+
+The mapping for questionnaire_response_id and research_response_id is in the 
 _deid_questionnaire_response_map lookup table.
 
-Original Issue: DC-1347, DC-518, DC-2065
+If no mapping is found for a survey_conduct_id in the mapping table, the row
+will be sandboxed and deleted from survey_conduct table, as survey_conduct_id
+is the primary key for survey_conduct table and it cannot be mapped to None.
 
-The purpose of this cleaning rule is to use the questionnaire mapping lookup table to remap the questionnaire_response_id 
-in the observation table to the randomly generated research_response_id in the _deid_questionnaire_response_map table.
+Original Issue: DC-1347, DC-518, DC-2065, DC-2637
+
+The purpose of this cleaning rule is to use the questionnaire mapping lookup 
+table to remap the questionnaire_response_id to the randomly generated 
+research_response_id in the _deid_questionnaire_response_map table.
 """
 
 # Python imports
@@ -13,35 +23,50 @@ import logging
 
 # Project imports
 from utils import pipeline_logging
-from common import OBSERVATION, DEID_QUESTIONNAIRE_RESPONSE_MAP, JINJA_ENV
+from common import DEID_QUESTIONNAIRE_RESPONSE_MAP, JINJA_ENV, OBSERVATION, SURVEY_CONDUCT
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 
 LOGGER = logging.getLogger(__name__)
 
-ISSUE_NUMBERS = ['DC1347', 'DC518', 'DC-2065']
+ISSUE_NUMBERS = ['DC1347', 'DC518', 'DC2065', 'DC2637']
 
-# Map the research_response_id from _deid_questionnaire_response_map lookup table to the questionnaire_response_id in
-# the observation table
+SANDBOX_SC_QUERY = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}` as (
+    SELECT *
+    FROM `{{project_id}}.{{dataset_id}}.survey_conduct`
+    WHERE survey_conduct_id NOT IN (
+        SELECT questionnaire_response_id 
+        FROM `{{project_id}}.{{deid_questionnaire_response_map_dataset_id}}.{{deid_questionnaire_response_map}}`
+    ))
+""")
+
+DELETE_SC_QUERY = JINJA_ENV.from_string("""
+DELETE FROM `{{project_id}}.{{dataset_id}}.survey_conduct`
+WHERE survey_conduct_id IN (
+    SELECT survey_conduct_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}`
+)
+""")
+
 QRID_RID_MAPPING_QUERY = JINJA_ENV.from_string("""
-UPDATE `{{project_id}}.{{dataset_id}}.observation` t
-SET t.questionnaire_response_id = d.research_response_id
+UPDATE `{{project_id}}.{{dataset_id}}.{{table}}` t
+SET t.{{qrid_column}} = d.research_response_id
 FROM (
     SELECT
-        o.* EXCEPT (questionnaire_response_id),
-        m.research_response_id
-    FROM `{{project_id}}.{{dataset_id}}.observation` o
+        o.*, m.research_response_id
+    FROM `{{project_id}}.{{dataset_id}}.{{table}}` o
     LEFT JOIN `{{project_id}}.{{deid_questionnaire_response_map_dataset_id}}.{{deid_questionnaire_response_map}}` m
-    ON o.questionnaire_response_id = m.questionnaire_response_id
+    ON o.{{qrid_column}} = m.questionnaire_response_id
     ) d
-WHERE t.observation_id = d.observation_id
+WHERE t.{{table}}_id = d.{{table}}_id
 """)
 
 
 class QRIDtoRID(BaseCleaningRule):
     """
-    Remap the QID (questionnaire_response_id) from the
-    observation table to the RID (research_response_id) found in that deid questionnaire response mapping lookup table
+    Remap the QRID (questionnaire_response_id/survey_conduct_id) to the RID 
+    (research_response_id) using mapping lookup table.
+    Sandbox and delete survey_conduct entries that cannot be mapped.
     """
 
     def __init__(self,
@@ -57,9 +82,10 @@ class QRIDtoRID(BaseCleaningRule):
         tickets may affect this SQL, append them to the list of Jira Issues.
         DO NOT REMOVE ORIGINAL JIRA ISSUE NUMBERS!
         """
-        desc = f'Remap the QID (questionnaire_response_id) from the observation table to the ' \
-               f'RID (research_response_id) found in ' \
-               f'the deid questionnaire response mapping lookup table.'
+        desc = (
+            'Remap the QID (questionnaire_response_id for observation and '
+            'survey_conduct_id for survey_conduct) to the RID (research_response_id) '
+            'found in the deid questionnaire response mapping lookup table.')
 
         if not deid_questionnaire_response_map_dataset:
             raise TypeError(
@@ -73,7 +99,7 @@ class QRIDtoRID(BaseCleaningRule):
                              cdr_consts.CONTROLLED_TIER_DEID,
                              cdr_consts.REGISTERED_TIER_DEID
                          ],
-                         affected_tables=OBSERVATION,
+                         affected_tables=[OBSERVATION, SURVEY_CONDUCT],
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id,
@@ -82,24 +108,64 @@ class QRIDtoRID(BaseCleaningRule):
     def get_query_specs(self, *args, **keyword_args):
         """
         Return a list of dictionary query specifications.
-
+        
         :return:  A list of dictionaries.  Each dictionary contains a
             single query and a specification for how to execute that query.
             The specifications are optional but the query is required.
         """
 
-        mapping_query = {
+        sandbox_query = {
             cdr_consts.QUERY:
-                QRID_RID_MAPPING_QUERY.render(
+                SANDBOX_SC_QUERY.render(
                     project_id=self.project_id,
                     dataset_id=self.dataset_id,
                     deid_questionnaire_response_map=
                     DEID_QUESTIONNAIRE_RESPONSE_MAP,
                     deid_questionnaire_response_map_dataset_id=self.
-                    deid_questionnaire_response_map_dataset)
+                    deid_questionnaire_response_map_dataset,
+                    sandbox_dataset_id=self.sandbox_dataset_id,
+                    sandbox_table=self.sandbox_table_for(SURVEY_CONDUCT))
         }
 
-        return [mapping_query]
+        delete_query = {
+            cdr_consts.QUERY:
+                DELETE_SC_QUERY.render(
+                    project_id=self.project_id,
+                    dataset_id=self.dataset_id,
+                    sandbox_dataset_id=self.sandbox_dataset_id,
+                    sandbox_table=self.sandbox_table_for(SURVEY_CONDUCT))
+        }
+
+        table_qrid_mappings = [
+            {
+                "table": OBSERVATION,
+                "qrid_column": "questionnaire_response_id"
+            },
+            {
+                "table": SURVEY_CONDUCT,
+                "qrid_column": "survey_conduct_id"
+            },
+        ]
+
+        mapping_queries = []
+        for table_qrid_mapping in table_qrid_mappings:
+
+            mapping_query = {
+                cdr_consts.QUERY:
+                    QRID_RID_MAPPING_QUERY.render(
+                        project_id=self.project_id,
+                        dataset_id=self.dataset_id,
+                        table=table_qrid_mapping["table"],
+                        qrid_column=table_qrid_mapping["qrid_column"],
+                        deid_questionnaire_response_map=
+                        DEID_QUESTIONNAIRE_RESPONSE_MAP,
+                        deid_questionnaire_response_map_dataset_id=self.
+                        deid_questionnaire_response_map_dataset)
+            }
+
+            mapping_queries.append(mapping_query)
+
+        return [sandbox_query] + [delete_query] + mapping_queries
 
     def setup_rule(self, client, *args, **keyword_args):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
@@ -1,22 +1,17 @@
 """
 Integration test for create_deid_questionnaire_response_map module
-
-None
-
-Original Issue: DC2065
 """
 
 # Python Imports
 import os
 
 # Third party imports
-from dateutil import parser
 
 # Project imports
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.deid.questionnaire_response_id_map import QRIDtoRID
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
-from common import DEID_QUESTIONNAIRE_RESPONSE_MAP, OBSERVATION
+from common import DEID_QUESTIONNAIRE_RESPONSE_MAP, OBSERVATION, SURVEY_CONDUCT
 
 
 class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
@@ -48,14 +43,16 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
 
         cls.fq_table_names = [
             f'{project_id}.{dataset_id}.{OBSERVATION}',
+            f'{project_id}.{dataset_id}.{SURVEY_CONDUCT}',
             f'{project_id}.{dataset_id}.{DEID_QUESTIONNAIRE_RESPONSE_MAP}'
         ]
 
-        cls.kwargs['deid_questionnaire_response_map_dataset'] = dataset_id
+        sb_table_name = cls.rule_instance.sandbox_table_for(SURVEY_CONDUCT)
+        cls.fq_sandbox_table_names = [
+            f'{project_id}.{cls.sandbox_id}.{sb_table_name}'
+        ]
 
-        # cls.fq_sandbox_table_names.append(
-        #     f'{cls.project_id}.{cls.sandbox_id}.{DEID_QUESTIONNAIRE_RESPONSE_MAP}'
-        # )
+        cls.kwargs['deid_questionnaire_response_map_dataset'] = dataset_id
 
         # call super to set up the client, create datasets, and create
         # empty test tables
@@ -66,8 +63,6 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         fq_dataset_name = self.fq_table_names[0].split('.')
         self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
 
-        self.date = parser.parse('2020-05-05').date()
-
         super().setUp()
 
     def test_qrid_to_rid_cleaning(self):
@@ -75,7 +70,7 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         Tests that the specifications perform as designed.
 
         Validates pre conditions, tests execution, and post conditions based on the load
-        statements and the tables_and_counts variable.        
+        statements and the tables_and_counts variable.
         """
 
         create_observations_query = self.jinja_env.from_string("""
@@ -91,6 +86,19 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
                 (6, 6, 43529626, date('2020-05-05'), 1, 99999)
             """).render(fq_dataset_name=self.fq_dataset_name)
 
+        create_survey_conduct_query = self.jinja_env.from_string("""
+            INSERT INTO `{{fq_dataset_name}}.survey_conduct`
+                (survey_conduct_id, person_id, survey_concept_id, survey_end_datetime, 
+                assisted_concept_id, respondent_type_concept_id, timing_concept_id,
+                collection_method_concept_id, survey_source_concept_id,
+                validated_survey_concept_id)
+            VALUES
+                (1, 1, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (2, 2, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (3, 3, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (4, 4, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0)
+            """).render(fq_dataset_name=self.fq_dataset_name)
+
         create_mappings_query = self.jinja_env.from_string("""
             INSERT INTO `{{fq_dataset_name}}.{{deid_questionnaire_response_map}}`
                 (questionnaire_response_id, research_response_id)
@@ -102,7 +110,10 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             fq_dataset_name=self.fq_dataset_name,
             deid_questionnaire_response_map=DEID_QUESTIONNAIRE_RESPONSE_MAP)
 
-        queries = [create_observations_query, create_mappings_query]
+        queries = [
+            create_observations_query, create_survey_conduct_query,
+            create_mappings_query
+        ]
 
         self.load_test_data(queries)
 
@@ -114,16 +125,17 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2, 3, 4, 5, 6],
             'sandboxed_ids': [],
             'fields': [
-                'observation_id', 'person_id', 'observation_concept_id',
-                'observation_date', 'observation_type_concept_id',
-                'questionnaire_response_id'
+                'observation_id', 'person_id', 'questionnaire_response_id'
             ],
-            'cleaned_values': [(1, 1, 43529626, self.date, 1, 5000),
-                               (2, 2, 43529099, self.date, 2, 5000),
-                               (3, 3, 43529102, self.date, 3, 8005),
-                               (4, 4, 43529627, self.date, 4, 8005),
-                               (5, 5, 43529625, self.date, 5, 9000),
-                               (6, 6, 43529626, self.date, 1, None)]
+            'cleaned_values': [(1, 1, 5000), (2, 2, 5000), (3, 3, 8005),
+                               (4, 4, 8005), (5, 5, 9000), (6, 6, None)]
+        }, {
+            'fq_table_name': f'{self.fq_dataset_name}.{SURVEY_CONDUCT}',
+            'fq_sandbox_table_name': self.fq_sandbox_table_names[0],
+            'loaded_ids': [1, 2, 3, 4],
+            'sandboxed_ids': [4],
+            'fields': ['survey_conduct_id', 'person_id'],
+            'cleaned_values': [(5000, 1), (8005, 2), (9000, 3)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
@@ -91,12 +91,12 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
                 (survey_conduct_id, person_id, survey_concept_id, survey_end_datetime, 
                 assisted_concept_id, respondent_type_concept_id, timing_concept_id,
                 collection_method_concept_id, survey_source_concept_id,
-                validated_survey_concept_id)
+                survey_source_identifier, validated_survey_concept_id)
             VALUES
-                (1, 1, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0),
-                (2, 2, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0),
-                (3, 3, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0),
-                (4, 4, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, 0)
+                (1, 1, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, '1', 0),
+                (2, 2, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, '2', 0),
+                (3, 3, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, '3', 0),
+                (4, 4, 0, timestamp('2020-05-05 00:00:00'), 0, 0, 0, 0, 0, '4', 0)
             """).render(fq_dataset_name=self.fq_dataset_name)
 
         create_mappings_query = self.jinja_env.from_string("""
@@ -130,12 +130,17 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
             'cleaned_values': [(1, 1, 5000), (2, 2, 5000), (3, 3, 8005),
                                (4, 4, 8005), (5, 5, 9000), (6, 6, None)]
         }, {
-            'fq_table_name': f'{self.fq_dataset_name}.{SURVEY_CONDUCT}',
-            'fq_sandbox_table_name': self.fq_sandbox_table_names[0],
+            'fq_table_name':
+                f'{self.fq_dataset_name}.{SURVEY_CONDUCT}',
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
             'loaded_ids': [1, 2, 3, 4],
             'sandboxed_ids': [4],
-            'fields': ['survey_conduct_id', 'person_id'],
-            'cleaned_values': [(5000, 1), (8005, 2), (9000, 3)]
+            'fields': [
+                'survey_conduct_id', 'person_id', 'survey_source_identifier'
+            ],
+            'cleaned_values': [(5000, 1, '5000'), (8005, 2, '8005'),
+                               (9000, 3, '9000')]
         }]
 
         self.default_test(tables_and_counts)


### PR DESCRIPTION
- Updated docstrings to better represent what this CR does.
- Refactored the mapping query to handle both `observation` and `survey_conduct`.
- Added sandbox and delete queries for `survey_conduct`.
- Added the test case for `survey_conduct` in the integration test.
- Updated the test case for `observation` so it is easier to understand.