### PR TITLE
[DC-2711] Suppress Monkeypox Data from Registered Tier Only for One-Year

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -111,6 +111,7 @@ from cdr_cleaner.cleaning_rules.generalize_state_by_population import Generalize
 from cdr_cleaner.cleaning_rules.section_participation_concept_suppression import SectionParticipationConceptSuppression
 from cdr_cleaner.cleaning_rules.covid_ehr_vaccine_concept_suppression import CovidEHRVaccineConceptSuppression
 from cdr_cleaner.cleaning_rules.missing_concept_record_suppression import MissingConceptRecordSuppression
+from cdr_cleaner.cleaning_rules.monkeypox_concept_suppression import MonkeypoxConceptSuppression
 from cdr_cleaner.cleaning_rules.create_deid_questionnaire_response_map import CreateDeidQuestionnaireResponseMap
 from cdr_cleaner.cleaning_rules.set_unmapped_question_answer_survey_concepts import (
     SetConceptIdsForSurveyQuestionsAnswers)
@@ -263,6 +264,7 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     ####################################
     (
         CovidEHRVaccineConceptSuppression,),  # should run after QRIDtoRID
+    (MonkeypoxConceptSuppression,),
     (VehicularAccidentConceptSuppression,),
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),

--- a/data_steward/cdr_cleaner/cleaning_rules/monkeypox_concept_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/monkeypox_concept_suppression.py
@@ -1,0 +1,225 @@
+"""
+Sandbox and suppress the monkeypox concepts from registered tier for 1 year holdout from start of the epidemic (same rules as covid).
+The start date for the monkeypox epidemic is 5/17/2022.
+
+This cleaning rule runs in the registered tier after date-shifting.
+Dates are unshifted using _deid_map table to decide if each record is within the holdout or not.
+
+Original Issues: DC-2711
+"""
+
+# Python imports
+import logging
+
+# Project imports
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from constants.bq_utils import WRITE_EMPTY
+from constants.cdr_cleaner import clean_cdr as cdr_consts
+from common import CATI_TABLES, JINJA_ENV
+from resources import get_concept_id_fields, get_date_fields, get_datetime_fields, MONKEYPOX_CONCEPTS_PATH
+from utils import pipeline_logging
+
+# Third party imports
+
+LOGGER = logging.getLogger(__name__)
+
+SUPPRESSION_RULE_CONCEPT_TABLE = 'monkeypox_concepts'
+SUPPRESSION_START_DATE_STR = '2022-05-17'
+SUPPRESSION_END_DATE_STR = '2023-05-17'
+
+SANDBOX_QUERY = JINJA_ENV.from_string("""
+CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table_id}}` AS (
+    SELECT t.* 
+    FROM `{{project_id}}.{{dataset_id}}.{{table}}` t
+    JOIN `{{project_id}}.{{mapping_dataset_id}}._deid_map` m
+    ON t.person_id = m.person_id
+    WHERE (
+    {% for concept_field in concept_fields %}
+        {{concept_field}} IN (
+            SELECT concept_id 
+            FROM `{{project_id}}.{{sandbox_dataset_id}}.{{suppression_concept_table}}`
+        )
+        {% if not loop.last -%} 
+        OR 
+        {% endif %}
+    {% endfor %}
+    )
+    AND (
+    {% if date_fields -%}
+        {% for date_field in date_fields %}
+        (
+            {{date_field}} IS NOT NULL 
+            AND DATE_ADD({{date_field}}, INTERVAL m.shift DAY) 
+                BETWEEN DATE('{{suppression_start_date}}') 
+                AND DATE('{{suppression_end_date}}')
+        )
+        {% if not loop.last -%} OR {% endif %}
+        {% endfor %}
+    {% endif %}
+    {% if date_fields and datetime_fields -%} OR {% endif %}
+    {% if datetime_fields -%}
+        {% for datetime_field in datetime_fields %}
+        (
+            {{datetime_field}} IS NOT NULL 
+            AND TIMESTAMP_ADD({{datetime_field}}, INTERVAL m.shift DAY)
+                BETWEEN TIMESTAMP('{{suppression_start_date}} 00:00:00') 
+                AND TIMESTAMP('{{suppression_end_date}} 23:59:59')
+        )
+        {% if not loop.last -%} OR {% endif %}
+        {% endfor %}
+    {% endif %}
+    )
+)
+""")
+
+DELETE_QUERY = JINJA_ENV.from_string("""
+DELETE FROM `{{project_id}}.{{dataset_id}}.{{table}}`
+{% if table == 'death' %}
+WHERE person_id IN (SELECT person_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table_id}}`)
+{% else %}
+WHERE {{table}}_id IN (SELECT {{table}}_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table_id}}`)
+{% endif %}
+""")
+
+
+class MonkeypoxConceptSuppression(BaseCleaningRule):
+
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 mapping_dataset_id,
+                 table_namer=None):
+        """
+        Initialize the class with proper information.
+
+        :param mapping_dataset_id: Dataset identifier. Identifies a dataset that
+            contains _deid_map table.
+        """
+        desc = (
+            'Sandbox and removes records for monkeypox concepts from registered '
+            'tier for 1 year holdout from start of the epidemic.')
+        super().__init__(issue_numbers=['DC2711'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.REGISTERED_TIER_DEID],
+                         affected_tables=CATI_TABLES,
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         table_namer=table_namer)
+
+        self.mapping_dataset_id = mapping_dataset_id
+
+    def setup_rule(self, client):
+        """
+        Responsible for grabbing and storing deactivated participant data.
+
+        :param client: a BiQueryClient passed to store the data
+        """
+
+        # Create suppression lookup table
+        client.upload_csv_data_to_bq_table(self.sandbox_dataset_id,
+                                           SUPPRESSION_RULE_CONCEPT_TABLE,
+                                           MONKEYPOX_CONCEPTS_PATH, WRITE_EMPTY)
+
+    def setup_validation(self, client, *args, **keyword_args):
+        """
+        Run required steps for validation setup
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client, *args, **keyword_args):
+        """
+        Validates the cleaning rule which deletes or updates the data from the tables
+        """
+        raise NotImplementedError("Please fix me.")
+
+    def get_sandbox_tablenames(self):
+        return [
+            self.sandbox_table_for(affected_table)
+            for affected_table in self.affected_tables
+        ]
+
+    def get_query_specs(self):
+        """
+        Return a list of dictionary query specifications.
+
+        :return:  A list of dictionaries. Each dictionary contains a single query
+            and a specification for how to execute that query. The specifications
+            are optional but the query is required.
+        """
+        sandbox_queries, delete_queries = [], []
+        for table in self.affected_tables:
+
+            date_fields = get_date_fields(table)
+            datetime_fields = get_datetime_fields(table)
+
+            if not date_fields and not datetime_fields:
+                LOGGER.info(
+                    f'Skipping {table}. {table} has no date or datetime fields.'
+                )
+                continue
+
+            sandbox_queries.append({
+                cdr_consts.QUERY:
+                    SANDBOX_QUERY.render(
+                        project_id=self.project_id,
+                        sandbox_dataset_id=self.sandbox_dataset_id,
+                        sandbox_table_id=self.sandbox_table_for(table),
+                        dataset_id=self.dataset_id,
+                        table=table,
+                        mapping_dataset_id=self.mapping_dataset_id,
+                        suppression_concept_table=SUPPRESSION_RULE_CONCEPT_TABLE,
+                        suppression_start_date=SUPPRESSION_START_DATE_STR,
+                        suppression_end_date=SUPPRESSION_END_DATE_STR,
+                        concept_fields=get_concept_id_fields(table),
+                        date_fields=date_fields,
+                        datetime_fields=datetime_fields)
+            })
+
+            delete_queries.append({
+                cdr_consts.QUERY:
+                    DELETE_QUERY.render(
+                        project_id=self.project_id,
+                        sandbox_dataset_id=self.sandbox_dataset_id,
+                        sandbox_table_id=self.sandbox_table_for(table),
+                        dataset_id=self.dataset_id,
+                        table=table)
+            })
+
+        return sandbox_queries + delete_queries
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    mapping_dataset_arg = {
+        parser.SHORT_ARGUMENT: '-m',
+        parser.LONG_ARGUMENT: '--mapping_dataset_id',
+        parser.ACTION: 'store',
+        parser.DEST: 'mapping_dataset_id',
+        parser.HELP: 'Identifies the dataset containing _deid_map table',
+        parser.REQUIRED: True
+    }
+
+    ARGS = parser.default_parse_args([mapping_dataset_arg])
+    pipeline_logging.configure(level=logging.DEBUG, add_console_handler=True)
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(
+            ARGS.project_id,
+            ARGS.dataset_id,
+            ARGS.sandbox_dataset_id, [(MonkeypoxConceptSuppression,)],
+            mapping_dataset_id=ARGS.mapping_dataset_id)
+
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id,
+                                   ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(MonkeypoxConceptSuppression,)],
+                                   mapping_dataset_id=ARGS.mapping_dataset_id)

--- a/data_steward/resource_files/cdr_cleaner/monkeypox_concept_suppression/monkeypox_concepts.csv
+++ b/data_steward/resource_files/cdr_cleaner/monkeypox_concept_suppression/monkeypox_concepts.csv
@@ -1,0 +1,64 @@
+concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,standard_concept,concept_code,valid_start_date,valid_end_date,invalid_reason
+443405,Human monkeypox,Condition,SNOMED,Clinical Finding,S,359811007,2002-01-31,2099-12-31,
+3119802,Monkeypox,Condition,Nebraska Lexicon,Clinical Finding,,186582008,2002-01-31,2017-07-31,U
+3138659,Monkeypox,Condition,Nebraska Lexicon,Clinical Finding,,240466002,2002-01-31,2017-07-31,U
+3139552,Monkeypox,Condition,Nebraska Lexicon,Clinical Finding,,25157001,2002-01-31,2017-07-31,U
+3311601,Monkey pox,Condition,Nebraska Lexicon,Clinical Finding,,359814004,2002-01-31,2099-12-31,
+3354141,Human monkeypox,Condition,Nebraska Lexicon,Clinical Finding,,359811007,2002-01-31,2099-12-31,
+4234275,Monkeypox,Condition,SNOMED,Clinical Finding,S,359814004,2002-01-31,2099-12-31,
+35205743,Monkeypox,Condition,ICD10CM,3-char billing code,,B04,2007-01-01,2099-12-31,
+40384350,Monkeypox,Condition,SNOMED,Clinical Finding,,186582008,1970-01-01,2002-01-31,U
+40442630,Monkeypox,Condition,SNOMED,Clinical Finding,,240466002,1970-01-01,2002-01-31,U
+40457112,Monkeypox,Condition,SNOMED,Clinical Finding,,25157001,1970-01-01,2002-01-31,U
+44826343,Monkeypox,Condition,ICD9CM,5-dig billing code,,059.01,1970-01-01,2099-12-31,
+44831017,Monocytic leukemia,Condition,ICD9CM,3-dig nonbill code,,206,1970-01-01,2099-12-31,
+45915691,Human Monkeypox,Condition,CIEL,Diagnosis,,138403,2007-11-03,2099-12-31,
+45941547,Convulsions,Condition,CIEL,Diagnosis,,206,2004-01-01,2099-12-31,
+724903,"smallpox monkeypox vaccine, live attenuated, preservative free (National Stockpile)",Drug,CVX,CVX,S,206,2020-07-20,2099-12-31,
+1224632,0.5 ML modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML Injection [Jynneos],Drug,NDC,11-digit NDC,,50632000101,2020-12-01,2099-12-31,
+1224633,0.5 ML modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML Injection [Jynneos],Drug,NDC,11-digit NDC,,50632000102,2020-12-01,2099-12-31,
+1396491,"smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/ML",Drug,RxNorm,Clinical Drug Comp,S,2170514,2019-07-01,2099-12-31,
+1396492,"smallpox vaccine live, New York City Board of Health vaccinia strain Injectable Solution",Drug,RxNorm,Clinical Drug Form,S,2170515,2019-07-01,2099-12-31,
+1396493,"smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/ML [ACAM2000]",Drug,RxNorm,Branded Drug Comp,S,2170517,2019-07-01,2099-12-31,
+1396494,"smallpox vaccine live, New York City Board of Health vaccinia strain Injectable Solution [ACAM2000]",Drug,RxNorm,Branded Drug Form,S,2170518,2019-07-01,2099-12-31,
+1985751,"vaccinia virus modified strain ankara-bavarian nordic non-replicating antigen 500000001/.5mL SUBCUTANEOUS INJECTION, SUSPENSION",Drug,NDC,9-digit NDC,,506320001,2021-03-17,2099-12-31,
+4352694,Monkeypox,Drug,NDFRT,Ind / CI,,N0000010966,1970-01-01,2099-12-31,
+19030120,"smallpox vaccine live, New York City Board of Health vaccinia strain",Drug,RxNorm,Ingredient,S,798467,2008-06-29,2099-12-31,
+19082103,Injectable Solution,Drug,RxNorm,Dose Form,,316949,1970-01-01,2099-12-31,
+19133773,smallpox vaccine live vaccinia virus,Drug,RxNorm,Ingredient,,833079,2009-03-01,2019-06-30,D
+19133774,smallpox vaccine live vaccinia virus 500000000 UNT/ML,Drug,RxNorm,Clinical Drug Comp,,833080,2009-03-01,2019-06-30,D
+19133775,"smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/ML Injectable Solution",Drug,RxNorm,Clinical Drug,S,833082,2009-03-01,2099-12-31,
+19133776,ACAM2000,Drug,RxNorm,Brand Name,,833083,2009-03-01,2099-12-31,
+19133777,smallpox vaccine live vaccinia virus 500000000 UNT/ML [ACAM2000],Drug,RxNorm,Branded Drug Comp,,833084,2009-03-01,2019-06-30,D
+19133778,"smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/ML Injectable Solution [ACAM2000]",Drug,RxNorm,Branded Drug,S,833086,2009-03-01,2099-12-31,
+35509170,"ACAM2000 - smallpox (vaccinia) vaccine, live injection, powder, lyophilized, for solution",Drug,SPL,Vaccine,C,f8b2634b-ccd7-4a42-8db3-26ba9e9627e6,2018-03-21,2099-12-31,
+35520595,"smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/ML Injectable Solution [ACAM2000]",Drug,NDC,11-digit NDC,,71665033001,2018-11-01,2099-12-31,
+35520596,"smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/ML Injectable Solution [ACAM2000]",Drug,NDC,11-digit NDC,,71665033002,2018-11-01,2099-12-31,
+35524233,"smallpox (vaccinia) vaccine, live 100000000[PFU]/mL PERCUTANEOUS INJECTION, POWDER, LYOPHILIZED, FOR SOLUTION",Drug,NDC,9-digit NDC,,716650330,2007-08-31,2099-12-31,
+35603384,vaccinia virus,Drug,RxNorm,Ingredient,S,1668221,2016-05-02,2099-12-31,
+35803058,Factor IX recombinant Fc fusion protein,Drug,HemOnc,Component,,206,2019-05-27,2099-12-31,
+36217210,Injectable Product,Drug,RxNorm,Dose Form Group,C,1151126,2016-08-01,2099-12-31,
+36221505,ACAM2000 Injectable Product,Drug,RxNorm,Branded Dose Group,C,1165898,2016-08-01,2099-12-31,
+36224407,smallpox vaccine live vaccinia virus Injectable Product,Drug,RxNorm,Clinical Dose Group,,1159666,2016-08-01,2019-06-30,D
+36225222,"smallpox vaccine live, New York City Board of Health vaccinia strain Injectable Product",Drug,RxNorm,Clinical Dose Group,C,1158766,2016-08-01,2099-12-31,
+37003258,modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML,Drug,RxNorm,Clinical Drug Comp,S,2464824,2021-01-04,2099-12-31,
+37003259,vaccinia virus Injectable Product,Drug,RxNorm,Clinical Dose Group,C,2464825,2021-01-04,2099-12-31,
+37003260,vaccinia virus Injection,Drug,RxNorm,Clinical Drug Form,S,2464826,2021-01-04,2099-12-31,
+37003262,modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML [Jynneos],Drug,RxNorm,Branded Drug Comp,S,2464829,2021-01-04,2099-12-31,
+37003263,vaccinia virus Injection [Jynneos],Drug,RxNorm,Branded Drug Form,S,2464830,2021-01-04,2099-12-31,
+37003264,Jynneos Injectable Product,Drug,RxNorm,Branded Dose Group,C,2464831,2021-01-04,2099-12-31,
+37003265,modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML Injection,Drug,RxNorm,Clinical Drug,S,2464833,2021-01-04,2099-12-31,
+37003266,modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML Injection [Jynneos],Drug,RxNorm,Branded Drug,S,2464834,2021-01-04,2099-12-31,
+37003638,0.5 ML modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML Injection,Drug,RxNorm,Quant Clinical Drug,S,2464827,2021-01-04,2099-12-31,
+37003639,0.5 ML modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/ML Injection [Jynneos],Drug,RxNorm,Quant Branded Drug,S,2464832,2021-01-04,2099-12-31,
+40157874,smallpox vaccine live vaccinia virus Injectable Solution,Drug,RxNorm,Clinical Drug Form,,833081,2009-03-01,2019-06-30,D
+40157875,smallpox vaccine live vaccinia virus Injectable Solution [ACAM2000],Drug,RxNorm,Branded Drug Form,,833085,2009-03-01,2019-06-30,D
+45410172,ethinyl estradiol-norgestimate 35 mcg-0.25 mg oral tablet,Drug,Multum,Multum,,206,1970-01-01,2099-12-31,
+41948397,Les Villettes,Geography,OSM,8th level,S,138403,1970-01-01,2099-12-31,
+41956720,Romelfing,Geography,OSM,8th level,S,1159666,1970-01-01,2099-12-31,
+35949560,ADAM28 (ADAM metallopeptidase domain 28) gene variant measurement,Measurement,OMOP Genomic,Genetic Variation,S,206,1999-07-29,2099-12-31,
+3255802,Monkeypox virus,Observation,Nebraska Lexicon,Organism,,59774002,2002-01-31,2099-12-31,
+4245290,Monkeypox virus,Observation,SNOMED,Organism,S,59774002,2002-01-31,2099-12-31,
+38000504,"Disorders of Liver Except Malignancy, Cirrhosis, Alcoholic Hepatitis without Complications, Comorbidities",Observation,DRG,DRG,,206,1994-10-01,2007-09-30,D
+38001052,Other respiratory system diagnoses w/o MCC,Observation,DRG,MS-DRG,S,206,2007-10-01,2099-12-31,
+2789560,"Imaging, Central Nervous System, Ultrasonography",Procedure,ICD10PCS,ICD10PCS Hierarchy,S,B04,1970-01-01,2099-12-31,

--- a/data_steward/resources.py
+++ b/data_steward/resources.py
@@ -76,6 +76,9 @@ PPI_BRANCHING_RULE_PATHS = [
     HEALTHCARE_ACCESS_CSV_PATH, LIFESTYLE_CSV_PATH, OVERALL_HEALTH_CSV_PATH,
     PERSONAL_MEDICAL_HISTORY_CSV_PATH
 ]
+MONKEYPOX_CONCEPTS_PATH = os.path.join(CDR_CLEANER_PATH,
+                                       'monkeypox_concept_suppression',
+                                       'monkeypox_concepts.csv')
 
 VALIDATION_STREET_CSV = os.path.join(resource_files_path, 'validation',
                                      'participants', 'abbreviation_street.csv')
@@ -408,7 +411,7 @@ def get_domain(domain_table):
 
 def get_concept_id_fields(table_name) -> List[str]:
     """
