### PR TITLE
[DC-2730] remap survey_conduct_ext table foreign key values

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -106,7 +106,7 @@ from cdr_cleaner.cleaning_rules.aggregate_zip_codes import AggregateZipCodes
 from cdr_cleaner.cleaning_rules.remove_extra_tables import RemoveExtraTables
 from cdr_cleaner.cleaning_rules.store_pid_rid_mappings import StoreNewPidRidMappings
 from cdr_cleaner.cleaning_rules.update_invalid_zip_codes import UpdateInvalidZipCodes
-from cdr_cleaner.manual_cleaning_rules.survey_version_info import COPESurveyVersionTask
+from cdr_cleaner.cleaning_rules.deid.survey_version_info import COPESurveyVersionTask
 from cdr_cleaner.cleaning_rules.deid.string_fields_suppression import StringFieldsSuppression
 from cdr_cleaner.cleaning_rules.generalize_state_by_population import GeneralizeStateByPopulation
 from cdr_cleaner.cleaning_rules.section_participation_concept_suppression import SectionParticipationConceptSuppression
@@ -251,14 +251,14 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     # Data mappings/re-mappings
     ####################################
     (
-        QRIDtoRID,),  # Should run before any row suppression rules
-    (GenerateExtTables,),
+        GenerateExtTables,),
     (COPESurveyVersionTask,
     ),  # Should run after GenerateExtTables and before CleanMappingExtTables
     # TODO: Uncomment rule after date-shift removed from deid module
     # (SurveyConductDateShiftRule,),
     (
         PopulateSurveyConductExt,),
+    (QRIDtoRID,),  # Should run before any row suppression rules
 
     # Data generalizations
     ####################################
@@ -308,6 +308,10 @@ REGISTERED_TIER_FITBIT_CLEANING_CLASSES = [
 
 CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (RtCtPIDtoRID,),
+    (GenerateExtTables,),
+    (COPESurveyVersionTask,
+    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
+    (PopulateSurveyConductExt,),
     (QRIDtoRID,),  # Should run before any row suppression rules
     (NullPersonBirthdate,),
     (TableSuppression,),
@@ -325,10 +329,6 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (YearOfBirthRecordsSuppression,),
     (ControlledCopeSurveySuppression,),
     (IDFieldSuppression,),  # Should run after any data remapping
-    (GenerateExtTables,),
-    (COPESurveyVersionTask,
-    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
-    (PopulateSurveyConductExt,),
     (CancerConceptSuppression,),  # Should run after any data remapping rules
     (SectionParticipationConceptSuppression,),
     (StringFieldsSuppression,),

--- a/data_steward/cdr_cleaner/cleaning_rules/date_unshift_cope_responses.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/date_unshift_cope_responses.py
@@ -27,7 +27,7 @@ import logging
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 from common import JINJA_ENV, OBSERVATION, SURVEY_CONDUCT
-from cdr_cleaner.manual_cleaning_rules.survey_version_info import COPESurveyVersionTask
+from cdr_cleaner.cleaning_rules.deid.survey_version_info import COPESurveyVersionTask
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ FROM `{{project_id}}.{{dataset_id}}.{{observation_table}}`
 INNER JOIN `{{project_id}}.{{dataset_id}}.{{observation_ext_table}}`
 USING (observation_id)
 WHERE survey_version_concept_id IN (2100000002, 2100000003, 2100000004, 2100000005, 2100000006,
-  2100000007, 905047, 905055, 765936) 
+  2100000007, 905047, 905055, 765936)
 """)
 
 SANDBOX_COPE_SURVEY_SC_QUERY = JINJA_ENV.from_string("""
@@ -48,7 +48,7 @@ CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset}}.{{intermediary_sc_ta
 SELECT *
 FROM `{{project_id}}.{{dataset_id}}.{{survey_conduct_table}}`
 WHERE survey_source_concept_id IN (2100000002, 2100000003, 2100000004, 2100000005, 2100000006,
-  2100000007, 905047, 905055, 765936) 
+  2100000007, 905047, 905055, 765936)
 """)
 
 DATE_UNSHIFT_OBS_QUERY = JINJA_ENV.from_string("""

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
@@ -4,7 +4,7 @@ Questionnaire_response_id exists in the following two tables:
     1. observation table, as column questionnaire_response_id
     2. survey_conduct table, as columns survey_conduct_id(int) and survey_source_identifier(str).
 
-The mapping for questionnaire_response_id and research_response_id is in the 
+The mapping for questionnaire_response_id and research_response_id is in the
 _deid_questionnaire_response_map lookup table.
 
 If no mapping is found for a survey_conduct_id in the mapping table, the row
@@ -13,8 +13,8 @@ is the primary key for survey_conduct table and it cannot be mapped to None.
 
 Original Issue: DC-1347, DC-518, DC-2065, DC-2637
 
-The purpose of this cleaning rule is to use the questionnaire mapping lookup 
-table to remap the questionnaire_response_id to the randomly generated 
+The purpose of this cleaning rule is to use the questionnaire mapping lookup
+table to remap the questionnaire_response_id to the randomly generated
 research_response_id in the _deid_questionnaire_response_map table.
 """
 
@@ -23,45 +23,24 @@ import logging
 
 # Project imports
 from utils import pipeline_logging
-from common import DEID_QUESTIONNAIRE_RESPONSE_MAP, JINJA_ENV, OBSERVATION, SURVEY_CONDUCT
+from common import (DEID_QUESTIONNAIRE_RESPONSE_MAP, EXT_SUFFIX, JINJA_ENV,
+                    OBSERVATION, SURVEY_CONDUCT)
 from constants.cdr_cleaner import clean_cdr as cdr_consts
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
+from cdr_cleaner.cleaning_rules.generate_ext_tables import GenerateExtTables
 
 LOGGER = logging.getLogger(__name__)
 
-ISSUE_NUMBERS = ['DC1347', 'DC518', 'DC2065', 'DC2637']
-
-SANDBOX_SC_QUERY = JINJA_ENV.from_string("""
-CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}` as (
-    SELECT *
-    FROM `{{project_id}}.{{dataset_id}}.survey_conduct`
-    WHERE survey_conduct_id NOT IN (
-        SELECT questionnaire_response_id 
-        FROM `{{project_id}}.{{deid_questionnaire_response_map_dataset_id}}.{{deid_questionnaire_response_map}}`
-    ))
-""")
-
-DELETE_SC_QUERY = JINJA_ENV.from_string("""
-DELETE FROM `{{project_id}}.{{dataset_id}}.survey_conduct`
-WHERE survey_conduct_id IN (
-    SELECT survey_conduct_id FROM `{{project_id}}.{{sandbox_dataset_id}}.{{sandbox_table}}`
-)
-""")
+ISSUE_NUMBERS = ['DC1347', 'DC518', 'DC2065', 'DC2637', 'DC2730']
 
 QRID_RID_MAPPING_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.{{table}}` t
