### PR TITLE
[DC-2737] Update truncate fitbit cleaning rule test to accommodate new list of sandbox tables

### DIFF
--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/truncate_fitbit_data_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/truncate_fitbit_data_test.py
@@ -142,8 +142,10 @@ class TruncateFitbitDataTest(BaseTest.CleaningRulesTestBase):
         tables_and_counts = [{
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, common.ACTIVITY_SUMMARY]),
-            'fq_sandbox_table_name':
-                self.fq_sandbox_table_names[0],
+            'fq_sandbox_table_name': [
+                table for table in self.fq_sandbox_table_names
+                if common.ACTIVITY_SUMMARY in table
+            ][0],
             'fields': ['person_id', 'date'],
             'loaded_ids': [111, 222, 333, 444],
             'sandboxed_ids': [333, 444],
@@ -153,8 +155,10 @@ class TruncateFitbitDataTest(BaseTest.CleaningRulesTestBase):
             'fq_table_name':
                 '.'.join([self.fq_dataset_name,
                           common.HEART_RATE_MINUTE_LEVEL]),
-            'fq_sandbox_table_name':
-                self.fq_sandbox_table_names[2],
+            'fq_sandbox_table_name': [
+                table for table in self.fq_sandbox_table_names
+                if common.HEART_RATE_MINUTE_LEVEL in table
+            ][0],
             'fields': ['person_id', 'datetime'],
             'loaded_ids': [111, 222, 333, 444],
             'sandboxed_ids': [333, 444],
@@ -163,8 +167,10 @@ class TruncateFitbitDataTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, common.HEART_RATE_SUMMARY]),
-            'fq_sandbox_table_name':
-                self.fq_sandbox_table_names[1],
+            'fq_sandbox_table_name': [
+                table for table in self.fq_sandbox_table_names
+                if common.HEART_RATE_SUMMARY in table
+            ][0],
             'fields': ['person_id', 'date'],
             'loaded_ids': [111, 222, 333, 444],
             'sandboxed_ids': [333, 444],
@@ -173,8 +179,10 @@ class TruncateFitbitDataTest(BaseTest.CleaningRulesTestBase):
         }, {
             'fq_table_name':
                 '.'.join([self.fq_dataset_name, common.STEPS_INTRADAY]),
-            'fq_sandbox_table_name':
-                self.fq_sandbox_table_names[3],
+            'fq_sandbox_table_name': [
+                table for table in self.fq_sandbox_table_names
+                if common.STEPS_INTRADAY in table
+            ][0],
             'fields': ['person_id', 'datetime'],
             'loaded_ids': [111, 222, 333, 444],
             'sandboxed_ids': [333, 444],


### PR DESCRIPTION
- [DC-2731](https://github.com/all-of-us/curation/pull/1412/files) updated the values in `FITBIT_DATE_TABLES`. This change added a few new sandbox tables to the cleaning rule.
- The integration test failed because it used positional arguments for specifying `fq_sandbox_table_name`. The newly added sandbox tables changed the positions in the list.
- This PR updates the logic so that the test uses the correct `fq_sandbox_table_name` regardless of the position of the sandbox table in the list.