-    Determine if column is a concept_id column
+    Get a list of concept_id columns in the table.
 
     :param table_name:
     :return: all *concept_id schemas given a table
@@ -417,6 +420,34 @@ def get_concept_id_fields(table_name) -> List[str]:
         field_name['name']
         for field_name in fields_for(table_name)
         if field_name['name'].endswith('concept_id')
+    ]
+
+
+def get_date_fields(table_name) -> List[str]:
+    """
+    Get a list of date columns in the table.
+
+    :param table_name:
+    :return: all *date schemas in the table
+    """
+    return [
+        field_name['name']
+        for field_name in fields_for(table_name)
+        if field_name['name'].endswith('date')
+    ]
+
+
+def get_datetime_fields(table_name) -> List[str]:
+    """
+    Get a list of datetime columns in the table.
+
+    :param table_name:
+    :return: all *datetime schemas in the table
+    """
+    return [
+        field_name['name']
+        for field_name in fields_for(table_name)
+        if field_name['name'].endswith('datetime')
     ]
 
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/monkeypox_concept_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/monkeypox_concept_suppression_test.py
@@ -1,0 +1,186 @@
+"""
+Integration test for MonkeypoxConceptSuppression module
+
+Original Issue: DC-2711
+"""
+# Python Imports
+import os
+import mock
+
+# Project imports
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.monkeypox_concept_suppression import MonkeypoxConceptSuppression, LOGGER, SUPPRESSION_RULE_CONCEPT_TABLE
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+from common import CARE_SITE, DEATH, DEID_MAP, FACT_RELATIONSHIP, JINJA_ENV, OBSERVATION, SURVEY_CONDUCT
+
+# Third party imports
+
+
+class MonkeypoxConceptSuppressionTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        cls.project_id = os.environ.get(PROJECT_ID)
+        cls.dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.mapping_dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.sandbox_id = f'{cls.dataset_id}_sandbox'
+
+        cls.rule_instance = MonkeypoxConceptSuppression(cls.project_id,
+                                                        cls.dataset_id,
+                                                        cls.sandbox_id,
+                                                        cls.mapping_dataset_id)
+
+        cls.kwargs.update({'mapping_dataset_id': cls.mapping_dataset_id})
+
+        cls.fq_table_names = [
+            f'{cls.project_id}.{cls.dataset_id}.{OBSERVATION}',
+            f'{cls.project_id}.{cls.dataset_id}.{SURVEY_CONDUCT}',
+            f'{cls.project_id}.{cls.dataset_id}.{DEATH}',
+            f'{cls.project_id}.{cls.dataset_id}.{CARE_SITE}',
+            f'{cls.project_id}.{cls.dataset_id}.{FACT_RELATIONSHIP}',
+            f'{cls.project_id}.{cls.mapping_dataset_id}.{DEID_MAP}',
+        ]
+
+        cls.fq_sandbox_table_names = [
+            f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(OBSERVATION)}',
+            f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(SURVEY_CONDUCT)}',
+            f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(DEATH)}',
+            f'{cls.project_id}.{cls.sandbox_id}.{SUPPRESSION_RULE_CONCEPT_TABLE}',
+        ]
+
+        # call super to set up the client, create datasets, and create
+        # empty test tables
+        # NOTE:  does not create empty sandbox tables.
+        super().setUpClass()
+
+    @mock.patch(
+        'cdr_cleaner.cleaning_rules.monkeypox_concept_suppression.MonkeypoxConceptSuppression.affected_tables',
+        [OBSERVATION, SURVEY_CONDUCT, DEATH, CARE_SITE, FACT_RELATIONSHIP])
+    def test_monkeypox_concept_suppression(self):
+        """
+        Tests that the specifications perform as designed.
+
+        OBSERVATION:
+            11... Not suppress: Not a monkeypox record.
+            12... Not suppress: A monkeypox record but the un-shifted date is before the suppression start date.
+            13... Not suppress: A monkeypox record but the un-shifted date is after the suppression end date.
+            14... Suppress: A monkeypox record and the un-shifted date within the suppression period.
+            15... Suppress: A monkeypox record, different concept column from 4.
+
+        SURVEY_CONDUCT:
+            21... Not suppress: Not a monkeypox record.
+            22... Not suppress: A monkeypox record but the un-shifted date/datetime is before the suppression start date.
+            23... Not suppress: A monkeypox record but the un-shifted date/datetime is after the suppression end date.
+            24... Suppress: A monkeypox record and the un-shifted start datetime within the suppression period.
+            25... Suppress: A monkeypox record and the un-shifted end datetime within the suppression period.
+
+        DEATH: Unlike other tables, its primary key is "person_id", not "death_id".
+            31... Not suppress: Not a monkeypox record.
+            32... Suppress: A monkeypox record and the un-shifted death date within the suppression period.
+
+        CARE_SITE, FACT_RELATIONSHIP: No date or datetime fields in this table. This CR skips it.
+
+        """
+
+        INSERT_DEID_MAP_QUERY = JINJA_ENV.from_string("""
+            INSERT INTO `{{project_id}}.{{mapping_dataset_id}}._deid_map`
+                (person_id, shift)
+            VALUES
+                (101, 1),
+                (102, 2),
+                (103, 3),
+                (104, 4),
+                (105, 5)
+        """).render(project_id=self.project_id,
+                    mapping_dataset_id=self.mapping_dataset_id)
+
+        INSERT_OBSERVATIONS_QUERY = JINJA_ENV.from_string("""
+            INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
+                (observation_id, person_id, observation_concept_id, observation_source_concept_id, 
+                 observation_date, observation_type_concept_id)
+            VALUES
+                (11, 101, 12345, 0, date('2022-09-01'), 1),
+                (12, 102, 443405, 0, date('2022-05-14'), 2),
+                (13, 103, 443405, 0, date('2023-05-15'), 3),
+                (14, 104, 443405, 0, date('2022-05-13'), 4),
+                (15, 105, 0, 3119802, date('2023-05-12'), 5)
+        """).render(project_id=self.project_id, dataset_id=self.dataset_id)
+
+        INSERT_SURVEY_CONDUCT_QUERY = JINJA_ENV.from_string("""
+            INSERT INTO `{{project_id}}.{{dataset_id}}.survey_conduct`
+                (survey_conduct_id, person_id, survey_concept_id,
+                 survey_start_date, survey_start_datetime,
+                 survey_end_date, survey_end_datetime,
+                 assisted_concept_id, respondent_type_concept_id, timing_concept_id,
+                 collection_method_concept_id, survey_source_concept_id,
+                 validated_survey_concept_id)
+            VALUES
+                (21, 101, 12345, date('2022-09-01'), timestamp('2022-09-01 00:00:00'), date('2022-09-02'), timestamp('2022-09-02 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (22, 102, 443405, date('2022-05-13'), timestamp('2022-05-13 00:00:00'), date('2022-05-14'), timestamp('2022-05-14 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (23, 103, 443405, date('2023-05-15'), timestamp('2023-05-15 00:00:00'), date('2023-05-16'), timestamp('2023-05-16 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (24, 104, 443405, NULL, timestamp('2023-05-13 00:00:00'), NULL, timestamp('2023-05-15 00:00:00'), 0, 0, 0, 0, 0, 0),
+                (25, 105, 443405, NULL, NULL, NULL, timestamp('2023-05-12 00:00:00'), 0, 0, 0, 0, 0, 0)
+        """).render(project_id=self.project_id, dataset_id=self.dataset_id)
+
+        INSERT_DEATH_QUERY = JINJA_ENV.from_string("""
+            INSERT INTO `{{project_id}}.{{dataset_id}}.death`
+                (person_id, death_date, death_type_concept_id, cause_concept_id)
+            VALUES
+                (101, date('2022-09-01'), 0, 0),
+                (102, date('2022-09-01'), 0, 443405)
+        """).render(project_id=self.project_id, dataset_id=self.dataset_id)
+
+        queries = [
+            INSERT_DEID_MAP_QUERY,
+            INSERT_OBSERVATIONS_QUERY,
+            INSERT_SURVEY_CONDUCT_QUERY,
+            INSERT_DEATH_QUERY,
+        ]
+
+        self.load_test_data(queries)
+
+        tables_and_counts = [{
+            'fq_table_name':
+                '.'.join([self.project_id, self.dataset_id, OBSERVATION]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[0],
+            'loaded_ids': [11, 12, 13, 14, 15],
+            'sandboxed_ids': [14, 15],
+            'fields': ['observation_id'],
+            'cleaned_values': [(11,), (12,), (13,)]
+        }, {
+            'fq_table_name':
+                '.'.join([self.project_id, self.dataset_id, SURVEY_CONDUCT]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[1],
+            'loaded_ids': [21, 22, 23, 24, 25],
+            'sandboxed_ids': [24, 25],
+            'fields': ['survey_conduct_id'],
+            'cleaned_values': [(21,), (22,), (23,)]
+        }, {
+            'fq_table_name':
+                '.'.join([self.project_id, self.dataset_id, DEATH]),
+            'fq_sandbox_table_name':
+                self.fq_sandbox_table_names[2],
+            'loaded_ids': [101, 102],
+            'sandboxed_ids': [102],
+            'fields': ['person_id'],
+            'cleaned_values': [(101,)]
+        }]
+
+        with self.assertLogs(LOGGER, level='INFO') as cm:
+            self.default_test(tables_and_counts)
+
+        self.assertIn(
+            'INFO:cdr_cleaner.cleaning_rules.monkeypox_concept_suppression:Skipping care_site. care_site has no date or datetime fields.',
+            cm.output)
+
+        self.assertIn(
+            'INFO:cdr_cleaner.cleaning_rules.monkeypox_concept_suppression:Skipping fact_relationship. fact_relationship has no date or datetime fields.',
+            cm.output)


### PR DESCRIPTION
- I ended up building from `BaseCleaningRule` instead of extending `AbstractBqLookupTableConceptSuppression` since the one-year holdout condition would make the script more complicated with `AbstractBqLookupTableConceptSuppression`.