-SET t.{{qrid_column}} = d.research_response_id
+SET t.{{qrid_column}} = m.research_response_id
 {% if table == 'survey_conduct' %}
-   ,t.survey_source_identifier = CAST(d.research_response_id AS STRING)
+   ,t.survey_source_identifier = CAST(m.research_response_id AS STRING)
 {% endif %}
-FROM (
-    SELECT
-        o.*, m.research_response_id
-    FROM `{{project_id}}.{{dataset_id}}.{{table}}` o
-    LEFT JOIN `{{project_id}}.{{deid_questionnaire_response_map_dataset_id}}.{{deid_questionnaire_response_map}}` m
-    ON o.{{qrid_column}} = m.questionnaire_response_id
-    ) d
-WHERE t.{{table}}_id = d.{{table}}_id
+FROM `{{project_id}}.{{deid_questionnaire_response_map_dataset_id}}.{{deid_questionnaire_response_map}}` m
+WHERE t.{{qrid_column}} = m.questionnaire_response_id
 """)
 
 
@@ -103,10 +82,14 @@ class QRIDtoRID(BaseCleaningRule):
                              cdr_consts.CONTROLLED_TIER_DEID,
                              cdr_consts.REGISTERED_TIER_DEID
                          ],
-                         affected_tables=[OBSERVATION, SURVEY_CONDUCT],
+                         affected_tables=[
+                             OBSERVATION, SURVEY_CONDUCT,
+                             f'{SURVEY_CONDUCT}{EXT_SUFFIX}'
+                         ],
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id,
+                         depends_on=[GenerateExtTables],
                          table_namer=table_namer)
 
     def get_query_specs(self, *args, **keyword_args):
@@ -117,39 +100,16 @@ class QRIDtoRID(BaseCleaningRule):
             single query and a specification for how to execute that query.
             The specifications are optional but the query is required.
         """
