### PR TITLE
[DC-2776] Serialize CircleCi nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,18 @@ orbs:
   slack: circleci/slack@3.4.2
 
 job_defaults: &job_defaults
-    machine:
-      image: ubuntu-2004:202107-02
-      docker_layer_caching: true
-    parallelism: 1
-    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
-    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
-    environment:
-      - CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      - GSDK_VERSION: 360.0.0
-      - GSDK_CHECKSUM: 6192cb2791f592da6d372888dbd7ee81d3d91f255d844ab5fc518fc97e453648
-      - CIRCLECI_CLI_VERSION: "0.1.15973"
-      - CIRCLECI_CLI_CHECKSUM: "4187a5245f06dd8e1d51d5a99ad40ed9e8963397cecf006fd2d6a04ac374bef6"
+  machine:
+    image: ubuntu-2004:202107-02
+    docker_layer_caching: true
+  parallelism: 1
+  # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+  # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+  environment:
+    - CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+    - GSDK_VERSION: 360.0.0
+    - GSDK_CHECKSUM: 6192cb2791f592da6d372888dbd7ee81d3d91f255d844ab5fc518fc97e453648
+    - CIRCLECI_CLI_VERSION: "0.1.15973"
+    - CIRCLECI_CLI_CHECKSUM: "4187a5245f06dd8e1d51d5a99ad40ed9e8963397cecf006fd2d6a04ac374bef6"
 
 commands:
   # Define reusable sets of steps to be run within the testing jobs.
@@ -150,5 +150,9 @@ workflows:
               only: develop
     jobs:
       - integration_test
-      - delete_stale_test_datasets
-      - delete_stale_test_buckets
+      - delete_stale_test_datasets:
+          requires:
+            - integration_test
+      - delete_stale_test_buckets:
+          requires:
+            - delete_stale_test_datasets


### PR DESCRIPTION
- Yapf corrected the indentation line 9-20. I confirmed that the `.yml` file works with no problem with the updated indentation. Please see the comment section of the JIRA ticket DC-2776.