-
-        sandbox_query = {
-            cdr_consts.QUERY:
-                SANDBOX_SC_QUERY.render(
-                    project_id=self.project_id,
-                    dataset_id=self.dataset_id,
-                    deid_questionnaire_response_map=
-                    DEID_QUESTIONNAIRE_RESPONSE_MAP,
-                    deid_questionnaire_response_map_dataset_id=self.
-                    deid_questionnaire_response_map_dataset,
-                    sandbox_dataset_id=self.sandbox_dataset_id,
-                    sandbox_table=self.sandbox_table_for(SURVEY_CONDUCT))
-        }
-
-        delete_query = {
-            cdr_consts.QUERY:
-                DELETE_SC_QUERY.render(
-                    project_id=self.project_id,
-                    dataset_id=self.dataset_id,
-                    sandbox_dataset_id=self.sandbox_dataset_id,
-                    sandbox_table=self.sandbox_table_for(SURVEY_CONDUCT))
-        }
-
-        table_qrid_mappings = [
-            {
-                "table": OBSERVATION,
-                "qrid_column": "questionnaire_response_id"
-            },
-            {
-                "table": SURVEY_CONDUCT,
-                "qrid_column": "survey_conduct_id"
-            },
-        ]
+        table_qrid_mappings = [{
+            "table": OBSERVATION,
+            "qrid_column": "questionnaire_response_id"
+        }, {
+            "table": SURVEY_CONDUCT,
+            "qrid_column": "survey_conduct_id"
+        }, {
+            "table": f'{SURVEY_CONDUCT}{EXT_SUFFIX}',
+            "qrid_column": "survey_conduct_id"
+        }]
 
         mapping_queries = []
         for table_qrid_mapping in table_qrid_mappings:
@@ -169,7 +129,7 @@ class QRIDtoRID(BaseCleaningRule):
 
             mapping_queries.append(mapping_query)
 
-        return [sandbox_query] + [delete_query] + mapping_queries
+        return mapping_queries
 
     def setup_rule(self, client, *args, **keyword_args):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
@@ -19,7 +19,7 @@ research_response_id in the _deid_questionnaire_response_map table.
 
 This rule will not sandbox survey_conduct_ext records that do not have a questionnaire_response_id mapping because
 1.  The mapping table will be built from the observation.questionnaire_response_id values
-2.  A cleaning rule, DC-2723, will ensure records in survey_conduct map to records in observation
+2.  A cleaning rule, DC-2735, will ensure records in survey_conduct map to records in observation
     IF there is not a valid mapping from survey_conduct.survey_conduct_id = observation.questionnaire_response_id
     THEN the record will be sandboxed and dropped from survey_conduct.
 3.  The clean mapping and extension tables rule will clean the survey_conduct_ext table.

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map.py
@@ -11,11 +11,18 @@ If no mapping is found for a survey_conduct_id in the mapping table, the row
 will be sandboxed and deleted from survey_conduct table, as survey_conduct_id
 is the primary key for survey_conduct table and it cannot be mapped to None.
 
-Original Issue: DC-1347, DC-518, DC-2065, DC-2637
+Original Issue: DC-1347, DC-518, DC-2065, DC-2637, DC-2730
 
 The purpose of this cleaning rule is to use the questionnaire mapping lookup
 table to remap the questionnaire_response_id to the randomly generated
 research_response_id in the _deid_questionnaire_response_map table.
+
+This rule will not sandbox survey_conduct_ext records that do not have a questionnaire_response_id mapping because
+1.  The mapping table will be built from the observation.questionnaire_response_id values
+2.  A cleaning rule, DC-2723, will ensure records in survey_conduct map to records in observation
+    IF there is not a valid mapping from survey_conduct.survey_conduct_id = observation.questionnaire_response_id
+    THEN the record will be sandboxed and dropped from survey_conduct.
+3.  The clean mapping and extension tables rule will clean the survey_conduct_ext table.
 """
 
 # Python imports

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
@@ -1,7 +1,7 @@
 """
 Adding COPE and Minute survey version info to the observation_ext table.
 
-Original Issue:  DC-1040
+Original Issue:  DC-1040, DC-2730
 
 The intent is to provide COPE and Minute survey version info as part of the observation_ext
 table.  In an ad-hoc form, this relies on receiving questionnaire_response_id to

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
@@ -24,7 +24,7 @@ from constants.cdr_cleaner import clean_cdr as cdr_consts
 
 LOGGER = logging.getLogger(__name__)
 
-ISSUE_NUMBERS = ['DC-1040', 'DC-2609']
+ISSUE_NUMBERS = ['DC-1040', 'DC-2609', 'DC2730']
 
 VERSION_COPE_SURVEYS_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{out_dataset_id}}.observation_ext` oe
@@ -241,6 +241,7 @@ if __name__ == '__main__':
         ARGS.deid_questionnaire_response_map_dataset)
     query_list = version_task.get_query_specs()
 
+    #TODO:  fix this so it is functional
     if ARGS.list_queries:
         version_task.log_queries()
     else:

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -11,7 +11,7 @@ import logging
 import constants.cdr_cleaner.clean_cdr as cdr_consts
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
 from cdr_cleaner.cleaning_rules.generate_ext_tables import GenerateExtTables
-from cdr_cleaner.manual_cleaning_rules.survey_version_info import COPESurveyVersionTask
+from cdr_cleaner.cleaning_rules.deid.survey_version_info import COPESurveyVersionTask
 from common import EXT_SUFFIX, JINJA_ENV, SURVEY_CONDUCT
 
 LOGGER = logging.getLogger(__name__)

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -2,7 +2,7 @@
 Populates survey_conduct_ext table with the language information
 as provided in the questionnaire_response_additional_info table.
 
-Original issue: DC-2627
+Original issue: DC-2627, DC-2730
 """
 # Python imports
 import logging
@@ -43,7 +43,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                 'information as provided in the '
                 'questionnaire_response_additional_info table.')
 
-        super().__init__(issue_numbers=['DC2627'],
+        super().__init__(issue_numbers=['DC2627', 'DC2730'],
                          description=desc,
                          affected_datasets=[
                              cdr_consts.REGISTERED_TIER_DEID,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/questionnaire_response_id_map_test.py
@@ -50,9 +50,7 @@ class QRIDtoRIDTest(BaseTest.CleaningRulesTestBase):
         ]
 
         sb_table_name = cls.rule_instance.sandbox_table_for(SURVEY_CONDUCT)
-        cls.fq_sandbox_table_names = [
-            # f'{project_id}.{cls.sandbox_id}.{sb_table_name}'
-        ]
+        cls.fq_sandbox_table_names = []
 
         cls.kwargs['deid_questionnaire_response_map_dataset'] = dataset_id
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
@@ -43,18 +43,13 @@ class COPESurveyVersionTaskTest(BaseTest.DeidRulesTestBase):
 
         dataset_id = os.environ.get('COMBINED_DATASET_ID')
         sandbox_id = f'{dataset_id}_sandbox'
-        cls.kwargs.update({
-            'deid_questionnaire_response_map_dataset':
-                cls.deid_questionnaire_response_map_dataset,
-            'cope_lookup_dataset_id':
-                cls.cope_dataset_id,
-            'cope_table_name':
-                COPE_SURVEY_MAP
-        })
+        cls.kwargs.update({'cope_lookup_dataset_id': cls.cope_dataset_id})
 
         cls.rule_instance = COPESurveyVersionTask(
-            cls.project_id, dataset_id, sandbox_id, cls.cope_dataset_id,
-            COPE_SURVEY_MAP, cls.deid_questionnaire_response_map_dataset)
+            cls.project_id,
+            dataset_id,
+            sandbox_id,
+            cope_lookup_dataset_id=cls.cope_dataset_id)
 
         cls.fq_table_names = [
             f"{cls.project_id}.{dataset_id}.observation",

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
@@ -28,8 +28,7 @@ class COPESurveyVersionTaskTest(BaseTest.DeidRulesTestBase):
         super().initialize_class_vars()
 
         # set the test project identifier
-        project_id = os.environ.get(PROJECT_ID)
-        cls.project_id = project_id
+        cls.project_id = os.environ.get(PROJECT_ID)
 
         # set the expected test datasets
         # intended to be run on the deid_base dataset.  The combined dataset
@@ -43,7 +42,7 @@ class COPESurveyVersionTaskTest(BaseTest.DeidRulesTestBase):
         cls.cope_dataset_id = cls.mapping_dataset_id
 
         dataset_id = os.environ.get('COMBINED_DATASET_ID')
-        sandbox_id = dataset_id + '_sandbox'
+        sandbox_id = f'{dataset_id}_sandbox'
         cls.kwargs.update({
             'deid_questionnaire_response_map_dataset':
                 cls.deid_questionnaire_response_map_dataset,
@@ -54,19 +53,19 @@ class COPESurveyVersionTaskTest(BaseTest.DeidRulesTestBase):
         })
 
         cls.rule_instance = COPESurveyVersionTask(
-            project_id, dataset_id, sandbox_id, cls.cope_dataset_id,
+            cls.project_id, dataset_id, sandbox_id, cls.cope_dataset_id,
             COPE_SURVEY_MAP, cls.deid_questionnaire_response_map_dataset)
 
         cls.fq_table_names = [
-            f"{project_id}.{dataset_id}.observation",
-            f"{project_id}.{dataset_id}.observation_ext",
-            f"{project_id}.{cls.cope_dataset_id}.{COPE_SURVEY_MAP}"
+            f"{cls.project_id}.{dataset_id}.observation",
+            f"{cls.project_id}.{dataset_id}.observation_ext",
+            f"{cls.project_id}.{cls.cope_dataset_id}.{COPE_SURVEY_MAP}"
         ]
 
         cls.dataset_id = dataset_id
         cls.sandbox_id = sandbox_id
 
-        cls.fq_questionnaire_tablename = f'{project_id}.{cls.deid_questionnaire_response_map_dataset}._deid_questionnaire_response_map'
+        cls.fq_questionnaire_tablename = f'{cls.project_id}.{cls.deid_questionnaire_response_map_dataset}._deid_questionnaire_response_map'
         # call super to set up the client, create datasets, and create
         # empty test tables
         # NOTE:  does not create empty sandbox tables.

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
@@ -9,7 +9,7 @@ import os
 
 # Project imports
 from app_identity import PROJECT_ID
-from cdr_cleaner.manual_cleaning_rules.survey_version_info import (
+from cdr_cleaner.cleaning_rules.deid.survey_version_info import (
     COPESurveyVersionTask)
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -14,7 +14,7 @@ from common import EXT_SUFFIX, JINJA_ENV, QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
 INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
-    INSERT INTO `{{project}}.{{dataset}}.survey_conduct_ext` 
+    INSERT INTO `{{project}}.{{dataset}}.survey_conduct_ext`
         (survey_conduct_id, src_id, language)
     VALUES
         (11, 'pi/pm', NULL),
@@ -24,7 +24,7 @@ INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
 """)
 
 INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
-    INSERT INTO `{{project}}.{{dataset}}.questionnaire_response_additional_info` 
+    INSERT INTO `{{project}}.{{dataset}}.questionnaire_response_additional_info`
         (questionnaire_response_id, type, value)
     VALUES
         (11, 'LANGUAGE', 'en'),
@@ -54,12 +54,7 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
         cls.rule_instance = PopulateSurveyConductExt(cls.project_id,
                                                      cls.dataset_id, sandbox_id)
 
-        sb_table_name = cls.rule_instance.sandbox_table_for(
-            f"{SURVEY_CONDUCT}{EXT_SUFFIX}")
-
-        cls.fq_sandbox_table_names = [
-            f'{cls.project_id}.{cls.sandbox_id}.{sb_table_name}'
-        ]
+        cls.fq_sandbox_table_names = []
 
         cls.fq_table_names = [
             f'{cls.project_id}.{cls.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
@@ -91,10 +86,10 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
             'fq_sandbox_table_name':
-                self.fq_sandbox_table_names[0],
+                '',
             'fields': ['survey_conduct_id', 'src_id', 'language'],
             'loaded_ids': [11, 12, 13, 14],
-            'sandboxed_ids': [11, 12],
+            'sandboxed_ids': [],
             'cleaned_values': [
                 (11, 'pi/pm', 'en'),
                 (12, 'site foo', 'es'),


### PR DESCRIPTION
* shuffling the generation table creation, population, and remapping cleaning rules
* removes sandbox and delete queries (and their tests) specific to the survey_conduct table
* changes the survey_version_info query from a create or replace statement to an update statement
* updates tests impacted by the changes