### PR TITLE
[DC-2904] Update retraction scripts for EHR, RDR, and UNIONED EHR datasets

### DIFF
--- a/data_steward/common.py
+++ b/data_steward/common.py
@@ -233,6 +233,7 @@ RDR = 'rdr'
 RELEASE = 'release'
 FITBIT = 'fitbit'
 OTHER = 'other'
+SANDBOX = 'sandbox'
 
 MAPPING = 'mapping'
 MAPPING_PREFIX = '_mapping_'

--- a/data_steward/retraction/retract_data_bq.py
+++ b/data_steward/retraction/retract_data_bq.py
@@ -7,6 +7,7 @@ Retraction is performed for each dataset based on its data stage.
 # Python imports
 import argparse
 import logging
+from itertools import product
 
 # Third party imports
 
@@ -14,42 +15,29 @@ import logging
 from utils import pipeline_logging
 from gcloud.bq import BigQueryClient
 from common import (CARE_SITE, CATI_TABLES, DEATH, FACT_RELATIONSHIP, JINJA_ENV,
-                    LOCATION, OBSERVATION_PERIOD, PERSON, PII_TABLES, PROVIDER)
+                    LOCATION, OBSERVATION_PERIOD, PERSON, PII_TABLES, PROVIDER,
+                    UNIONED_EHR)
 from resources import mapping_table_for
-from retraction import retract_utils as ru
+from retraction.retract_utils import (get_datasets_list, is_combined_dataset,
+                                      is_deid_dataset, is_ehr_dataset,
+                                      is_fitbit_dataset, is_rdr_dataset,
+                                      is_unioned_dataset)
 
 LOGGER = logging.getLogger(__name__)
 
-UNIONED_EHR = 'unioned_ehr_'
-SITE = 'site'
-UNIONED = 'unioned'
-
 PERSON_ID = 'person_id'
 RESEARCH_ID = 'research_id'
-
 RETRACTION_RDR_EHR = 'rdr_and_ehr'
 RETRACTION_ONLY_EHR = 'only_ehr'
-
 NONE_STR = 'none'
 
 NON_PID_TABLES = [CARE_SITE, LOCATION, FACT_RELATIONSHIP, PROVIDER]
 OTHER_PID_TABLES = [OBSERVATION_PERIOD]
 
-# person from RDR should not be removed, but person from EHR must be
 NON_EHR_TABLES = [PERSON]
 TABLES_FOR_RETRACTION = set(PII_TABLES + CATI_TABLES +
                             OTHER_PID_TABLES) - set(NON_PID_TABLES +
                                                     NON_EHR_TABLES)
-
-ONLY_EHR_CONDITION = """
-AND {{table}}_id IN (
-{% if is_deid %}
-    SELECT {{table}}_id FROM `{{project}}.{{dataset}}.{{table}}_ext` WHERE src_id LIKE 'EHR%'
-{% else %}
-    SELECT {{table}}_id FROM `{{project}}.{{dataset}}._mapping_{{table}}` WHERE src_hpo_id != 'rdr'
-{% endif %}
-)
-"""
 
 RETRACT_QUERY = """
 {% if sandbox %}
@@ -61,7 +49,14 @@ FROM `{{project}}.{{dataset}}.{{table}}`
 WHERE person_id IN (
     SELECT {{person_id}} FROM `{{project}}.{{sb_dataset}}.{{lookup_table_id}}`
 )
-{% if only_ehr_condition is defined %}{{only_ehr_condition}}
+{% if table != 'death' and retraction_type == 'only_ehr' %}
+AND {{table}}_id IN (
+    {% if is_deid %}
+    SELECT {{table}}_id FROM `{{project}}.{{dataset}}.{{table}}_ext` WHERE src_id LIKE 'EHR%'
+    {% else %}
+    SELECT {{table}}_id FROM `{{project}}.{{dataset}}._mapping_{{table}}` WHERE src_hpo_id != 'rdr'
+    {% endif %}
+)
 {% endif %}
 """
 
@@ -71,7 +66,7 @@ CREATE TABLE `{{project}}.{{sb_dataset}}.{{sb_table}}` AS SELECT *
 {% else %}
 DELETE
 {% endif %}
-FROM `{{project}}.{{dataset}}.fact_relationship`
+FROM `{{project}}.{{dataset}}.{{table}}`
 WHERE
   (
     domain_concept_id_1 = 56
@@ -91,14 +86,14 @@ OR
 RETRACT_QUERY_FACT_RELATIONSHIP_ONLY_EHR = """
 {% if sandbox %}
 CREATE TABLE `{{project}}.{{sb_dataset}}.{{sb_table}}` AS SELECT f.*
-FROM `{{project}}.{{dataset}}.fact_relationship` f
+FROM `{{project}}.{{dataset}}.{{table}}` f
 INNER JOIN (
 {% else %}
-MERGE `{{project}}.{{dataset}}.fact_relationship` f
+MERGE `{{project}}.{{dataset}}.{{table}}` f
 USING(
 {% endif %}
     SELECT fr.*
-    FROM `{{project}}.{{dataset}}.fact_relationship` fr
+    FROM `{{project}}.{{dataset}}.{{table}}` fr
     LEFT JOIN (
     SELECT mp.*
     FROM `{{project}}.{{dataset}}._mapping_measurement` mp
@@ -159,113 +154,13 @@ WHEN MATCHED THEN delete
 """
 
 
-def get_site_table(hpo_id, table):
-    """
-    Return hpo table for site
-    :param hpo_id: identifies the hpo site as str
-    :param table: identifies the cdm table as str
-    :return: cdm table name for the site as str
-    """
-    return f'{hpo_id}_{table}'
-
-
-def get_table_id(table):
-    """
-    Returns primary key for the CDM table
-    :param table: CDM table as str
-    :return: primary key as str
-    """
-    return f'{PERSON}_id' if table == DEATH else f'{table}_id'
-
-
-def get_retraction_queries_for_ehr_dataset(client, dataset_id, sb_dataset_id,
-                                           hpo_id, person_id_query,
-                                           skip_sandboxing):
-    """
-    Get list of queries to remove all records in all tables associated with supplied ids
-    :param client: a BigQueryClient
-    :param dataset_id: identifies associated dataset
-    :param sb_dataset_id: identifies sandbox dataset when skip_sandboxing==False
-    :param hpo_id: identifies the HPO site
-    :param person_id_query: query to select person_ids to retract
-    :param skip_sandboxing: True if you wish not to sandbox the retracted data.
-    :return: list of queries to run
-    
-    # TODO this function is tested yet since it's for EHR dataset.
-    """
-    LOGGER.info(f'Checking existing tables for {client.project}.{dataset_id}')
-    existing_tables = [
-        table.table_id
-        for table in client.list_tables(f'{client.project}.{dataset_id}')
-    ]
-    queries = {SITE: [], UNIONED: []}
-    tables_to_retract = TABLES_FOR_RETRACTION | set(NON_EHR_TABLES)
-    for table in tables_to_retract:
-        table_names = {
-            SITE: get_site_table(hpo_id, table),
-            UNIONED: UNIONED_EHR + table
-        }
-        for table_type in [SITE, UNIONED]:
-            if table_names[table_type] in existing_tables:
-                if not skip_sandboxing:
-                    q_sandbox = JINJA_ENV.from_string(RETRACT_QUERY).render(
-                        project=client.project,
-                        dataset=dataset_id,
-                        table=table_names[table_type],
-                        person_id_query=person_id_query,
-                        sandbox=True,
-                        sb_dataset=sb_dataset_id,
-                        sb_table=
-                        f'retract_{dataset_id}_{table_names[table_type]}')
-                    queries[table_type].append(q_sandbox)
-
-                q_site = JINJA_ENV.from_string(RETRACT_QUERY).render(
-                    project=client.project,
-                    dataset=dataset_id,
-                    sb_dataset=sb_dataset_id,
-                    table=table_names[table_type],
-                    person_id_query=person_id_query)
-                queries[table_type].append(q_site)
-
-    # Remove fact_relationship records referencing retracted person_ids
-    fact_rel_table_names = {
-        SITE: get_site_table(hpo_id, FACT_RELATIONSHIP),
-        UNIONED: UNIONED_EHR + FACT_RELATIONSHIP
-    }
-    for table_type in [SITE, UNIONED]:
-        if fact_rel_table_names[table_type] in existing_tables:
-            if not skip_sandboxing:
-                q_sandbox_fact_relationship = JINJA_ENV.from_string(
-                    RETRACT_QUERY_FACT_RELATIONSHIP
-                ).render(
-                    project=client.project,
-                    dataset=dataset_id,
-                    table=fact_rel_table_names[table_type],
-                    person_id_query=person_id_query,
-                    sandbox=True,
-                    sb_dataset=sb_dataset_id,
-                    sb_table=
-                    f'retract_{dataset_id}_{fact_rel_table_names[table_type]}')
-
-                queries[table_type].append(q_sandbox_fact_relationship)
-
-            q_site_fact_relationship = JINJA_ENV.from_string(
-                RETRACT_QUERY_FACT_RELATIONSHIP).render(
-                    project=client.project,
-                    dataset=dataset_id,
-                    table=fact_rel_table_names[table_type],
-                    person_id_query=person_id_query)
-            queries[table_type].append(q_site_fact_relationship)
-
-    return queries[UNIONED] + queries[SITE]
-
-
 def get_retraction_queries(client: BigQueryClient,
                            dataset_id,
                            sb_dataset_id,
                            lookup_table_id,
                            skip_sandboxing,
-                           retraction_type=None) -> list:
+                           retraction_type=None,
+                           hpo_id=None) -> list:
     """
     Gets list of queries for retraction.
     :param client: BigQuery client
@@ -277,59 +172,37 @@ def get_retraction_queries(client: BigQueryClient,
         or if RDR data needs to be kept intact. Can take the values 'rdr_and_ehr' or 'only_ehr'
     :return: list of queries
     """
-    LOGGER.info(f'Checking existing tables for {client.project}.{dataset_id}')
-    existing_tables = [
-        table.table_id
-        for table in client.list_tables(f'{client.project}.{dataset_id}')
-    ]
-    tables_to_retract = [
-        table for table in existing_tables
-        if any(col.name == 'person_id' for col in client.get_table(
-            f'{client.project}.{dataset_id}.{table}').schema)
-    ]
+    tables_to_retract = get_tables_to_retract(client,
+                                              dataset_id,
+                                              retraction_type=retraction_type,
+                                              hpo_id=hpo_id)
+
     LOGGER.info(
         f"Tables to retract in {dataset_id}:\n"
         f"Tables with person_id column... {', '.join(tables_to_retract)}\n"
-        f"If it's a non-deid dataset, {FACT_RELATIONSHIP} will be retracted too.\n"
+        f"If it's a non-deid dataset, {FACT_RELATIONSHIP} will be retracted too."
     )
 
-    person_id = RESEARCH_ID if ru.is_deid_dataset(dataset_id) else PERSON_ID
+    person_id = RESEARCH_ID if is_deid_dataset(dataset_id) else PERSON_ID
 
     queries = []
 
     for table in tables_to_retract:
-
-        if skip_retraction(client, dataset_id, table, retraction_type):
-            continue
-
-        only_ehr_condition = get_only_ehr_condition(
-            client, dataset_id,
-            table) if retraction_type == RETRACTION_ONLY_EHR else ''
-
-        if not skip_sandboxing:
-            q_sandbox = JINJA_ENV.from_string(RETRACT_QUERY).render(
-                sandbox=True,
-                sb_table=f'retract_{dataset_id}_{table}',
+        for create_sandbox in [False] if skip_sandboxing else [True, False]:
+            q = JINJA_ENV.from_string(RETRACT_QUERY).render(
+                sandbox=create_sandbox,
                 project=client.project,
+                sb_dataset=sb_dataset_id,
+                sb_table=f'retract_{dataset_id}_{table}',
                 dataset=dataset_id,
                 table=table,
                 person_id=person_id,
-                only_ehr_condition=only_ehr_condition,
-                sb_dataset=sb_dataset_id,
-                lookup_table_id=lookup_table_id)
-            queries.append(q_sandbox)
-        q_dataset = JINJA_ENV.from_string(RETRACT_QUERY).render(
-            project=client.project,
-            dataset=dataset_id,
-            table=table,
-            person_id=person_id,
-            only_ehr_condition=only_ehr_condition,
-            sb_dataset=sb_dataset_id,
-            lookup_table_id=lookup_table_id)
-        queries.append(q_dataset)
+                lookup_table_id=lookup_table_id,
+                retraction_type=retraction_type,
+                is_deid=is_deid_dataset(dataset_id))
+            queries.append(q)
 
-    if not ru.is_deid_dataset(dataset_id) and not ru.is_fitbit_dataset(
-            dataset_id):
+    if not is_deid_dataset(dataset_id) and not is_fitbit_dataset(dataset_id):
         queries.extend(
             get_retraction_queries_fact_relationship(client, dataset_id,
                                                      sb_dataset_id,
@@ -345,7 +218,8 @@ def get_retraction_queries_fact_relationship(client: BigQueryClient,
                                              sb_dataset_id,
                                              lookup_table_id,
                                              skip_sandboxing,
-                                             retraction_type=None) -> list:
+                                             retraction_type=None,
+                                             hpo_id=None) -> list:
     """
     Get list of queries for retracting fact_relationship table.
 
@@ -365,52 +239,73 @@ def get_retraction_queries_fact_relationship(client: BigQueryClient,
     queries = []
     sb_table = f'retract_{dataset_id}_{FACT_RELATIONSHIP}'
 
-    person_id = RESEARCH_ID if ru.is_deid_dataset(dataset_id) else PERSON_ID
+    tables = [
+        f'{hpo_id}_{FACT_RELATIONSHIP}', f"{UNIONED_EHR}_{FACT_RELATIONSHIP}"
+    ] if is_ehr_dataset(dataset_id) else [FACT_RELATIONSHIP]
 
-    if retraction_type == RETRACTION_ONLY_EHR:
-        if not skip_sandboxing:
-            q_sandbox = JINJA_ENV.from_string(
-                RETRACT_QUERY_FACT_RELATIONSHIP_ONLY_EHR).render(
-                    sandbox=True,
-                    project=client.project,
-                    dataset=dataset_id,
-                    lookup_table_id=lookup_table_id,
-                    person_id=person_id,
-                    sb_dataset=sb_dataset_id,
-                    sb_table=sb_table)
-            queries.append(q_sandbox)
-        q_fact_relationship = JINJA_ENV.from_string(
-            RETRACT_QUERY_FACT_RELATIONSHIP_ONLY_EHR).render(
-                project=client.project,
-                dataset=dataset_id,
-                lookup_table_id=lookup_table_id,
-                person_id=person_id,
-                sb_dataset=sb_dataset_id,
-                sb_table=sb_table)
-        queries.append(q_fact_relationship)
+    person_id = RESEARCH_ID if is_deid_dataset(dataset_id) else PERSON_ID
 
-    else:
-        if not skip_sandboxing:
-            q_sandbox = JINJA_ENV.from_string(
-                RETRACT_QUERY_FACT_RELATIONSHIP).render(
-                    project=client.project,
-                    dataset=dataset_id,
-                    person_id=person_id,
-                    lookup_table_id=lookup_table_id,
-                    sandbox=True,
-                    sb_dataset=sb_dataset_id,
-                    sb_table=sb_table)
-            queries.append(q_sandbox)
-        q_fact_relationship = JINJA_ENV.from_string(
-            RETRACT_QUERY_FACT_RELATIONSHIP).render(
-                project=client.project,
-                dataset=dataset_id,
-                person_id=person_id,
-                sb_dataset=sb_dataset_id,
-                lookup_table_id=lookup_table_id)
-        queries.append(q_fact_relationship)
+    for table in tables:
+
+        if retraction_type == RETRACTION_ONLY_EHR:
+            for create_sandbox in [False] if skip_sandboxing else [True, False]:
+                q = JINJA_ENV.from_string(
+                    RETRACT_QUERY_FACT_RELATIONSHIP_ONLY_EHR).render(
+                        sandbox=create_sandbox,
+                        sb_dataset=sb_dataset_id,
+                        sb_table=sb_table,
+                        project=client.project,
+                        dataset=dataset_id,
+                        lookup_table_id=lookup_table_id,
+                        person_id=person_id,
+                        table=table)
+                queries.append(q)
+
+        else:
+            for create_sandbox in [False] if skip_sandboxing else [True, False]:
+                q = JINJA_ENV.from_string(
+                    RETRACT_QUERY_FACT_RELATIONSHIP).render(
+                        sandbox=create_sandbox,
+                        sb_dataset=sb_dataset_id,
+                        sb_table=sb_table,
+                        dataset=dataset_id,
+                        person_id=person_id,
+                        lookup_table_id=lookup_table_id,
+                        table=table)
+                queries.append(q)
 
     return queries
+
+
+def get_tables_to_retract(client: BigQueryClient,
+                          dataset_id,
+                          hpo_id='',
+                          retraction_type=None) -> list:
+    tables_to_retract = []
+
+    if is_ehr_dataset(dataset_id):
+        tables_to_retract = [
+            f'{prefix}_{table}' for prefix, table in
+            product([hpo_id, UNIONED_EHR], TABLES_FOR_RETRACTION |
+                    set(NON_EHR_TABLES))
+            if client.table_exists(f'{prefix}_{table}', dataset_id)
+        ]
+
+    else:
+        LOGGER.info(
+            f'Checking existing tables for {client.project}.{dataset_id}')
+        existing_tables = [
+            table.table_id
+            for table in client.list_tables(f'{client.project}.{dataset_id}')
+        ]
+        tables_to_retract = [
+            table for table in existing_tables
+            if any(col.name == 'person_id' for col in client.get_table(
+                f'{client.project}.{dataset_id}.{table}').schema) and
+            not skip_retraction(client, dataset_id, table, retraction_type)
+        ]
+
+    return tables_to_retract
 
 
 def skip_retraction(client, dataset_id, table_id, retraction_type) -> bool:
@@ -439,34 +334,16 @@ def skip_retraction(client, dataset_id, table_id, retraction_type) -> bool:
         elif table_id == PERSON:
             LOGGER.info(msg_only_rdr)
             return True
-        elif ru.is_deid_dataset(dataset_id) and not client.table_exists(
+        elif is_deid_dataset(dataset_id) and not client.table_exists(
                 f'{table_id}_ext', dataset_id):
             LOGGER.info(msg_no_mapping_table)
             return True
-        elif ru.is_combined_dataset(dataset_id) and not client.table_exists(
+        elif is_combined_dataset(dataset_id) and not client.table_exists(
                 mapping_table_for(table_id), dataset_id):
             LOGGER.info(msg_no_mapping_table)
             return True
 
     return False
-
-
-def get_only_ehr_condition(client: BigQueryClient, dataset_id, table_id) -> str:
-    """
-    Generates WHERE clause for only_ehr retraction.
-    :param client: BigQuery client
-    :param dataset_id: dataset to run retraction for
-    :param table_id: table to run retraction for
-    :return: WHERE clause in str format to be added when only_ehr
-    """
-    if table_id == DEATH:
-        return ''
-
-    return JINJA_ENV.from_string(ONLY_EHR_CONDITION).render(
-        project=client.project,
-        dataset=dataset_id,
-        table=table_id,
-        is_deid=ru.is_deid_dataset(dataset_id))
 
 
 def retraction_query_runner(client: BigQueryClient, queries):
@@ -513,30 +390,33 @@ def run_bq_retraction(project_id,
     """
     client = bq_client if bq_client else BigQueryClient(project_id)
 
-    dataset_ids = ru.get_datasets_list(client, dataset_list)
-    queries = []
+    dataset_ids = get_datasets_list(client, dataset_list)
     for dataset in dataset_ids:
 
-        if ru.is_ehr_dataset(dataset) and hpo_id == NONE_STR:
-            # TODO this part is not tested yet
-            LOGGER.info(
-                f'"RETRACTION_HPO_ID" set to "{NONE_STR}", skipping retraction from {dataset}'
+        if is_ehr_dataset(dataset) and (hpo_id == NONE_STR or not hpo_id):
+            raise ValueError(
+                f'hpo_id is not specified. hpo_id must be defined when retracting from an EHR dataset.'
             )
-        elif ru.is_ehr_dataset(dataset):
-            # TODO this part is not tested yet
-            queries = get_retraction_queries_for_ehr_dataset(
-                client, dataset, sandbox_dataset_id, hpo_id, lookup_table_id,
-                skip_sandboxing)
-        else:
-            # TODO test for Unioned dataset
-            queries = get_retraction_queries(
-                client,
-                dataset,
-                sandbox_dataset_id,
-                lookup_table_id,
-                skip_sandboxing,
-                retraction_type=None
-                if ru.is_unioned_dataset(dataset) else retraction_type)
+
+        if is_rdr_dataset(dataset) and retraction_type == RETRACTION_ONLY_EHR:
+            raise ValueError(
+                f'Cannot run retraction for RDR dataset when {RETRACTION_ONLY_EHR} is specified.'
+            )
+
+        # Argument hpo_id is effective for only EHR dataset.
+        hpo_id = hpo_id if is_ehr_dataset(dataset) else ''
+
+        # retraction type should be none for ehr and unioned_ehr datasets
+        retraction_type = None if is_ehr_dataset(dataset) or is_unioned_dataset(
+            dataset) else retraction_type
+
+        queries = get_retraction_queries(client,
+                                         dataset,
+                                         sandbox_dataset_id,
+                                         lookup_table_id,
+                                         skip_sandboxing,
+                                         retraction_type=retraction_type,
+                                         hpo_id=hpo_id)
 
         LOGGER.info(f"Started retracting from dataset {dataset}")
         retraction_query_runner(client, queries)
@@ -582,7 +462,7 @@ if __name__ == '__main__':
                         action='store',
                         dest='hpo_id',
                         help='Identifies the site to retract data from',
-                        required=True)
+                        required=False)
     parser.add_argument(
         '-d',
         '--dataset_ids',

--- a/data_steward/retraction/retract_data_bq.py
+++ b/data_steward/retraction/retract_data_bq.py
@@ -21,7 +21,8 @@ from resources import mapping_table_for
 from retraction.retract_utils import (get_datasets_list, get_dataset_type,
                                       is_combined_dataset, is_deid_dataset,
                                       is_ehr_dataset, is_fitbit_dataset,
-                                      is_rdr_dataset, is_unioned_dataset)
+                                      is_rdr_dataset, is_sandbox_dataset,
+                                      is_unioned_dataset)
 from constants.retraction.retract_utils import (NONE, PERSON_ID, RESEARCH_ID)
 
 LOGGER = logging.getLogger(__name__)
@@ -200,7 +201,8 @@ def get_retraction_queries(client: BigQueryClient,
                 is_deid=is_deid_dataset(dataset_id))
             queries.append(q)
 
-    if not is_deid_dataset(dataset_id) and not is_fitbit_dataset(dataset_id):
+    if not is_deid_dataset(dataset_id) and not is_fitbit_dataset(
+            dataset_id) and not is_sandbox_dataset(dataset_id):
         queries.extend(
             get_retraction_queries_fact_relationship(client, dataset_id,
                                                      sb_dataset_id,
@@ -379,7 +381,7 @@ def skip_dataset_retraction(dataset_id, hpo_id, retraction_type) -> bool:
             LOGGER.warning(f'{msg_skip}{msg_no_ehr}')
             return True
 
-        if get_dataset_type(dataset_id) == OTHER:
+        if get_dataset_type(dataset_id) == OTHER or is_sandbox_dataset(dataset_id):
             LOGGER.warning(f'{msg_skip}{msg_no_mapping}')
             return True
 

--- a/data_steward/retraction/retract_data_bq.py
+++ b/data_steward/retraction/retract_data_bq.py
@@ -187,11 +187,12 @@ def get_retraction_queries(client: BigQueryClient,
     )
 
     person_id = RESEARCH_ID if is_deid_dataset(dataset_id) else PERSON_ID
+    action_list = ['delete'] if skip_sandboxing else ['sandbox', 'delete']
 
     queries = []
 
     for table in tables_to_retract:
-        for action in ['delete'] if skip_sandboxing else ['sandbox', 'delete']:
+        for action in action_list:
             q = JINJA_ENV.from_string(RETRACT_QUERY).render(
                 sandbox=action == 'sandbox',
                 project=client.project,

--- a/data_steward/retraction/retract_data_bq.py
+++ b/data_steward/retraction/retract_data_bq.py
@@ -407,6 +407,12 @@ def run_bq_retraction(project_id,
                 f'Cannot run retraction for RDR dataset when {RETRACTION_ONLY_EHR} is specified.'
             )
 
+        if is_fitbit_dataset(
+                dataset) and retraction_type == RETRACTION_ONLY_EHR:
+            raise ValueError(
+                f'Cannot run retraction for FITBIT dataset when {RETRACTION_ONLY_EHR} is specified.'
+            )
+
         # Argument hpo_id is effective for only EHR dataset.
         hpo_id = hpo_id if is_ehr_dataset(dataset) else ''
 

--- a/data_steward/retraction/retract_data_bq.py
+++ b/data_steward/retraction/retract_data_bq.py
@@ -376,12 +376,11 @@ def skip_table_retraction(client: BigQueryClient, dataset_id, table_id,
     return False
 
 
-def skip_dataset_retraction(dataset_id, hpo_id, retraction_type) -> bool:
+def skip_dataset_retraction(dataset_id, retraction_type) -> bool:
     """
     Some datasets do not need retraction depending on how we want to retract.
     This function returns True if the dataset does not need retraction.
     :param dataset_id: dataset to run retraction for
-    :param hpo_id: hpo_id of the site to retract from
     :param retraction_type: string indicating whether all data needs to be removed including RDR,
         or if RDR data needs to be kept intact. Can take the values 'rdr_and_ehr' or 'only_ehr'
     :return: True if the dataset should be skipped. False if we need to retract the dataset.
@@ -457,7 +456,7 @@ def run_bq_retraction(project_id,
 
     for dataset in dataset_ids:
 
-        if skip_dataset_retraction(dataset, hpo_id, retraction_type):
+        if skip_dataset_retraction(dataset, retraction_type):
             continue
 
         # Argument hpo_id is effective for only EHR dataset.

--- a/data_steward/retraction/retract_data_bq.py
+++ b/data_steward/retraction/retract_data_bq.py
@@ -381,7 +381,8 @@ def skip_dataset_retraction(dataset_id, hpo_id, retraction_type) -> bool:
             LOGGER.warning(f'{msg_skip}{msg_no_ehr}')
             return True
 
-        if get_dataset_type(dataset_id) == OTHER or is_sandbox_dataset(dataset_id):
+        if get_dataset_type(dataset_id) == OTHER or is_sandbox_dataset(
+                dataset_id):
             LOGGER.warning(f'{msg_skip}{msg_no_mapping}')
             return True
 

--- a/data_steward/retraction/retract_data_gcs.py
+++ b/data_steward/retraction/retract_data_gcs.py
@@ -311,16 +311,7 @@ if __name__ == '__main__':
         action='store_true',
         help='Optional. Indicates pids must be retracted without user prompts',
         required=False)
-    parser.add_argument('-l',
-                        '--console_log',
-                        dest='console_log',
-                        action='store_true',
-                        required=False,
-                        help='Log to the console as well as to a file.')
     args = parser.parse_args()
-
-    pipeline_logging.configure(level=logging.INFO,
-                               add_console_handler=args.console_log)
 
     run_gcs_retraction(args.project_id, args.sandbox_dataset_id,
                        args.pid_table_id, args.hpo_id, args.folder_name,

--- a/data_steward/retraction/retract_data_gcs.py
+++ b/data_steward/retraction/retract_data_gcs.py
@@ -311,8 +311,16 @@ if __name__ == '__main__':
         action='store_true',
         help='Optional. Indicates pids must be retracted without user prompts',
         required=False)
-
+    parser.add_argument('-l',
+                        '--console_log',
+                        dest='console_log',
+                        action='store_true',
+                        required=False,
+                        help='Log to the console as well as to a file.')
     args = parser.parse_args()
+
+    pipeline_logging.configure(level=logging.INFO,
+                               add_console_handler=args.console_log)
 
     run_gcs_retraction(args.project_id, args.sandbox_dataset_id,
                        args.pid_table_id, args.hpo_id, args.folder_name,

--- a/data_steward/retraction/retract_data_gcs.py
+++ b/data_steward/retraction/retract_data_gcs.py
@@ -258,7 +258,7 @@ def extract_pids_from_table(project_id, sandbox_dataset_id, pid_table_id):
 
 
 if __name__ == '__main__':
-    pipeline_logging.configure(logging.DEBUG, add_console_handler=True)
+    pipeline_logging.configure(logging.INFO, add_console_handler=True)
 
     parser = argparse.ArgumentParser(
         description=

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -101,8 +101,8 @@ def get_datasets_list(client, dataset_ids_list):
     elif dataset_ids_list == [consts.ALL_DATASETS]:
         dataset_ids = all_dataset_ids
         LOGGER.info(
-            f"All datasets are specified. Setting dataset_ids to all datasets in project: {client.project}\n"
-            f"Found datasets to retract from: {', '.join(dataset_ids)}")
+            f"All datasets are specified. Setting dataset_ids to all datasets in project: {client.project}."
+        )
     else:
         # only consider datasets that exist in the project
         dataset_ids = [
@@ -119,6 +119,8 @@ def get_datasets_list(client, dataset_ids_list):
         if get_dataset_type(dataset_id) != OTHER and
         not is_sandbox_dataset(dataset_id)
     ]
+
+    LOGGER.info(f"Found datasets to retract from: {', '.join(dataset_ids)}")
 
     return dataset_ids
 

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -85,6 +85,9 @@ def get_datasets_list(client, dataset_ids_list):
     :param dataset_ids_list: list of datasets to retract from. If set to 'all_datasets',
         retracts from all datasets. If set to 'none', skips retraction from BigQuery datasets
     :return: List of dataset_ids to retract from
+
+    NOTE sandbox datasets and OTHER datasets are excluded from retraction
+
     """
     all_dataset_ids = [
         dataset.dataset_id for dataset in list(client.list_datasets())
@@ -109,6 +112,13 @@ def get_datasets_list(client, dataset_ids_list):
         LOGGER.info(
             f"Datasets specified and existing in project {client.project}: {dataset_ids}"
         )
+
+    # NOTE Excludes sandbox and OTHER datasets
+    dataset_ids = [
+        dataset_id for dataset_id in dataset_ids
+        if get_dataset_type(dataset_id) != OTHER and
+        not is_sandbox_dataset(dataset_id)
+    ]
 
     return dataset_ids
 

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -13,12 +13,8 @@ from constants.utils import bq as bq_consts
 LOGGER = logging.getLogger(__name__)
 
 DEID_REGEX = re.compile(r'.*deid.*')
-RELEASE_REGEX = re.compile(r'R\d{4}Q\dR\d')
-RELEASE_TAG_REGEX = re.compile(r'\d{4}[qQ]\d[rR]\d')
 SANDBOX_REGEX = re.compile(r'.*sandbox.*')
 STAGING_REGEX = re.compile(r'.*staging.*')
-VOCABULARY_REGEX = re.compile(r'vocabulary.*')
-VALIDATION_REGEX = re.compile(r'validation.*')
 
 
 def get_table_id(table):
@@ -217,6 +213,15 @@ def is_ehr_dataset(dataset_id):
     :return: Boolean indicating if the dataset is an ehr dataset
     """
     return EHR in dataset_id and not UNIONED_EHR in dataset_id
+
+
+def is_rdr_dataset(dataset_id):
+    """
+    Returns boolean indicating if a dataset is a rdr dataset using the dataset_id
+    :param dataset_id: Identifies the dataset
+    :return: Boolean indicating if the dataset is an ehr dataset
+    """
+    return RDR in dataset_id
 
 
 def is_sandbox_dataset(dataset_id):

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -236,7 +236,7 @@ def is_sandbox_dataset(dataset_id):
 def is_staging_dataset(dataset_id):
     """
     # NOTE This function is not referenced anywhere.
-    
+
     Returns boolean indicating if a dataset is a staging dataset using the dataset_id
     :param dataset_id: Identifies the dataset
     :return: Boolean indicating if the dataset is a staging dataset

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -5,7 +5,7 @@ import logging
 
 # Project imports
 from common import (COMBINED, DEID, EHR, EXT, EXT_SUFFIX, FITBIT, MAPPING,
-                    MAPPING_PREFIX, OTHER, RDR, UNIONED_EHR)
+                    MAPPING_PREFIX, OTHER, RDR, SANDBOX, UNIONED_EHR)
 from gcloud.bq import BigQueryClient
 from constants.retraction import retract_utils as consts
 from constants.utils import bq as bq_consts
@@ -13,7 +13,6 @@ from constants.utils import bq as bq_consts
 LOGGER = logging.getLogger(__name__)
 
 DEID_REGEX = re.compile(r'.*deid.*')
-SANDBOX_REGEX = re.compile(r'.*sandbox.*')
 STAGING_REGEX = re.compile(r'.*staging.*')
 
 
@@ -225,7 +224,7 @@ def is_sandbox_dataset(dataset_id):
     :param dataset_id: Identifies the dataset
     :return: Boolean indicating if the dataset is a sandbox dataset
     """
-    return bool(re.match(SANDBOX_REGEX, dataset_id))
+    return SANDBOX in dataset_id
 
 
 def is_staging_dataset(dataset_id):

--- a/data_steward/retraction/run_retraction.py
+++ b/data_steward/retraction/run_retraction.py
@@ -16,8 +16,6 @@ You need to re-run the dataset creation script after source datasets are retract
     - [CT] antibody quest dataset
 
 Original Issues: DC-2801, DC-2865
-TODO: Improve code coverage for retracting with dataset_list = 'all_datasets'.
-    DC-2801 did not use 'all_datasets' option for retraction. This needs to be tested.
 """
 
 # Python imports

--- a/data_steward/retraction/run_retraction.py
+++ b/data_steward/retraction/run_retraction.py
@@ -15,15 +15,9 @@ You cannot use this script for retraction for the following datasets.
 You need to re-run the dataset creation script after source datasets are retracted:
     - [CT] antibody quest dataset
 
-Original Issues: DC-2801
-
-TODO: Improve code coverage for retracting RDR, EHR, and UNIONED_EHR datasets.
-    This script is initally created and used for DC-2801. RDR, EHR, and
-    UNIONED_EHR datasets are not in DC-2801's scope. Therefore, retraction for
-    RDR, EHR, and UNIONED_EHR is not fully tested.
-TODO: Improve code coverage for retracting with dataset_ids_list = 'all_datasets'.
-    For the same reason, DC-2801 did not use 'all_datasets' option for
-    retraction. This also needs to be tested.
+Original Issues: DC-2801, DC-2865
+TODO: Improve code coverage for retracting with dataset_list = 'all_datasets'.
+    DC-2801 did not use 'all_datasets' option for retraction. This needs to be tested.
 """
 
 # Python imports
@@ -212,8 +206,8 @@ def parse_args(raw_args=None):
         nargs='+',
         action='store',
         dest='source_datasets',
-        help=
-        'Datasets that need retraction. If there are more than one, seperate them by whitespaces.',
+        help=('Datasets that need retraction. If there are more than one, '
+              'seperate them by whitespaces.'),
         required=True)
     parser.add_argument(
         '--new_release_tag',
@@ -233,12 +227,16 @@ def parse_args(raw_args=None):
                         action='store_true',
                         required=False,
                         help='Log to the console as well as to a file.')
-    parser.add_argument('-i',
-                        '--hpo_id',
-                        action='store',
-                        dest='hpo_id',
-                        help='Identifies the site to retract data from.',
-                        required=True)
+    parser.add_argument(
+        '-i',
+        '--hpo_id',
+        action='store',
+        dest='hpo_id',
+        help=('Identifies the site to retract data from. '
+              'Specify this argument when retracting from EHR dataset. '
+              'This argument is effective only for EHR dataset. '
+              'For other datasets, it gets ignored.'),
+        required=False)
     parser.add_argument(
         '-r',
         '--retraction_type',

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -1035,7 +1035,6 @@ def union_ehr():
 @log_traceback
 def run_retraction_cron():
     project_id = bq_utils.app_identity.get_application_id()
-    output_project_id = bq_utils.get_output_project_id()
     hpo_id = bq_utils.get_retraction_hpo_id()
     retraction_type = bq_utils.get_retraction_type()
     pid_table_id = bq_utils.get_retraction_pid_table_id()
@@ -1045,15 +1044,11 @@ def run_retraction_cron():
     dataset_ids = bq_utils.get_retraction_dataset_ids()
     logging.info(f"Dataset id/s to target from env variable: {dataset_ids}")
     logging.info(f"Running retraction on BQ datasets")
-    if output_project_id:
-        # retract from output dataset
-        retract_data_bq.run_bq_retraction(output_project_id, sandbox_dataset_id,
-                                          project_id, pid_table_id, hpo_id,
-                                          dataset_ids, retraction_type)
+
     # retract from default dataset
     retract_data_bq.run_bq_retraction(project_id, sandbox_dataset_id,
-                                      project_id, pid_table_id, hpo_id,
-                                      dataset_ids, retraction_type)
+                                      pid_table_id, hpo_id, dataset_ids,
+                                      retraction_type)
     logging.info(f"Completed retraction on BQ datasets")
 
     # retract from gcs

--- a/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
@@ -692,7 +692,8 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                                         mock_is_sandbox):
         """
         Test for ehr dataset.
-        Retraction runs against all the tables with person_id inthe EHR dataset.
+        Retraction runs against all the tables with person_id in EHR dataset 
+        if hpo_id is none.
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
@@ -997,13 +998,15 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
 
     def test_retract_all(self):
         """
-        When ['all_datasets'] specified for dataset_list, BQ retraction runs against all the datasets.
+        When ['all_datasets'] specified for dataset_list, BQ retraction runs against all the datasets
+        excluding sandbox datasets and OTHER datasets.
+        TODO This exclusion rule might be revisited.
         """
         dataset_list = get_datasets_list(self.client, [ALL_DATASETS])
         self.assertTrue(
             set([
-                self.sandbox_id, self.rdr_id, self.ehr_id, self.unioned_ehr_id,
-                self.combined_id, self.deid_id, self.fitbit_id
+                self.rdr_id, self.ehr_id, self.unioned_ehr_id, self.combined_id,
+                self.deid_id, self.fitbit_id
             ]).issubset(dataset_list))
 
     def test_retract_none(self):

--- a/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
@@ -1,41 +1,95 @@
+"""
+detail will be added here
+"""
+
 # Python imports
 import os
-from io import open
-from unittest import TestCase, mock
-import logging
+from unittest import mock
 
 # Third party imports
-from google.cloud import bigquery
-import pandas as pd
 
 # Project imports
-import app_identity
-from common import JINJA_ENV
-from gcloud.bq import BigQueryClient
-from tests import test_util
+from app_identity import PROJECT_ID
+from common import (ACTIVITY_SUMMARY, JINJA_ENV, OBSERVATION, PERSON,
+                    UNIONED_EHR)
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+from retraction.retract_data_bq import (NONE_STR, RETRACTION_ONLY_EHR,
+                                        RETRACTION_RDR_EHR)
 from retraction import retract_data_bq as rbq
 
-TABLE_ROWS_QUERY = 'SELECT * FROM {dataset_id}.__TABLES__ '
+CREATE_LOOKUP_TMPL = JINJA_ENV.from_string("""
+CREATE TABLE `{{project}}.{{dataset}}.pid_rid_to_retract` 
+(person_id INT64, research_id INT64)
+""")
 
-EXPECTED_ROWS_QUERY = """
-SELECT COUNT(*) as count FROM {{dataset_id}}.{{table_id}}
-{% if retraction_type == 'only_ehr' and table_id.endswith('person') %}
--- person table does not need retraction when only_ehr --
-WHERE 0 = 1
-{% else %}
-WHERE person_id IN (
-    SELECT person_id FROM {{dataset_id}}.{{lookup_table_id}}
-)
-{% endif %}
-"""
+LOOKUP_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.pid_rid_to_retract` 
+(person_id, research_id)
+VALUES
+(2, 102), (4, 104)
+""")
 
-INSERT_PID_TABLE = """
-INSERT INTO {{dataset_id}}.{{lookup_table_id}} (person_id, research_id)
-VALUES {{person_research_ids}}
-"""
+PERSON_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.{{table}}` 
+(person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
+VALUES
+(1, 0, 2001, 0, 0), (2, 0, 2001, 0, 0), 
+(3, 0, 2001, 0, 0), (4, 0, 2001, 0, 0),
+(5, 0, 2001, 0, 0),
+(101, 0, 2001, 0, 0), (102, 0, 2001, 0, 0), 
+(103, 0, 2001, 0, 0), (104, 0, 2001, 0, 0),
+(105, 0, 2001, 0, 0)
+""")
+
+OBSERVATION_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.{{table}}` 
+(observation_id, person_id, observation_concept_id, observation_date, observation_type_concept_id)
+VALUES
+(111, 1, 0, date('2021-01-01'), 0), (112, 1, 0, date('2021-01-01'), 0), 
+(121, 2, 0, date('2021-01-01'), 0), (122, 2, 0, date('2021-01-01'), 0), 
+(131, 3, 0, date('2021-01-01'), 0), (132, 3, 0, date('2021-01-01'), 0), 
+(141, 4, 0, date('2021-01-01'), 0), (142, 4, 0, date('2021-01-01'), 0),
+(151, 5, 0, date('2021-01-01'), 0), (152, 5, 0, date('2021-01-01'), 0),
+(1111, 101, 0, date('2021-01-01'), 0), (1112, 101, 0, date('2021-01-01'), 0),
+(1121, 102, 0, date('2021-01-01'), 0), (1122, 102, 0, date('2021-01-01'), 0),
+(1131, 103, 0, date('2021-01-01'), 0), (1132, 103, 0, date('2021-01-01'), 0), 
+(1141, 104, 0, date('2021-01-01'), 0), (1142, 104, 0, date('2021-01-01'), 0),
+(1151, 105, 0, date('2021-01-01'), 0), (1152, 105, 0, date('2021-01-01'), 0)
+""")
+
+MAPPING_OBSERVATION_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}._mapping_observation` 
+(observation_id, src_hpo_id)
+VALUES
+(111, 'rdr'), (112, 'rdr'), 
+(121, 'rdr'), (122, 'rdr'), 
+(131, 'fake'), (132, 'fake'), 
+(141, 'fake'), (142, 'fake'), 
+(151, 'foo'), (152, 'foo')
+""")
+
+OBSERVATION_EXT_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.observation_ext` 
+(observation_id, src_id)
+VALUES
+(1111, 'PPI/PM'), (1112, 'PPI/PM'), 
+(1121, 'PPI/PM'), (1122, 'PPI/PM'), 
+(1131, 'EHR 130'), (1132, 'EHR 130'), 
+(1141, 'EHR 130'), (1142, 'EHR 130'),
+(1151, 'EHR 150'), (1152, 'EHR 150')
+""")
+
+ACTIVITY_SUMMARY_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.activity_summary` 
+(person_id)
+VALUES
+(1), (2), (3), (4), (5), (101), (102), (103), (104), (105)
+""")
+
+# TODO add DEATH table
 
 
-class RetractDataBqTest(TestCase):
+class RetractDataBqTest(BaseTest.BigQueryTestBase):
 
     @classmethod
     def setUpClass(cls):
@@ -43,119 +97,243 @@ class RetractDataBqTest(TestCase):
         print(cls.__name__)
         print('**************************************************************')
 
+        super().initialize_class_vars()
+
+        cls.project_id = os.environ.get(PROJECT_ID)
+        cls.rdr_dataset_id = os.environ.get('RDR_DATASET_ID')
+        cls.ehr_dataset_id = os.environ.get('BIGQUERY_DATASET_ID')
+        cls.unioned_ehr_dataset_id = os.environ.get('UNIONED_DATASET_ID')
+        cls.combined_dataset_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.fitbit_dataset_id = os.environ.get('FITBIT_DATSET_ID')
+        cls.deid_dataset_id = os.environ.get('COMBINED_DEID_DATASET_ID')
+        cls.sandbox_id = f"{os.environ.get('BIGQUERY_DATASET_ID')}_sandbox"
+
+        cls.lookup_table_id = 'pid_rid_to_retract'
+        cls.omop_datasets = [
+            cls.rdr_dataset_id, cls.unioned_ehr_dataset_id,
+            cls.combined_dataset_id, cls.deid_dataset_id
+        ]
+
+        cls.fq_table_names = [
+            f'{cls.project_id}.{dataset}.{PERSON}'
+            for dataset in cls.omop_datasets
+        ] + [
+            f'{cls.project_id}.{dataset}.{OBSERVATION}'
+            for dataset in cls.omop_datasets
+        ] + [
+            f'{cls.project_id}.{cls.combined_dataset_id}._mapping_{OBSERVATION}',
+            f'{cls.project_id}.{cls.fitbit_dataset_id}.{ACTIVITY_SUMMARY}',
+            f'{cls.project_id}.{cls.deid_dataset_id}.{ACTIVITY_SUMMARY}',
+            f'{cls.project_id}.{cls.deid_dataset_id}.{OBSERVATION}_ext',
+        ]
+
+        cls.fq_sandbox_table_names = [
+            #f'{cls.project_id}.{cls.ehr_dataset_id}.fake_{PERSON}',
+            #f'{cls.project_id}.{cls.ehr_dataset_id}.fake_{OBSERVATION}',
+            #f'{cls.project_id}.{cls.ehr_dataset_id}.unioned_ehr_{PERSON}',
+            #f'{cls.project_id}.{cls.ehr_dataset_id}.unioned_ehr_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.{cls.lookup_table_id}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.rdr_dataset_id}_{PERSON}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.rdr_dataset_id}_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.unioned_ehr_dataset_id}_{PERSON}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.unioned_ehr_dataset_id}_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.combined_dataset_id}_{PERSON}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.combined_dataset_id}_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.deid_dataset_id}_{PERSON}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.deid_dataset_id}_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_fake_{PERSON}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_fake_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_unioned_ehr_{PERSON}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_unioned_ehr_{OBSERVATION}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.deid_dataset_id}_{ACTIVITY_SUMMARY}',
+            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.fitbit_dataset_id}_{ACTIVITY_SUMMARY}',
+        ]
+
+        super().setUpClass()
+
     def setUp(self):
-        self.hpo_id = 'fake'
-        self.project_id = 'fake-project-id'
-        self.test_project_id = app_identity.get_application_id()
-        self.lookup_table_id = 'pid_rid_to_retract'
-        self.bq_dataset_id = os.environ.get('COMBINED_DATASET_ID')
-        self.bq_client = BigQueryClient(self.test_project_id)
-        self.dataset_ids = 'all_datasets'
-        self.retraction_type = 'rdr_and_ehr'
-        self.person_research_ids = [(1, 6890173), (2, 858761),
-                                    (1234567, 4589763)]
+        super().setUp()
 
-    @mock.patch('retraction.retract_utils.is_deid_dataset')
-    @mock.patch('retraction.retract_utils.is_combined_dataset')
-    @mock.patch('retraction.retract_utils.is_unioned_dataset')
-    @mock.patch('retraction.retract_utils.is_ehr_dataset')
-    @mock.patch('retraction.retract_utils.get_datasets_list')
-    def test_integration_queries_to_retract_from_fake_dataset(
-        self, mock_list_datasets, mock_is_ehr_dataset, mock_is_unioned_dataset,
-        mock_is_combined_dataset, mock_is_deid_dataset):
-        mock_list_datasets.return_value = [self.bq_dataset_id]
-        mock_is_deid_dataset.return_value = False
+        queries = []
+
+        for dataset in self.omop_datasets:
+            insert_observation = OBSERVATION_TMPL.render(
+                project=self.project_id, dataset=dataset, table=OBSERVATION)
+            insert_person = PERSON_TMPL.render(project=self.project_id,
+                                               dataset=dataset,
+                                               table=PERSON)
+            queries.extend([insert_observation, insert_person])
+
+        # insert_observation = OBSERVATION_TMPL.render(
+        #     project=self.project_id,
+        #     dataset=self.ehr_dataset_id,
+        #     table=f'fake_{OBSERVATION}')
+        # insert_person = PERSON_TMPL.render(project=self.project_id,
+        #                                    dataset=self.ehr_dataset_id,
+        #                                    table=f'fake_{PERSON}')
+        # queries.extend([insert_observation, insert_person])
+
+        # insert_observation = OBSERVATION_TMPL.render(
+        #     project=self.project_id,
+        #     dataset=self.ehr_dataset_id,
+        #     table=f'unioned_ehr_{OBSERVATION}')
+        # insert_person = PERSON_TMPL.render(project=self.project_id,
+        #                                    dataset=self.ehr_dataset_id,
+        #                                    table=f'unioned_ehr_{PERSON}')
+        # queries.extend([insert_observation, insert_person])
+
+        insert_mapping_observation = MAPPING_OBSERVATION_TMPL.render(
+            project=self.project_id, dataset=self.combined_dataset_id)
+        queries.extend([insert_mapping_observation])
+
+        insert_observation_ext = OBSERVATION_EXT_TMPL.render(
+            project=self.project_id, dataset=self.deid_dataset_id)
+        queries.extend([insert_observation_ext])
+
+        create_lookup = CREATE_LOOKUP_TMPL.render(project=self.project_id,
+                                                  dataset=self.sandbox_id)
+        queries.extend([create_lookup])
+
+        insert_lookup = LOOKUP_TMPL.render(project=self.project_id,
+                                           dataset=self.sandbox_id)
+        queries.extend([insert_lookup])
+
+        insert_activity_summary = ACTIVITY_SUMMARY_TMPL.render(
+            project=self.project_id, dataset=self.fitbit_dataset_id)
+        queries.extend([insert_activity_summary])
+
+        insert_activity_summary = ACTIVITY_SUMMARY_TMPL.render(
+            project=self.project_id, dataset=self.deid_dataset_id)
+        queries.extend([insert_activity_summary])
+
+        self.load_test_data(queries)
+
+    @mock.patch('retraction.retract_data_bq.is_unioned_dataset')
+    @mock.patch('retraction.retract_utils.get_dataset_type')
+    def test_unioned_ehr_rdr_and_ehr(self, mock_get_dataset_type,
+                                     mock_is_unioned_dataset):
+        """
+        a
+        """
+        mock_get_dataset_type.return_value = UNIONED_EHR
+        mock_is_unioned_dataset.return_value = True
+
+        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
+                              self.lookup_table_id, NONE_STR,
+                              [self.unioned_ehr_dataset_id], RETRACTION_RDR_EHR,
+                              False, self.client)
+
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{PERSON}',
+            ['person_id'], [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+    @mock.patch('retraction.retract_data_bq.is_unioned_dataset')
+    @mock.patch('retraction.retract_utils.get_dataset_type')
+    def test_unioned_ehr_only_ehr(self, mock_get_dataset_type,
+                                  mock_is_unioned_dataset):
+        """
+        a
+        """
+        mock_get_dataset_type.return_value = UNIONED_EHR
+        mock_is_unioned_dataset.return_value = True
+
+        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
+                              self.lookup_table_id, NONE_STR,
+                              [self.unioned_ehr_dataset_id],
+                              RETRACTION_ONLY_EHR, False, self.client)
+
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{PERSON}',
+            ['person_id'], [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+    @mock.patch('retraction.retract_data_bq.is_combined_dataset')
+    @mock.patch('retraction.retract_utils.get_dataset_type')
+    def test_combined_ehr_rdr_and_ehr(self, mock_get_dataset_type,
+                                      mock_is_combined_dataset):
+        """
+        a
+        """
+        mock_get_dataset_type.return_value = UNIONED_EHR
         mock_is_combined_dataset.return_value = True
-        mock_is_unioned_dataset.return_value = False
-        mock_is_ehr_dataset.return_value = False
 
-        # create and load person_ids to pid table
-        self.bq_client.create_tables(
-            [
-                f'{self.test_project_id}.{self.bq_dataset_id}.{self.lookup_table_id}'
-            ],
-            exists_ok=False,
-            fields=[[{
-                "type": "integer",
-                "name": "person_id",
-                "mode": "required",
-                "description": "The person_id to retract data for"
-            }, {
-                "type": "integer",
-                "name": "research_id",
-                "mode": "nullable",
-                "description": "The research_id corresponding to the person_id"
-            }]])
-        bq_formatted_insert_values = ', '.join([
-            f'({person_id}, {research_id})'
-            for (person_id, research_id) in self.person_research_ids
-        ])
-        q = JINJA_ENV.from_string(INSERT_PID_TABLE).render(
-            dataset_id=self.bq_dataset_id,
-            lookup_table_id=self.lookup_table_id,
-            person_research_ids=bq_formatted_insert_values)
-        job = self.bq_client.query(q)
-        job.result()
+        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
+                              self.lookup_table_id, NONE_STR,
+                              [self.combined_dataset_id], RETRACTION_RDR_EHR,
+                              False, self.client)
 
-        row_count_queries = {}
-        # load the cdm files into dataset
-        for cdm_file in test_util.NYC_FIVE_PERSONS_FILES:
-            cdm_file_name = os.path.basename(cdm_file)
-            cdm_table = cdm_file_name.split('.')[0]
-            hpo_table = f'{self.hpo_id}_{cdm_table}'
-            # store query for checking number of rows to delete
-            row_count_queries[hpo_table] = JINJA_ENV.from_string(
-                EXPECTED_ROWS_QUERY).render(
-                    dataset_id=self.bq_dataset_id,
-                    table_id=hpo_table,
-                    lookup_table_id=self.lookup_table_id,
-                    retraction_type=self.retraction_type)
-            logging.info(
-                f'Preparing to load table {self.bq_dataset_id}.{hpo_table}')
-            with open(cdm_file, 'rb') as f:
-                job_config = bigquery.LoadJobConfig()
-                job_config.source_format = bigquery.SourceFormat.CSV
-                job_config.skip_leading_rows = 1
-                job_config.write_disposition = 'WRITE_EMPTY'
-                job_config.schema = self.bq_client.get_table_schema(cdm_table)
-                load_job = self.bq_client.load_table_from_file(
-                    f,
-                    f'{self.test_project_id}.{self.bq_dataset_id}.{hpo_table}',
-                    job_config=job_config)
-                load_job.result()
-        logging.info('All tables loaded successfully')
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.combined_dataset_id}.{PERSON}',
+            ['person_id'], [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{PERSON}',
+            ['person_id'], [2, 4])
 
-        # use query results to count number of expected row deletions
-        expected_row_count = {}
-        for table in row_count_queries:
-            job = self.bq_client.query(row_count_queries[table])
-            result = job.result()
-            expected_row_count[table] = result.to_dataframe()['count'].to_list(
-            )[0]
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.combined_dataset_id}.{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
 
-        # separate check to find number of actual deleted rows
-        q = TABLE_ROWS_QUERY.format(dataset_id=self.bq_dataset_id)
-        job = self.bq_client.query(q)
-        result = job.result().to_dataframe()
-        row_counts_before_retraction = pd.Series(
-            result.row_count.values, index=result.table_id).to_dict()
+    @mock.patch('retraction.retract_data_bq.is_combined_dataset')
+    @mock.patch('retraction.retract_utils.get_dataset_type')
+    def test_combined_ehr_only_ehr(self, mock_get_dataset_type,
+                                   mock_is_combined_dataset):
+        """
+        a
+        """
+        mock_get_dataset_type.return_value = UNIONED_EHR
+        mock_is_combined_dataset.return_value = True
 
-        # perform retraction
-        rbq.run_bq_retraction(self.test_project_id, self.bq_dataset_id,
-                              self.lookup_table_id, self.hpo_id,
-                              self.dataset_ids, self.retraction_type)
+        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
+                              self.lookup_table_id, NONE_STR,
+                              [self.combined_dataset_id], RETRACTION_ONLY_EHR,
+                              False, self.client)
 
-        # find actual deleted rows
-        job = self.bq_client.query(q)
-        result = job.result().to_dataframe()
-        row_counts_after_retraction = pd.Series(
-            result.row_count.values, index=result.table_id).to_dict()
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.combined_dataset_id}.{PERSON}',
+            ['person_id'], [1, 2, 3, 4, 5, 101, 102, 103, 104, 105])
 
-        for table in expected_row_count:
-            self.assertEqual(
-                expected_row_count[table], row_counts_before_retraction[table] -
-                row_counts_after_retraction[table])
+        # TODO add table_not_found assertion
+        # self.assertRowIDsMatch(
+        #     f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{PERSON}',
+        #     ['person_id'], [])
 
-    def tearDown(self):
-        for table in self.bq_client.list_tables(self.bq_dataset_id):
-            self.bq_client.delete_table(table, not_found_ok=True)
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.combined_dataset_id}.{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 121, 122, 131, 132, 151, 152, 1111, 1112, 1121, 1122,
+                1131, 1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{OBSERVATION}',
+            ['observation_id'], [141, 142])

--- a/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
@@ -25,35 +25,26 @@ LOOKUP_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.pid_rid_to_retract` 
     (person_id, research_id)
 VALUES
-    (2, 102), (4, 104)
+    (102, 202), (104, 204)
 """)
 
 PERSON_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.{{table}}` 
     (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
 VALUES
-    (1, 0, 2001, 0, 0), 
-    (2, 0, 2001, 0, 0), 
-    (3, 0, 2001, 0, 0), 
-    (4, 0, 2001, 0, 0),
-    (101, 0, 2001, 0, 0), 
-    (102, 0, 2001, 0, 0), 
-    (103, 0, 2001, 0, 0), 
-    (104, 0, 2001, 0, 0)
+{% for pers_id in person_ids %}
+    ({{pers_id}}, 0, 2001, 0, 0){% if not loop.last -%}, {% endif %}
+{% endfor %}
 """)
 
 OBSERVATION_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.{{table}}` 
     (observation_id, person_id, observation_concept_id, observation_date, observation_type_concept_id)
 VALUES
-    (111, 1, 0, date('2021-01-01'), 0), (112, 1, 0, date('2021-01-01'), 0), 
-    (121, 2, 0, date('2021-01-01'), 0), (122, 2, 0, date('2021-01-01'), 0), 
-    (131, 3, 0, date('2021-01-01'), 0), (132, 3, 0, date('2021-01-01'), 0), 
-    (141, 4, 0, date('2021-01-01'), 0), (142, 4, 0, date('2021-01-01'), 0),
-    (1111, 101, 0, date('2021-01-01'), 0), (1112, 101, 0, date('2021-01-01'), 0),
-    (1121, 102, 0, date('2021-01-01'), 0), (1122, 102, 0, date('2021-01-01'), 0),
-    (1131, 103, 0, date('2021-01-01'), 0), (1132, 103, 0, date('2021-01-01'), 0), 
-    (1141, 104, 0, date('2021-01-01'), 0), (1142, 104, 0, date('2021-01-01'), 0)
+{% for pers_id in person_ids %}
+    ({{pers_id}}1, {{pers_id}}, 0, date('2021-01-01'), 0),
+    ({{pers_id}}2, {{pers_id}}, 0, date('2021-01-01'), 0){% if not loop.last -%}, {% endif %}
+{% endfor %}
 """)
 
 EHR_TMPL = JINJA_ENV.from_string("""
@@ -65,59 +56,61 @@ MAPPING_OBSERVATION_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}._mapping_observation` 
     (observation_id, src_hpo_id)
 VALUES
-    (111, 'rdr'), 
-    (112, 'rdr'), 
-    (121, 'rdr'), 
-    (122, 'rdr'), 
-    (131, 'fake'), 
-    (132, 'fake'), 
-    (141, 'fake'), 
-    (142, 'fake'), 
-    (1111, 'bar'), 
-    (1112, 'bar'), 
-    (1121, 'bar'), 
-    (1122, 'bar'), 
-    (1131, 'bar'), 
-    (1132, 'bar'), 
-    (1141, 'bar'), 
-    (1142, 'bar')
+{% for obs_id in observation_ids %}
+    {% if 1011 <= obs_id <= 1022 -%}({{obs_id}}, 'rdr')
+    {% else %}({{obs_id}}, 'foo'){% endif %}
+    {% if not loop.last -%}, {% endif %}
+{% endfor %}
 """)
 
 OBSERVATION_EXT_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.observation_ext` 
     (observation_id, src_id)
 VALUES
-    (111, 'EHR foo'), 
-    (112, 'EHR foo'), 
-    (121, 'EHR foo'), 
-    (122, 'EHR foo'), 
-    (131, 'EHR foo'), 
-    (132, 'EHR foo'), 
-    (141, 'EHR foo'), 
-    (142, 'EHR foo'),
-    (1111, 'PPI/PM'), 
-    (1112, 'PPI/PM'), 
-    (1121, 'PPI/PM'), 
-    (1122, 'PPI/PM'), 
-    (1131, 'EHR 130'), 
-    (1132, 'EHR 130'), 
-    (1141, 'EHR 130'), 
-    (1142, 'EHR 130')
+{% for obs_id in observation_ids %}
+    {% if 2011 <= obs_id <= 2022 -%}({{obs_id}}, 'PPI/PM')
+    {% else %}({{obs_id}}, 'EHR 999'){% endif %}
+    {% if not loop.last -%}, {% endif %}
+{% endfor %}
 """)
 
 ACTIVITY_SUMMARY_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.activity_summary` 
     (person_id)
 VALUES
-    (1), 
-    (2), 
-    (3), 
-    (4), 
-    (101), 
-    (102),
-    (103),
-    (104)
+{% for pers_id in person_ids %}
+    ({{pers_id}}){% if not loop.last -%}, {% endif %}
+{% endfor %}
 """)
+
+PERS_ALL = [101, 102, 103, 104, 201, 202, 203, 204]
+PERS_PID_TO_RETRACT = [102, 104]
+PERS_RID_TO_RETRACT = [202, 204]
+PERS_PID_RETRACTED = [101, 103, 201, 202, 203, 204]
+PERS_RID_RETRACTED = [101, 102, 103, 104, 201, 203]
+
+OBS_ALL = [
+    1011, 1012, 1021, 1022, 1031, 1032, 1041, 1042, 2011, 2012, 2021, 2022,
+    2031, 2032, 2041, 2042
+]
+OBS_PID_TO_RETRACT = [1021, 1022, 1041, 1042]
+OBS_RID_TO_RETRACT = [2021, 2022, 2041, 2042]
+OBS_PID_TO_RETRACT_ONLY_EHR = [1041, 1042]
+OBS_RID_TO_RETRACT_ONLY_EHR = [2041, 2042]
+OBS_PID_RETRACTED = [
+    1011, 1012, 1031, 1032, 2011, 2012, 2021, 2022, 2031, 2032, 2041, 2042
+]
+OBS_RID_RETRACTED = [
+    1011, 1012, 1021, 1022, 1031, 1032, 1041, 1042, 2011, 2012, 2031, 2032
+]
+OBS_PID_RETRACTED_ONLY_EHR = [
+    1011, 1012, 1021, 1022, 1031, 1032, 2011, 2012, 2021, 2022, 2031, 2032,
+    2041, 2042
+]
+OBS_RID_RETRACTED_ONLY_EHR = [
+    1011, 1012, 1021, 1022, 1031, 1032, 1041, 1042, 2011, 2012, 2021, 2022,
+    2031, 2032
+]
 
 
 def mock_patch_decorator_bundle(*decorators):
@@ -227,23 +220,28 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         ]:
             insert_pers = PERSON_TMPL.render(project=self.project_id,
                                              dataset=dataset,
-                                             table=PERSON)
+                                             table=PERSON,
+                                             person_ids=PERS_ALL)
             insert_obs = OBSERVATION_TMPL.render(project=self.project_id,
                                                  dataset=dataset,
-                                                 table=OBSERVATION)
+                                                 table=OBSERVATION,
+                                                 person_ids=PERS_ALL)
             queries.extend([insert_pers, insert_obs])
 
         # mapping tables/ ext tables
         insert_map_obs = MAPPING_OBSERVATION_TMPL.render(
-            project=self.project_id, dataset=self.combined_id)
+            project=self.project_id,
+            dataset=self.combined_id,
+            observation_ids=OBS_ALL)
         insert_obs_ext = OBSERVATION_EXT_TMPL.render(project=self.project_id,
-                                                     dataset=self.deid_id)
+                                                     dataset=self.deid_id,
+                                                     observation_ids=OBS_ALL)
         queries.extend([insert_map_obs, insert_obs_ext])
 
         # fitbit tables
         for dataset in [self.deid_id, self.fitbit_id]:
             insert_activity_summary = ACTIVITY_SUMMARY_TMPL.render(
-                project=self.project_id, dataset=dataset)
+                project=self.project_id, dataset=dataset, person_ids=PERS_ALL)
             queries.extend([insert_activity_summary])
 
         # tables for EHR dataset
@@ -295,17 +293,16 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 3, 101, 102, 103, 104])
+                               ['person_id'], PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
-        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}', [
-            'observation_id'
-        ], [111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141, 1142])
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
+                               ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_unioned_ehr_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
@@ -334,17 +331,16 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 3, 101, 102, 103, 104])
+                               ['person_id'], PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
-        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}', [
-            'observation_id'
-        ], [111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141, 1142])
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
+                               ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_combined_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
@@ -372,17 +368,16 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 3, 101, 102, 103, 104])
+                               ['person_id'], PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
-        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}', [
-            'observation_id'
-        ], [111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141, 1142])
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
+                               ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_combined_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
@@ -411,19 +406,16 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 2, 3, 4, 101, 102, 103, 104])
+                               ['person_id'], PERS_ALL)
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.retract_{dataset_id}_{PERSON}'
         )
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
-                               ['observation_id'], [
-                                   111, 112, 121, 122, 131, 132, 1111, 1112,
-                                   1121, 1122, 1131, 1132, 1141, 1142
-                               ])
+                               ['observation_id'], OBS_PID_RETRACTED_ONLY_EHR)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT_ONLY_EHR)
 
     @mock_patch_bundle
     def test_deid_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
@@ -450,23 +442,22 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 2, 3, 4, 101, 103])
+                               ['person_id'], PERS_RID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
-            ['person_id'], [102, 104])
+            ['person_id'], PERS_RID_TO_RETRACT)
 
-        self.assertRowIDsMatch(
-            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'],
-            [111, 112, 121, 122, 131, 132, 141, 142, 1111, 1112, 1131, 1132])
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
+                               ['observation_id'], OBS_RID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [1121, 1122, 1141, 1142])
+            ['observation_id'], OBS_RID_TO_RETRACT)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
-                               ['person_id'], [1, 2, 3, 4, 101, 103])
+                               ['person_id'], PERS_RID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}',
-            ['person_id'], [102, 104])
+            ['person_id'], PERS_RID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_deid_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
@@ -496,22 +487,19 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 2, 3, 4, 101, 102, 103, 104])
+                               ['person_id'], PERS_ALL)
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.retract_{dataset_id}_{PERSON}'
         )
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
-                               ['observation_id'], [
-                                   111, 112, 121, 122, 131, 132, 141, 142, 1111,
-                                   1112, 1121, 1122, 1131, 1132
-                               ])
+                               ['observation_id'], OBS_RID_RETRACTED_ONLY_EHR)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [1141, 1142])
+            ['observation_id'], OBS_RID_TO_RETRACT_ONLY_EHR)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
-                               ['person_id'], [1, 2, 3, 4, 101, 102, 103, 104])
+                               ['person_id'], PERS_ALL)
         self.assertTableDoesNotExist(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}'
         )
@@ -541,17 +529,16 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], [1, 3, 101, 102, 103, 104])
+                               ['person_id'], PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
-        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}', [
-            'observation_id'
-        ], [111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141, 1142])
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
+                               ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_rdr_only_ehr(self, mock_get_dataset_type, mock_is_rdr, mock_is_ehr,
@@ -605,43 +592,34 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{self.hpo_id}_{PERSON}', ['person_id'],
-            [1, 3, 101, 102, 103, 104])
+            PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{UNIONED_EHR}_{PERSON}', ['person_id'],
-            [1, 3, 101, 102, 103, 104])
+            PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{self.hpo_id}_{OBSERVATION}',
-            ['observation_id'], [
-                111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141,
-                1142
-            ])
+            ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{UNIONED_EHR}_{OBSERVATION}',
-            ['observation_id'], [
-                111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141,
-                1142
-            ])
+            ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.foo_{OBSERVATION}',
-                               ['observation_id'], [
-                                   111, 112, 121, 122, 131, 132, 141, 142, 1111,
-                                   1112, 1121, 1122, 1131, 1132, 1141, 1142
-                               ])
+                               ['observation_id'], OBS_ALL)
         self.assertTableDoesNotExist(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_foo_{OBSERVATION}',
         )
@@ -674,43 +652,34 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{self.hpo_id}_{PERSON}', ['person_id'],
-            [1, 3, 101, 102, 103, 104])
+            PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{UNIONED_EHR}_{PERSON}', ['person_id'],
-            [1, 3, 101, 102, 103, 104])
+            PERS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{PERSON}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{self.hpo_id}_{OBSERVATION}',
-            ['observation_id'], [
-                111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141,
-                1142
-            ])
+            ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(
             f'{project_id}.{dataset_id}.{UNIONED_EHR}_{OBSERVATION}',
-            ['observation_id'], [
-                111, 112, 131, 132, 1111, 1112, 1121, 1122, 1131, 1132, 1141,
-                1142
-            ])
+            ['observation_id'], OBS_PID_RETRACTED)
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{OBSERVATION}',
-            ['observation_id'], [121, 122, 141, 142])
+            ['observation_id'], OBS_PID_TO_RETRACT)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.foo_{OBSERVATION}',
-                               ['observation_id'], [
-                                   111, 112, 121, 122, 131, 132, 141, 142, 1111,
-                                   1112, 1121, 1122, 1131, 1132, 1141, 1142
-                               ])
+                               ['observation_id'], OBS_ALL)
         self.assertTableDoesNotExist(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_foo_{OBSERVATION}',
         )
@@ -763,11 +732,11 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
-                               ['person_id'], [1, 3, 101, 102, 103, 104])
+                               ['person_id'], PERS_PID_RETRACTED)
 
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}',
-            ['person_id'], [2, 4])
+            ['person_id'], PERS_PID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_fitbit_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
@@ -820,11 +789,11 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
                           self.client)
 
         self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
-                               ['person_id'], [1, 2, 3, 4, 101, 103])
+                               ['person_id'], PERS_RID_RETRACTED)
 
         self.assertRowIDsMatch(
             f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}',
-            ['person_id'], [102, 104])
+            ['person_id'], PERS_RID_TO_RETRACT)
 
     @mock_patch_bundle
     def test_deid_fitbit_only_ehr(self, mock_get_dataset_type, mock_is_rdr,

--- a/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
@@ -16,6 +16,7 @@ from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_te
 from retraction.retract_data_bq import (NONE, RETRACTION_ONLY_EHR,
                                         RETRACTION_RDR_EHR, get_datasets_list,
                                         run_bq_retraction)
+from retraction.retract_utils import get_dataset_type, is_sandbox_dataset
 from constants.retraction.retract_utils import ALL_DATASETS
 
 CREATE_LOOKUP_TMPL = JINJA_ENV.from_string("""
@@ -132,13 +133,15 @@ def mock_patch_decorator_bundle(*decorators):
 
 mock_patch_bundle = mock_patch_decorator_bundle(
     mock.patch('retraction.retract_data_bq.is_sandbox_dataset'),
+    mock.patch('retraction.retract_utils.is_sandbox_dataset'),
     mock.patch('retraction.retract_data_bq.is_fitbit_dataset'),
     mock.patch('retraction.retract_data_bq.is_deid_dataset'),
     mock.patch('retraction.retract_data_bq.is_combined_dataset'),
     mock.patch('retraction.retract_data_bq.is_unioned_dataset'),
     mock.patch('retraction.retract_data_bq.is_ehr_dataset'),
     mock.patch('retraction.retract_data_bq.is_rdr_dataset'),
-    mock.patch('retraction.retract_data_bq.get_dataset_type'))
+    mock.patch('retraction.retract_data_bq.get_dataset_type'),
+    mock.patch('retraction.retract_utils.get_dataset_type'))
 
 
 class RetractDataBqTest(BaseTest.BigQueryTestBase):
@@ -272,11 +275,10 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         self.load_test_data(queries)
 
     @mock_patch_bundle
-    def test_retract_unioned_ehr_rdr_and_ehr(self, mock_get_dataset_type,
-                                             mock_is_rdr, mock_is_ehr,
-                                             mock_is_unioned, mock_is_combined,
-                                             mock_is_deid, mock_is_fitbit,
-                                             mock_is_sandbox):
+    def test_retract_unioned_ehr_rdr_and_ehr(
+        self, mock_ru_get_dataset_type, mock_rdb_get_dataset_type, mock_is_rdr,
+        mock_is_ehr, mock_is_unioned, mock_is_combined, mock_is_deid,
+        mock_is_fitbit, mock_ru_is_sandbox, mock_rdb_is_sandbox):
         """
         Test for unioned ehr dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
@@ -284,11 +286,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_unioned.return_value = True
-        mock_get_dataset_type.return_value = UNIONED_EHR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = UNIONED_EHR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.unioned_ehr_id
 
@@ -308,11 +311,10 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_unioned_ehr_only_ehr(self, mock_get_dataset_type,
-                                          mock_is_rdr, mock_is_ehr,
-                                          mock_is_unioned, mock_is_combined,
-                                          mock_is_deid, mock_is_fitbit,
-                                          mock_is_sandbox):
+    def test_retract_unioned_ehr_only_ehr(
+        self, mock_ru_get_dataset_type, mock_rdb_get_dataset_type, mock_is_rdr,
+        mock_is_ehr, mock_is_unioned, mock_is_combined, mock_is_deid,
+        mock_is_fitbit, mock_ru_is_sandbox, mock_rdb_is_sandbox):
         """
         Test for unioned ehr dataset.
         run_bq_retraction with retraction_type = 'only_ehr'.
@@ -321,11 +323,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_unioned.return_value = True
-        mock_get_dataset_type.return_value = UNIONED_EHR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = UNIONED_EHR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.unioned_ehr_id
 
@@ -345,11 +348,10 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_combined_rdr_and_ehr(self, mock_get_dataset_type,
-                                          mock_is_rdr, mock_is_ehr,
-                                          mock_is_unioned, mock_is_combined,
-                                          mock_is_deid, mock_is_fitbit,
-                                          mock_is_sandbox):
+    def test_retract_combined_rdr_and_ehr(
+        self, mock_ru_get_dataset_type, mock_rdb_get_dataset_type, mock_is_rdr,
+        mock_is_ehr, mock_is_unioned, mock_is_combined, mock_is_deid,
+        mock_is_fitbit, mock_ru_is_sandbox, mock_rdb_is_sandbox):
         """
         Test for combined dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
@@ -357,11 +359,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_combined.return_value = True
-        mock_get_dataset_type.return_value = COMBINED
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = COMBINED
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.combined_id
 
@@ -381,10 +384,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_combined_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_combined_only_ehr(self, mock_ru_get_dataset_type,
+                                       mock_rdb_get_dataset_type, mock_is_rdr,
                                        mock_is_ehr, mock_is_unioned,
                                        mock_is_combined, mock_is_deid,
-                                       mock_is_fitbit, mock_is_sandbox):
+                                       mock_is_fitbit, mock_ru_is_sandbox,
+                                       mock_rdb_is_sandbox):
         """
         Test for combined dataset.
         run_bq_retraction with retraction_type = 'only_ehr'.
@@ -394,11 +399,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_combined.return_value = True
-        mock_get_dataset_type.return_value = COMBINED
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = COMBINED
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.combined_id
 
@@ -419,10 +425,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['observation_id'], OBS_PID_TO_RETRACT_ONLY_EHR)
 
     @mock_patch_bundle
-    def test_retract_deid_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_deid_rdr_and_ehr(self, mock_ru_get_dataset_type,
+                                      mock_rdb_get_dataset_type, mock_is_rdr,
                                       mock_is_ehr, mock_is_unioned,
                                       mock_is_combined, mock_is_deid,
-                                      mock_is_fitbit, mock_is_sandbox):
+                                      mock_is_fitbit, mock_ru_is_sandbox,
+                                      mock_rdb_is_sandbox):
         """
         Test for deid dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
@@ -430,11 +438,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_deid.return_value = True
-        mock_get_dataset_type.return_value = DEID
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = DEID
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.deid_id
 
@@ -460,10 +469,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['person_id'], PERS_RID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_deid_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_deid_only_ehr(self, mock_ru_get_dataset_type,
+                                   mock_rdb_get_dataset_type, mock_is_rdr,
                                    mock_is_ehr, mock_is_unioned,
                                    mock_is_combined, mock_is_deid,
-                                   mock_is_fitbit, mock_is_sandbox):
+                                   mock_is_fitbit, mock_ru_is_sandbox,
+                                   mock_rdb_is_sandbox):
         """
         Test for deid dataset.
         run_bq_retraction with retraction_type = 'only_ehr'.
@@ -474,11 +485,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_deid.return_value = True
-        mock_get_dataset_type.return_value = DEID
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = DEID
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.deid_id
 
@@ -505,10 +517,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         )
 
     @mock_patch_bundle
-    def test_retract_rdr_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_rdr_rdr_and_ehr(self, mock_ru_get_dataset_type,
+                                     mock_rdb_get_dataset_type, mock_is_rdr,
                                      mock_is_ehr, mock_is_unioned,
                                      mock_is_combined, mock_is_deid,
-                                     mock_is_fitbit, mock_is_sandbox):
+                                     mock_is_fitbit, mock_ru_is_sandbox,
+                                     mock_rdb_is_sandbox):
         """
         Test for rdr dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
@@ -516,11 +530,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_rdr.return_value = True
-        mock_get_dataset_type.return_value = RDR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = RDR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.rdr_id
 
@@ -540,10 +555,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_rdr_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_rdr_only_ehr(self, mock_ru_get_dataset_type,
+                                  mock_rdb_get_dataset_type, mock_is_rdr,
                                   mock_is_ehr, mock_is_unioned,
                                   mock_is_combined, mock_is_deid,
-                                  mock_is_fitbit, mock_is_sandbox):
+                                  mock_is_fitbit, mock_ru_is_sandbox,
+                                  mock_rdb_is_sandbox):
         """
         Test for rdr dataset.
         run_bq_retraction with retraction_type = 'only_ehr'.
@@ -551,11 +568,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_rdr.return_value = True
-        mock_get_dataset_type.return_value = RDR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = RDR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.rdr_id
 
@@ -566,10 +584,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         self.assertTrue(f"Skipping retraction" in cm.output[0])
 
     @mock_patch_bundle
-    def test_retract_ehr_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_ehr_rdr_and_ehr(self, mock_ru_get_dataset_type,
+                                     mock_rdb_get_dataset_type, mock_is_rdr,
                                      mock_is_ehr, mock_is_unioned,
                                      mock_is_combined, mock_is_deid,
-                                     mock_is_fitbit, mock_is_sandbox):
+                                     mock_is_fitbit, mock_ru_is_sandbox,
+                                     mock_rdb_is_sandbox):
         """
         Test for ehr dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
@@ -578,11 +598,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_ehr.return_value = True
-        mock_get_dataset_type.return_value = EHR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = EHR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.ehr_id
 
@@ -625,10 +646,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         )
 
     @mock_patch_bundle
-    def test_retract_ehr_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_ehr_only_ehr(self, mock_ru_get_dataset_type,
+                                  mock_rdb_get_dataset_type, mock_is_rdr,
                                   mock_is_ehr, mock_is_unioned,
                                   mock_is_combined, mock_is_deid,
-                                  mock_is_fitbit, mock_is_sandbox):
+                                  mock_is_fitbit, mock_ru_is_sandbox,
+                                  mock_rdb_is_sandbox):
         """
         Test for ehr dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
@@ -638,11 +661,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_ehr.return_value = True
-        mock_get_dataset_type.return_value = EHR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = EHR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.ehr_id
 
@@ -685,11 +709,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         )
 
     @mock_patch_bundle
-    def test_retract_ehr_without_hpo_id(self, mock_get_dataset_type,
-                                        mock_is_rdr, mock_is_ehr,
-                                        mock_is_unioned, mock_is_combined,
-                                        mock_is_deid, mock_is_fitbit,
-                                        mock_is_sandbox):
+    def test_retract_ehr_without_hpo_id(self, mock_ru_get_dataset_type,
+                                        mock_rdb_get_dataset_type, mock_is_rdr,
+                                        mock_is_ehr, mock_is_unioned,
+                                        mock_is_combined, mock_is_deid,
+                                        mock_is_fitbit, mock_ru_is_sandbox,
+                                        mock_rdb_is_sandbox):
         """
         Test for ehr dataset.
         Retraction runs against all the tables with person_id in EHR dataset 
@@ -697,11 +722,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_ehr.return_value = True
-        mock_get_dataset_type.return_value = EHR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = EHR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.ehr_id
 
@@ -749,22 +775,24 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['observation_id'], OBS_PID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_fitbit_rdr_and_ehr(self, mock_get_dataset_type,
-                                        mock_is_rdr, mock_is_ehr,
-                                        mock_is_unioned, mock_is_combined,
-                                        mock_is_deid, mock_is_fitbit,
-                                        mock_is_sandbox):
+    def test_retract_fitbit_rdr_and_ehr(self, mock_ru_get_dataset_type,
+                                        mock_rdb_get_dataset_type, mock_is_rdr,
+                                        mock_is_ehr, mock_is_unioned,
+                                        mock_is_combined, mock_is_deid,
+                                        mock_is_fitbit, mock_ru_is_sandbox,
+                                        mock_rdb_is_sandbox):
         """
         Test for fitbit dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_fitbit.return_value = True
-        mock_get_dataset_type.return_value = FITBIT
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = FITBIT
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
 
@@ -779,10 +807,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['person_id'], PERS_PID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_fitbit_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_fitbit_only_ehr(self, mock_ru_get_dataset_type,
+                                     mock_rdb_get_dataset_type, mock_is_rdr,
                                      mock_is_ehr, mock_is_unioned,
                                      mock_is_combined, mock_is_deid,
-                                     mock_is_fitbit, mock_is_sandbox):
+                                     mock_is_fitbit, mock_ru_is_sandbox,
+                                     mock_rdb_is_sandbox):
         """
         Test for fitbit dataset.
         run_bq_retraction with retraction_type = 'only_ehr'.
@@ -790,11 +820,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_fitbit.return_value = True
-        mock_get_dataset_type.return_value = FITBIT
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = FITBIT
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
 
@@ -805,23 +836,23 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         self.assertTrue(f"Skipping retraction" in cm.output[0])
 
     @mock_patch_bundle
-    def test_retract_deid_fitbit_rdr_and_ehr(self, mock_get_dataset_type,
-                                             mock_is_rdr, mock_is_ehr,
-                                             mock_is_unioned, mock_is_combined,
-                                             mock_is_deid, mock_is_fitbit,
-                                             mock_is_sandbox):
+    def test_retract_deid_fitbit_rdr_and_ehr(
+        self, mock_ru_get_dataset_type, mock_rdb_get_dataset_type, mock_is_rdr,
+        mock_is_ehr, mock_is_unioned, mock_is_combined, mock_is_deid,
+        mock_is_fitbit, mock_ru_is_sandbox, mock_rdb_is_sandbox):
         """
         Test for fitbit dataset.
         run_bq_retraction with retraction_type = 'rdr_and_ehr'.
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_deid.return_value = True
         mock_is_fitbit.return_value = True
-        mock_get_dataset_type.return_value = FITBIT
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = FITBIT
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
 
@@ -836,11 +867,10 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
             ['person_id'], PERS_RID_TO_RETRACT)
 
     @mock_patch_bundle
-    def test_retract_deid_fitbit_only_ehr(self, mock_get_dataset_type,
-                                          mock_is_rdr, mock_is_ehr,
-                                          mock_is_unioned, mock_is_combined,
-                                          mock_is_deid, mock_is_fitbit,
-                                          mock_is_sandbox):
+    def test_retract_deid_fitbit_only_ehr(
+        self, mock_ru_get_dataset_type, mock_rdb_get_dataset_type, mock_is_rdr,
+        mock_is_ehr, mock_is_unioned, mock_is_combined, mock_is_deid,
+        mock_is_fitbit, mock_ru_is_sandbox, mock_rdb_is_sandbox):
         """
         Test for deid fitbit dataset.
         run_bq_retraction with retraction_type = 'only_ehr'.
@@ -848,12 +878,13 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_deid.return_value = True
         mock_is_fitbit.return_value = True
-        mock_get_dataset_type.return_value = FITBIT
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = FITBIT
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
 
@@ -864,110 +895,58 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         self.assertTrue(f"Skipping retraction" in cm.output[0])
 
     @mock_patch_bundle
-    def test_retract_other_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
-                                       mock_is_ehr, mock_is_unioned,
-                                       mock_is_combined, mock_is_deid,
-                                       mock_is_fitbit, mock_is_sandbox):
+    def test_retract_other(self, mock_ru_get_dataset_type,
+                           mock_rdb_get_dataset_type, mock_is_rdr, mock_is_ehr,
+                           mock_is_unioned, mock_is_combined, mock_is_deid,
+                           mock_is_fitbit, mock_ru_is_sandbox,
+                           mock_rdb_is_sandbox):
         """
         Test for dataset that is none of the above.
-        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
-        Retraction runs on the tables in the dataset anyway.
+        retract_utils.get_datasets_list() excludes such datasets from retraction
+        regardless of `retraction_type`.
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
-        mock_get_dataset_type.return_value = OTHER
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = OTHER
 
-        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.other_id
-
-        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id, NONE,
-                          [dataset_id], RETRACTION_RDR_EHR, False, self.client)
-
-        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
-                               ['person_id'], PERS_PID_AFTER_RETRACTION)
-        self.assertRowIDsMatch(
-            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
-            ['person_id'], PERS_PID_TO_RETRACT)
-
-        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
-                               ['observation_id'], OBS_PID_AFTER_RETRACTION)
-        self.assertRowIDsMatch(
-            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
-            ['observation_id'], OBS_PID_TO_RETRACT)
+        dataset_list = get_datasets_list(self.client, [self.other_id])
+        self.assertEqual(dataset_list, [])
 
     @mock_patch_bundle
-    def test_retract_other_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
-                                    mock_is_ehr, mock_is_unioned,
-                                    mock_is_combined, mock_is_deid,
-                                    mock_is_fitbit, mock_is_sandbox):
+    def test_retract_sandbox(self, mock_ru_get_dataset_type,
+                             mock_rdb_get_dataset_type, mock_is_rdr,
+                             mock_is_ehr, mock_is_unioned, mock_is_combined,
+                             mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                             mock_rdb_is_sandbox):
         """
-        Test for dataset that is none of the above.
-        run_bq_retraction with retraction_type = 'only_ehr'.
-        Retraction is skipped because we cannot tell which data came from EHR for this dataset type.
+        Test for sandbox datasets with both retraction_type = 'only_ehr' and 'rdr_and_ehr'.
+        retract_utils.get_datasets_list() excludes sandbox datasets from retraction
+        regardless of `retraction_type`.
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
-        ]:
-            mock_.return_value = False
-        mock_get_dataset_type.return_value = OTHER
-
-        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.other_id
-
-        with self.assertLogs(level='WARNING') as cm:
-            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
-                              NONE, [dataset_id], RETRACTION_ONLY_EHR, False,
-                              self.client)
-        self.assertTrue(f"Skipping retraction" in cm.output[0])
-
-    @mock_patch_bundle
-    def test_retract_sandbox_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
-                                      mock_is_ehr, mock_is_unioned,
-                                      mock_is_combined, mock_is_deid,
-                                      mock_is_fitbit, mock_is_sandbox):
-        """
-        Test for combined sandbox dataset and deid sandbox dataset with
-        retraction_type = 'only_ehr'. The retraction is skipped here
-        because mapping table/ ext tables do not exist for the sandbox
-        dataset.
-        NOTE If retraction_type = 'rdr_and_ehr', sandbox datasets are 
-        retracted just like combined/ deid datasets.
-        """
-        for mock_ in [
-                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_combined.return_value = True
-        mock_is_sandbox.return_value = True
-        mock_get_dataset_type.return_value = COMBINED
+        mock_rdb_is_sandbox.return_value = mock_ru_is_sandbox.return_value = True
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = COMBINED
 
-        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.combined_id
-
-        with self.assertLogs(level='WARNING') as cm:
-            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
-                              NONE, [dataset_id], RETRACTION_ONLY_EHR, False,
-                              self.client)
-        self.assertTrue(f"Skipping retraction" in cm.output[0])
-
-        mock_is_combined.return_value = False
-        mock_is_deid.return_value = True
-        mock_get_dataset_type.return_value = DEID
-        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.deid_id
-
-        with self.assertLogs(level='WARNING') as cm:
-            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
-                              NONE, [dataset_id], RETRACTION_ONLY_EHR, False,
-                              self.client)
-        self.assertTrue(f"Skipping retraction" in cm.output[0])
+        dataset_list = get_datasets_list(self.client, [self.sandbox_id])
+        self.assertEqual(dataset_list, [])
 
     @mock_patch_bundle
-    def test_retract_skip_sandboxing(self, mock_get_dataset_type, mock_is_rdr,
+    def test_retract_skip_sandboxing(self, mock_ru_get_dataset_type,
+                                     mock_rdb_get_dataset_type, mock_is_rdr,
                                      mock_is_ehr, mock_is_unioned,
                                      mock_is_combined, mock_is_deid,
-                                     mock_is_fitbit, mock_is_sandbox):
+                                     mock_is_fitbit, mock_ru_is_sandbox,
+                                     mock_rdb_is_sandbox):
         """
         Test for skip_sandboxing option.
         Everything is same with test_rdr_rdr_and_ehr except skip_sandboxing=True.
@@ -975,11 +954,12 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         for mock_ in [
                 mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
-                mock_is_deid, mock_is_fitbit, mock_is_sandbox
+                mock_is_deid, mock_is_fitbit, mock_ru_is_sandbox,
+                mock_rdb_is_sandbox
         ]:
             mock_.return_value = False
         mock_is_rdr.return_value = True
-        mock_get_dataset_type.return_value = RDR
+        mock_rdb_get_dataset_type.return_value = mock_ru_get_dataset_type.return_value = RDR
 
         project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.rdr_id
 
@@ -1000,14 +980,21 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         """
         When ['all_datasets'] specified for dataset_list, BQ retraction runs against all the datasets
         excluding sandbox datasets and OTHER datasets.
-        TODO This exclusion rule might be revisited.
+        NOTE This exclusion rule might be revisited.
         """
-        dataset_list = get_datasets_list(self.client, [ALL_DATASETS])
+        actual = set(get_datasets_list(self.client, [ALL_DATASETS]))
+        all_datasets = set([
+            dataset.dataset_id for dataset in list(self.client.list_datasets())
+        ])
+        datasets_to_exclude = set([
+            dataset for dataset in all_datasets
+            if is_sandbox_dataset(dataset) or get_dataset_type(dataset) == OTHER
+        ])
+
+        self.assertTrue(actual.issubset(all_datasets))
+        self.assertTrue(actual.intersection(datasets_to_exclude) == set())
         self.assertTrue(
-            set([
-                self.rdr_id, self.ehr_id, self.unioned_ehr_id, self.combined_id,
-                self.deid_id, self.fitbit_id
-            ]).issubset(dataset_list))
+            len(actual) == len(all_datasets) - len(datasets_to_exclude))
 
     def test_retract_none(self):
         """

--- a/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
+++ b/tests/integration_tests/data_steward/retraction/retract_data_bq_test.py
@@ -1,5 +1,5 @@
 """
-detail will be added here
+Integration test for BigQuery retraction.
 """
 
 # Python imports
@@ -10,12 +10,11 @@ from unittest import mock
 
 # Project imports
 from app_identity import PROJECT_ID
-from common import (ACTIVITY_SUMMARY, JINJA_ENV, OBSERVATION, PERSON,
-                    UNIONED_EHR)
+from common import (ACTIVITY_SUMMARY, COMBINED, DEID, EHR, FITBIT, JINJA_ENV,
+                    OBSERVATION, PERSON, RDR, UNIONED_EHR)
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from retraction.retract_data_bq import (NONE_STR, RETRACTION_ONLY_EHR,
-                                        RETRACTION_RDR_EHR)
-from retraction import retract_data_bq as rbq
+                                        RETRACTION_RDR_EHR, run_bq_retraction)
 
 CREATE_LOOKUP_TMPL = JINJA_ENV.from_string("""
 CREATE TABLE `{{project}}.{{dataset}}.pid_rid_to_retract` 
@@ -24,69 +23,117 @@ CREATE TABLE `{{project}}.{{dataset}}.pid_rid_to_retract`
 
 LOOKUP_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.pid_rid_to_retract` 
-(person_id, research_id)
+    (person_id, research_id)
 VALUES
-(2, 102), (4, 104)
+    (2, 102), (4, 104)
 """)
 
 PERSON_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.{{table}}` 
-(person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
+    (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
 VALUES
-(1, 0, 2001, 0, 0), (2, 0, 2001, 0, 0), 
-(3, 0, 2001, 0, 0), (4, 0, 2001, 0, 0),
-(5, 0, 2001, 0, 0),
-(101, 0, 2001, 0, 0), (102, 0, 2001, 0, 0), 
-(103, 0, 2001, 0, 0), (104, 0, 2001, 0, 0),
-(105, 0, 2001, 0, 0)
+    (1, 0, 2001, 0, 0), 
+    (2, 0, 2001, 0, 0), 
+    (3, 0, 2001, 0, 0), 
+    (4, 0, 2001, 0, 0),
+    (5, 0, 2001, 0, 0),
+    (101, 0, 2001, 0, 0), 
+    (102, 0, 2001, 0, 0), 
+    (103, 0, 2001, 0, 0), 
+    (104, 0, 2001, 0, 0),
+    (105, 0, 2001, 0, 0)
 """)
 
 OBSERVATION_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.{{table}}` 
-(observation_id, person_id, observation_concept_id, observation_date, observation_type_concept_id)
+    (observation_id, person_id, observation_concept_id, observation_date, observation_type_concept_id)
 VALUES
-(111, 1, 0, date('2021-01-01'), 0), (112, 1, 0, date('2021-01-01'), 0), 
-(121, 2, 0, date('2021-01-01'), 0), (122, 2, 0, date('2021-01-01'), 0), 
-(131, 3, 0, date('2021-01-01'), 0), (132, 3, 0, date('2021-01-01'), 0), 
-(141, 4, 0, date('2021-01-01'), 0), (142, 4, 0, date('2021-01-01'), 0),
-(151, 5, 0, date('2021-01-01'), 0), (152, 5, 0, date('2021-01-01'), 0),
-(1111, 101, 0, date('2021-01-01'), 0), (1112, 101, 0, date('2021-01-01'), 0),
-(1121, 102, 0, date('2021-01-01'), 0), (1122, 102, 0, date('2021-01-01'), 0),
-(1131, 103, 0, date('2021-01-01'), 0), (1132, 103, 0, date('2021-01-01'), 0), 
-(1141, 104, 0, date('2021-01-01'), 0), (1142, 104, 0, date('2021-01-01'), 0),
-(1151, 105, 0, date('2021-01-01'), 0), (1152, 105, 0, date('2021-01-01'), 0)
+    (111, 1, 0, date('2021-01-01'), 0), (112, 1, 0, date('2021-01-01'), 0), 
+    (121, 2, 0, date('2021-01-01'), 0), (122, 2, 0, date('2021-01-01'), 0), 
+    (131, 3, 0, date('2021-01-01'), 0), (132, 3, 0, date('2021-01-01'), 0), 
+    (141, 4, 0, date('2021-01-01'), 0), (142, 4, 0, date('2021-01-01'), 0),
+    (151, 5, 0, date('2021-01-01'), 0), (152, 5, 0, date('2021-01-01'), 0),
+    (1111, 101, 0, date('2021-01-01'), 0), (1112, 101, 0, date('2021-01-01'), 0),
+    (1121, 102, 0, date('2021-01-01'), 0), (1122, 102, 0, date('2021-01-01'), 0),
+    (1131, 103, 0, date('2021-01-01'), 0), (1132, 103, 0, date('2021-01-01'), 0), 
+    (1141, 104, 0, date('2021-01-01'), 0), (1142, 104, 0, date('2021-01-01'), 0),
+    (1151, 105, 0, date('2021-01-01'), 0), (1152, 105, 0, date('2021-01-01'), 0)
+""")
+
+EHR_TMPL = JINJA_ENV.from_string("""
+CREATE TABLE `{{project}}.{{dataset}}.{{table}}` 
+AS SELECT * FROM `{{project}}.{{source_dataset}}.{{source_table}}` 
 """)
 
 MAPPING_OBSERVATION_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}._mapping_observation` 
-(observation_id, src_hpo_id)
+    (observation_id, src_hpo_id)
 VALUES
-(111, 'rdr'), (112, 'rdr'), 
-(121, 'rdr'), (122, 'rdr'), 
-(131, 'fake'), (132, 'fake'), 
-(141, 'fake'), (142, 'fake'), 
-(151, 'foo'), (152, 'foo')
+    (111, 'rdr'), 
+    (112, 'rdr'), 
+    (121, 'rdr'), 
+    (122, 'rdr'), 
+    (131, 'fake'), 
+    (132, 'fake'), 
+    (141, 'fake'), 
+    (142, 'fake'), 
+    (151, 'foo'), 
+    (152, 'foo')
 """)
 
 OBSERVATION_EXT_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.observation_ext` 
-(observation_id, src_id)
+    (observation_id, src_id)
 VALUES
-(1111, 'PPI/PM'), (1112, 'PPI/PM'), 
-(1121, 'PPI/PM'), (1122, 'PPI/PM'), 
-(1131, 'EHR 130'), (1132, 'EHR 130'), 
-(1141, 'EHR 130'), (1142, 'EHR 130'),
-(1151, 'EHR 150'), (1152, 'EHR 150')
+    (1111, 'PPI/PM'), 
+    (1112, 'PPI/PM'), 
+    (1121, 'PPI/PM'), 
+    (1122, 'PPI/PM'), 
+    (1131, 'EHR 130'), 
+    (1132, 'EHR 130'), 
+    (1141, 'EHR 130'), 
+    (1142, 'EHR 130'),
+    (1151, 'EHR 150'), 
+    (1152, 'EHR 150')
 """)
 
 ACTIVITY_SUMMARY_TMPL = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.activity_summary` 
-(person_id)
+    (person_id)
 VALUES
-(1), (2), (3), (4), (5), (101), (102), (103), (104), (105)
+    (1), 
+    (2), 
+    (3), 
+    (4), 
+    (5), 
+    (101), 
+    (102),
+    (103),
+    (104),
+    (105)
 """)
 
-# TODO add DEATH table
+
+def mock_patch_decorator_bundle(*decorators):
+    """abc
+    """
+
+    def _chain(patch):
+        for dec in reversed(decorators):
+            patch = dec(patch)
+        return patch
+
+    return _chain
+
+
+mock_patch_bundle = mock_patch_decorator_bundle(
+    mock.patch('retraction.retract_data_bq.is_fitbit_dataset'),
+    mock.patch('retraction.retract_data_bq.is_deid_dataset'),
+    mock.patch('retraction.retract_data_bq.is_combined_dataset'),
+    mock.patch('retraction.retract_data_bq.is_unioned_dataset'),
+    mock.patch('retraction.retract_data_bq.is_ehr_dataset'),
+    mock.patch('retraction.retract_data_bq.is_rdr_dataset'),
+    mock.patch('retraction.retract_utils.get_dataset_type'))
 
 
 class RetractDataBqTest(BaseTest.BigQueryTestBase):
@@ -100,54 +147,56 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
         super().initialize_class_vars()
 
         cls.project_id = os.environ.get(PROJECT_ID)
-        cls.rdr_dataset_id = os.environ.get('RDR_DATASET_ID')
-        cls.ehr_dataset_id = os.environ.get('BIGQUERY_DATASET_ID')
-        cls.unioned_ehr_dataset_id = os.environ.get('UNIONED_DATASET_ID')
-        cls.combined_dataset_id = os.environ.get('COMBINED_DATASET_ID')
-        cls.fitbit_dataset_id = os.environ.get('FITBIT_DATSET_ID')
-        cls.deid_dataset_id = os.environ.get('COMBINED_DEID_DATASET_ID')
+        cls.rdr_id = os.environ.get('RDR_DATASET_ID')
+        cls.ehr_id = os.environ.get('BIGQUERY_DATASET_ID')
+        cls.unioned_ehr_id = os.environ.get('UNIONED_DATASET_ID')
+        cls.combined_id = os.environ.get('COMBINED_DATASET_ID')
+        cls.deid_id = os.environ.get('COMBINED_DEID_DATASET_ID')
+        cls.fitbit_id = f"{os.environ.get('BIGQUERY_DATASET_ID')}_fitbit"
         cls.sandbox_id = f"{os.environ.get('BIGQUERY_DATASET_ID')}_sandbox"
 
+        cls.hpo_id = 'fake'
         cls.lookup_table_id = 'pid_rid_to_retract'
-        cls.omop_datasets = [
-            cls.rdr_dataset_id, cls.unioned_ehr_dataset_id,
-            cls.combined_dataset_id, cls.deid_dataset_id
-        ]
 
-        cls.fq_table_names = [
-            f'{cls.project_id}.{dataset}.{PERSON}'
-            for dataset in cls.omop_datasets
-        ] + [
-            f'{cls.project_id}.{dataset}.{OBSERVATION}'
-            for dataset in cls.omop_datasets
-        ] + [
-            f'{cls.project_id}.{cls.combined_dataset_id}._mapping_{OBSERVATION}',
-            f'{cls.project_id}.{cls.fitbit_dataset_id}.{ACTIVITY_SUMMARY}',
-            f'{cls.project_id}.{cls.deid_dataset_id}.{ACTIVITY_SUMMARY}',
-            f'{cls.project_id}.{cls.deid_dataset_id}.{OBSERVATION}_ext',
-        ]
+        # omop tables (excluding EHR dataset)
+        for dataset in [
+                cls.rdr_id, cls.unioned_ehr_id, cls.combined_id, cls.deid_id
+        ]:
+            cls.fq_table_names.extend([
+                f'{cls.project_id}.{dataset}.{PERSON}',
+                f'{cls.project_id}.{dataset}.{OBSERVATION}'
+            ])
+            cls.fq_sandbox_table_names.extend([
+                f'{cls.project_id}.{cls.sandbox_id}.retract_{dataset}_{PERSON}',
+                f'{cls.project_id}.{cls.sandbox_id}.retract_{dataset}_{OBSERVATION}'
+            ])
 
-        cls.fq_sandbox_table_names = [
-            #f'{cls.project_id}.{cls.ehr_dataset_id}.fake_{PERSON}',
-            #f'{cls.project_id}.{cls.ehr_dataset_id}.fake_{OBSERVATION}',
-            #f'{cls.project_id}.{cls.ehr_dataset_id}.unioned_ehr_{PERSON}',
-            #f'{cls.project_id}.{cls.ehr_dataset_id}.unioned_ehr_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.{cls.lookup_table_id}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.rdr_dataset_id}_{PERSON}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.rdr_dataset_id}_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.unioned_ehr_dataset_id}_{PERSON}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.unioned_ehr_dataset_id}_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.combined_dataset_id}_{PERSON}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.combined_dataset_id}_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.deid_dataset_id}_{PERSON}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.deid_dataset_id}_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_fake_{PERSON}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_fake_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_unioned_ehr_{PERSON}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_dataset_id}_unioned_ehr_{OBSERVATION}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.deid_dataset_id}_{ACTIVITY_SUMMARY}',
-            f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.fitbit_dataset_id}_{ACTIVITY_SUMMARY}',
-        ]
+        # mapping tables/ ext tables
+        cls.fq_table_names.extend([
+            f'{cls.project_id}.{cls.combined_id}._mapping_{OBSERVATION}',
+            f'{cls.project_id}.{cls.deid_id}.{OBSERVATION}_ext'
+        ])
+
+        # fitbit tables
+        for dataset in [cls.deid_id, cls.fitbit_id]:
+            cls.fq_table_names.append(
+                f'{cls.project_id}.{dataset}.{ACTIVITY_SUMMARY}')
+            cls.fq_sandbox_table_names.append(
+                f'{cls.project_id}.{cls.sandbox_id}.retract_{dataset}_{ACTIVITY_SUMMARY}'
+            )
+
+        # tables for EHR dataset
+        for hpo in [cls.hpo_id, UNIONED_EHR]:
+            cls.fq_sandbox_table_names.extend([
+                f'{cls.project_id}.{cls.ehr_id}.{hpo}_{PERSON}',
+                f'{cls.project_id}.{cls.ehr_id}.{hpo}_{OBSERVATION}',
+                f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_id}_{hpo}_{PERSON}',
+                f'{cls.project_id}.{cls.sandbox_id}.retract_{cls.ehr_id}_{hpo}_{OBSERVATION}'
+            ])
+
+        # lookup table
+        cls.fq_sandbox_table_names.append(
+            f'{cls.project_id}.{cls.sandbox_id}.{cls.lookup_table_id}')
 
         super().setUpClass()
 
@@ -156,184 +205,633 @@ class RetractDataBqTest(BaseTest.BigQueryTestBase):
 
         queries = []
 
-        for dataset in self.omop_datasets:
-            insert_observation = OBSERVATION_TMPL.render(
-                project=self.project_id, dataset=dataset, table=OBSERVATION)
+        # omop tables (excluding EHR dataset)
+        for dataset in [
+                self.rdr_id, self.unioned_ehr_id, self.combined_id, self.deid_id
+        ]:
             insert_person = PERSON_TMPL.render(project=self.project_id,
                                                dataset=dataset,
                                                table=PERSON)
-            queries.extend([insert_observation, insert_person])
+            insert_observation = OBSERVATION_TMPL.render(
+                project=self.project_id, dataset=dataset, table=OBSERVATION)
+            queries.extend([insert_person, insert_observation])
 
-        # insert_observation = OBSERVATION_TMPL.render(
-        #     project=self.project_id,
-        #     dataset=self.ehr_dataset_id,
-        #     table=f'fake_{OBSERVATION}')
-        # insert_person = PERSON_TMPL.render(project=self.project_id,
-        #                                    dataset=self.ehr_dataset_id,
-        #                                    table=f'fake_{PERSON}')
-        # queries.extend([insert_observation, insert_person])
-
-        # insert_observation = OBSERVATION_TMPL.render(
-        #     project=self.project_id,
-        #     dataset=self.ehr_dataset_id,
-        #     table=f'unioned_ehr_{OBSERVATION}')
-        # insert_person = PERSON_TMPL.render(project=self.project_id,
-        #                                    dataset=self.ehr_dataset_id,
-        #                                    table=f'unioned_ehr_{PERSON}')
-        # queries.extend([insert_observation, insert_person])
-
+        # mapping tables/ ext tables
         insert_mapping_observation = MAPPING_OBSERVATION_TMPL.render(
-            project=self.project_id, dataset=self.combined_dataset_id)
-        queries.extend([insert_mapping_observation])
-
+            project=self.project_id, dataset=self.combined_id)
         insert_observation_ext = OBSERVATION_EXT_TMPL.render(
-            project=self.project_id, dataset=self.deid_dataset_id)
-        queries.extend([insert_observation_ext])
+            project=self.project_id, dataset=self.deid_id)
+        queries.extend([insert_mapping_observation, insert_observation_ext])
 
+        # fitbit tables
+        for dataset in [self.deid_id, self.fitbit_id]:
+            insert_activity_summary = ACTIVITY_SUMMARY_TMPL.render(
+                project=self.project_id, dataset=dataset)
+            queries.extend([insert_activity_summary])
+
+        # tables for EHR dataset
+        for hpo in [self.hpo_id, UNIONED_EHR]:
+            create_person_ehr = EHR_TMPL.render(project=self.project_id,
+                                                dataset=self.ehr_id,
+                                                table=f'{hpo}_{PERSON}',
+                                                source_dataset=self.rdr_id,
+                                                source_table=PERSON)
+            create_observation_ehr = EHR_TMPL.render(
+                project=self.project_id,
+                dataset=self.ehr_id,
+                table=f'{hpo}_{OBSERVATION}',
+                source_dataset=self.rdr_id,
+                source_table=OBSERVATION)
+            queries.extend([create_person_ehr, create_observation_ehr])
+
+        # lookup table
         create_lookup = CREATE_LOOKUP_TMPL.render(project=self.project_id,
                                                   dataset=self.sandbox_id)
-        queries.extend([create_lookup])
-
         insert_lookup = LOOKUP_TMPL.render(project=self.project_id,
                                            dataset=self.sandbox_id)
-        queries.extend([insert_lookup])
-
-        insert_activity_summary = ACTIVITY_SUMMARY_TMPL.render(
-            project=self.project_id, dataset=self.fitbit_dataset_id)
-        queries.extend([insert_activity_summary])
-
-        insert_activity_summary = ACTIVITY_SUMMARY_TMPL.render(
-            project=self.project_id, dataset=self.deid_dataset_id)
-        queries.extend([insert_activity_summary])
+        queries.extend([create_lookup, insert_lookup])
 
         self.load_test_data(queries)
 
-    @mock.patch('retraction.retract_data_bq.is_unioned_dataset')
-    @mock.patch('retraction.retract_utils.get_dataset_type')
-    def test_unioned_ehr_rdr_and_ehr(self, mock_get_dataset_type,
-                                     mock_is_unioned_dataset):
+    @mock_patch_bundle
+    def test_unioned_ehr_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                                     mock_is_ehr, mock_is_unioned,
+                                     mock_is_combined, mock_is_deid,
+                                     mock_is_fitbit):
         """
-        a
+        Test for unioned ehr dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        Retracts records based on person_ids in the lookup table.
         """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
         mock_get_dataset_type.return_value = UNIONED_EHR
-        mock_is_unioned_dataset.return_value = True
+        mock_is_unioned.return_value = True
 
-        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
-                              self.lookup_table_id, NONE_STR,
-                              [self.unioned_ehr_dataset_id], RETRACTION_RDR_EHR,
-                              False, self.client)
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.unioned_ehr_id
 
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'],
+                               [1, 3, 5, 101, 102, 103, 104, 105])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{PERSON}',
-            ['person_id'], [1, 3, 5, 101, 102, 103, 104, 105])
-        self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{PERSON}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
             ['person_id'], [2, 4])
 
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{OBSERVATION}',
-            ['observation_id'], [
+            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'], [
                 111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
                 1132, 1141, 1142, 1151, 1152
             ])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{OBSERVATION}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
             ['observation_id'], [121, 122, 141, 142])
 
-    @mock.patch('retraction.retract_data_bq.is_unioned_dataset')
-    @mock.patch('retraction.retract_utils.get_dataset_type')
-    def test_unioned_ehr_only_ehr(self, mock_get_dataset_type,
-                                  mock_is_unioned_dataset):
+    @mock_patch_bundle
+    def test_unioned_ehr_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                                  mock_is_ehr, mock_is_unioned,
+                                  mock_is_combined, mock_is_deid,
+                                  mock_is_fitbit):
         """
-        a
+        Test for unioned ehr dataset.
+        run_bq_retraction with retraction_type = 'only_ehr'.
+        Retracts records based on person_ids in the lookup table.
+        * Same result as retraction_type = 'rdr_and_ehr'.
         """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
         mock_get_dataset_type.return_value = UNIONED_EHR
-        mock_is_unioned_dataset.return_value = True
+        mock_is_unioned.return_value = True
+        mock_is_combined.return_value = False
+        mock_is_deid.return_value = False
+        mock_is_fitbit.return_value = False
 
-        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
-                              self.lookup_table_id, NONE_STR,
-                              [self.unioned_ehr_dataset_id],
-                              RETRACTION_ONLY_EHR, False, self.client)
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.unioned_ehr_id
 
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_ONLY_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'],
+                               [1, 3, 5, 101, 102, 103, 104, 105])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{PERSON}',
-            ['person_id'], [1, 3, 5, 101, 102, 103, 104, 105])
-        self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{PERSON}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
             ['person_id'], [2, 4])
 
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.unioned_ehr_dataset_id}.{OBSERVATION}',
-            ['observation_id'], [
+            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'], [
                 111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
                 1132, 1141, 1142, 1151, 1152
             ])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.unioned_ehr_dataset_id}_{OBSERVATION}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
             ['observation_id'], [121, 122, 141, 142])
 
-    @mock.patch('retraction.retract_data_bq.is_combined_dataset')
-    @mock.patch('retraction.retract_utils.get_dataset_type')
-    def test_combined_ehr_rdr_and_ehr(self, mock_get_dataset_type,
-                                      mock_is_combined_dataset):
+    @mock_patch_bundle
+    def test_combined_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                                  mock_is_ehr, mock_is_unioned,
+                                  mock_is_combined, mock_is_deid,
+                                  mock_is_fitbit):
         """
-        a
+        Test for combined dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        Retracts records based on person_ids in the lookup table.
         """
-        mock_get_dataset_type.return_value = UNIONED_EHR
-        mock_is_combined_dataset.return_value = True
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
 
-        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
-                              self.lookup_table_id, NONE_STR,
-                              [self.combined_dataset_id], RETRACTION_RDR_EHR,
-                              False, self.client)
+        mock_get_dataset_type.return_value = COMBINED
+        mock_is_combined.return_value = True
 
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.combined_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'],
+                               [1, 3, 5, 101, 102, 103, 104, 105])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.combined_dataset_id}.{PERSON}',
-            ['person_id'], [1, 3, 5, 101, 102, 103, 104, 105])
-        self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{PERSON}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
             ['person_id'], [2, 4])
 
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.combined_dataset_id}.{OBSERVATION}',
-            ['observation_id'], [
+            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'], [
                 111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
                 1132, 1141, 1142, 1151, 1152
             ])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{OBSERVATION}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
             ['observation_id'], [121, 122, 141, 142])
 
-    @mock.patch('retraction.retract_data_bq.is_combined_dataset')
-    @mock.patch('retraction.retract_utils.get_dataset_type')
-    def test_combined_ehr_only_ehr(self, mock_get_dataset_type,
-                                   mock_is_combined_dataset):
+    @mock_patch_bundle
+    def test_combined_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                               mock_is_ehr, mock_is_unioned, mock_is_combined,
+                               mock_is_deid, mock_is_fitbit):
         """
-        a
+        Test for combined dataset.
+        run_bq_retraction with retraction_type = 'only_ehr'.
+        Retracts records based on person_ids in the lookup table and
+        src_hpo_id in the mapping table.
+        person table is not retracted because all the data is from RDR.
         """
-        mock_get_dataset_type.return_value = UNIONED_EHR
-        mock_is_combined_dataset.return_value = True
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
 
-        rbq.run_bq_retraction(self.project_id, self.sandbox_id,
-                              self.lookup_table_id, NONE_STR,
-                              [self.combined_dataset_id], RETRACTION_ONLY_EHR,
-                              False, self.client)
+        mock_get_dataset_type.return_value = COMBINED
+        mock_is_combined.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.combined_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_ONLY_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'],
+                               [1, 2, 3, 4, 5, 101, 102, 103, 104, 105])
+        self.assertTableDoesNotExist(
+            f'{self.project_id}.{self.sandbox_id}.retract_{dataset_id}_{PERSON}'
+        )
 
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.combined_dataset_id}.{PERSON}',
-            ['person_id'], [1, 2, 3, 4, 5, 101, 102, 103, 104, 105])
-
-        # TODO add table_not_found assertion
-        # self.assertRowIDsMatch(
-        #     f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{PERSON}',
-        #     ['person_id'], [])
-
-        self.assertRowIDsMatch(
-            f'{self.project_id}.{self.combined_dataset_id}.{OBSERVATION}',
-            ['observation_id'], [
+            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'], [
                 111, 112, 121, 122, 131, 132, 151, 152, 1111, 1112, 1121, 1122,
                 1131, 1132, 1141, 1142, 1151, 1152
             ])
         self.assertRowIDsMatch(
-            f'{self.project_id}.{self.sandbox_id}.retract_{self.combined_dataset_id}_{OBSERVATION}',
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
             ['observation_id'], [141, 142])
+
+    @mock_patch_bundle
+    def test_deid_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                              mock_is_ehr, mock_is_unioned, mock_is_combined,
+                              mock_is_deid, mock_is_fitbit):
+        """
+        Test for deid dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        Retracts records based on research_ids in the lookup table.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = DEID
+        mock_is_deid.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.deid_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'], [1, 2, 3, 4, 5, 101, 103, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
+            ['person_id'], [102, 104])
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{OBSERVATION}',
+                               ['observation_id'], [
+                                   111, 112, 121, 122, 131, 132, 141, 142, 151,
+                                   152, 1111, 1112, 1131, 1132, 1151, 1152
+                               ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
+            ['observation_id'], [1121, 1122, 1141, 1142])
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
+                               ['person_id'], [1, 2, 3, 4, 5, 101, 103, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}',
+            ['person_id'], [102, 104])
+
+    @mock_patch_bundle
+    def test_deid_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                           mock_is_ehr, mock_is_unioned, mock_is_combined,
+                           mock_is_deid, mock_is_fitbit):
+        """
+        Test for deid dataset.
+        run_bq_retraction with retraction_type = 'only_ehr'.
+        Retracts records based on research_ids in the lookup table and
+        src_id in the ext table.
+        person table and fitbit table are not retracted because all the
+        data is from RDR.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = DEID
+        mock_is_deid.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.deid_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_ONLY_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'],
+                               [1, 2, 3, 4, 5, 101, 102, 103, 104, 105])
+        self.assertTableDoesNotExist(
+            f'{self.project_id}.{self.sandbox_id}.retract_{dataset_id}_{PERSON}'
+        )
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'], [
+                111, 112, 121, 122, 131, 132, 141, 142, 151, 152, 1111, 1112,
+                1121, 1122, 1131, 1132, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
+            ['observation_id'], [1141, 1142])
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
+                               ['person_id'],
+                               [1, 2, 3, 4, 5, 101, 102, 103, 104, 105])
+        self.assertTableDoesNotExist(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}'
+        )
+
+    @mock_patch_bundle
+    def test_rdr_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                             mock_is_ehr, mock_is_unioned, mock_is_combined,
+                             mock_is_deid, mock_is_fitbit):
+        """
+        Test for rdr dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        Retracts records based on person_ids in the lookup table.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = RDR
+        mock_is_rdr.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.rdr_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{PERSON}',
+                               ['person_id'],
+                               [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{OBSERVATION}', ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+    @mock_patch_bundle
+    def test_rdr_only_ehr(self, mock_get_dataset_type, mock_is_rdr, mock_is_ehr,
+                          mock_is_unioned, mock_is_combined, mock_is_deid,
+                          mock_is_fitbit):
+        """
+        Test for rdr dataset.
+        run_bq_retraction with retraction_type = 'only_ehr'.
+        Throws an error since RDR dataset cannot be retracted when 'only_ehr'.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = RDR
+        mock_is_rdr.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.rdr_id
+
+        with self.assertRaises(ValueError):
+            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                              NONE_STR, [dataset_id], RETRACTION_ONLY_EHR,
+                              False, self.client)
+
+    @mock_patch_bundle
+    def test_ehr_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                             mock_is_ehr, mock_is_unioned, mock_is_combined,
+                             mock_is_deid, mock_is_fitbit):
+        """
+        Test for ehr dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        EHR dataset's table naming convention is different from other datasets.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = EHR
+        mock_is_ehr.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.ehr_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          self.hpo_id, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{self.hpo_id}_{PERSON}', ['person_id'],
+            [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{UNIONED_EHR}_{PERSON}', ['person_id'],
+            [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{self.hpo_id}_{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{UNIONED_EHR}_{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+    @mock_patch_bundle
+    def test_ehr_ehr_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                              mock_is_ehr, mock_is_unioned, mock_is_combined,
+                              mock_is_deid, mock_is_fitbit):
+        """
+        Test for ehr dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        EHR dataset's table naming convention is different from other datasets.
+        * Same result as retraction_type = 'rdr_and_ehr'.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = EHR
+        mock_is_ehr.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.ehr_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id, 'fake',
+                          [dataset_id], RETRACTION_ONLY_EHR, False, self.client)
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{self.hpo_id}_{PERSON}', ['person_id'],
+            [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{UNIONED_EHR}_{PERSON}', ['person_id'],
+            [1, 3, 5, 101, 102, 103, 104, 105])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{PERSON}',
+            ['person_id'], [2, 4])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{self.hpo_id}_{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{self.hpo_id}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{dataset_id}.{UNIONED_EHR}_{OBSERVATION}',
+            ['observation_id'], [
+                111, 112, 131, 132, 151, 152, 1111, 1112, 1121, 1122, 1131,
+                1132, 1141, 1142, 1151, 1152
+            ])
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{UNIONED_EHR}_{OBSERVATION}',
+            ['observation_id'], [121, 122, 141, 142])
+
+    @mock_patch_bundle
+    def test_ehr_without_hpo_id(self, mock_get_dataset_type, mock_is_rdr,
+                                mock_is_ehr, mock_is_unioned, mock_is_combined,
+                                mock_is_deid, mock_is_fitbit):
+        """
+        Test for ehr dataset.
+        Throws a ValueError when hpo_id is not specified.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = EHR
+        mock_is_ehr.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.ehr_id
+
+        with self.assertRaises(ValueError):
+            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                              NONE_STR, [dataset_id], RETRACTION_ONLY_EHR,
+                              False, self.client)
+
+    @mock_patch_bundle
+    def test_fitbit_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                                mock_is_ehr, mock_is_unioned, mock_is_combined,
+                                mock_is_deid, mock_is_fitbit):
+        """
+        Test for fitbit dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = FITBIT
+        mock_is_fitbit.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
+                               ['person_id'], [1,3,5, 101, 102,103,104,105])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}',
+            ['person_id'], [2,4])
+
+    @mock_patch_bundle
+    def test_fitbit_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                             mock_is_ehr, mock_is_unioned, mock_is_combined,
+                             mock_is_deid, mock_is_fitbit):
+        """
+        Test for fitbit dataset.
+        run_bq_retraction with retraction_type = 'only_ehr'.
+        Throws an error since fitbit dataset cannot be retracted when 'only_ehr'.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = FITBIT
+        mock_is_fitbit.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
+
+        with self.assertRaises(ValueError):
+            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                              NONE_STR, [dataset_id], RETRACTION_ONLY_EHR,
+                              False, self.client)
+
+    @mock_patch_bundle
+    def test_deid_fitbit_rdr_and_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                                     mock_is_ehr, mock_is_unioned,
+                                     mock_is_combined, mock_is_deid,
+                                     mock_is_fitbit):
+        """
+        Test for fitbit dataset.
+        run_bq_retraction with retraction_type = 'rdr_and_ehr'.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = FITBIT
+        mock_is_deid.return_value = True
+        mock_is_fitbit.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
+
+        run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                          NONE_STR, [dataset_id], RETRACTION_RDR_EHR, False,
+                          self.client)
+
+        self.assertRowIDsMatch(f'{project_id}.{dataset_id}.{ACTIVITY_SUMMARY}',
+                               ['person_id'], [1, 2, 3, 4, 5, 101, 103, 105])
+
+        self.assertRowIDsMatch(
+            f'{project_id}.{sandbox_id}.retract_{dataset_id}_{ACTIVITY_SUMMARY}',
+            ['person_id'], [102, 104])
+
+    @mock_patch_bundle
+    def test_deid_fitbit_only_ehr(self, mock_get_dataset_type, mock_is_rdr,
+                                  mock_is_ehr, mock_is_unioned,
+                                  mock_is_combined, mock_is_deid,
+                                  mock_is_fitbit):
+        """
+        Test for deid fitbit dataset.
+        run_bq_retraction with retraction_type = 'only_ehr'.
+        Throws an error since fitbit dataset cannot be retracted when 'only_ehr'.
+        """
+        for mock_ in [
+                mock_is_rdr, mock_is_ehr, mock_is_unioned, mock_is_combined,
+                mock_is_deid, mock_is_fitbit
+        ]:
+            mock_.return_value = False
+
+        mock_get_dataset_type.return_value = FITBIT
+        mock_is_deid.return_value = True
+        mock_is_fitbit.return_value = True
+
+        project_id, sandbox_id, dataset_id = self.project_id, self.sandbox_id, self.fitbit_id
+
+        with self.assertRaises(ValueError):
+            run_bq_retraction(project_id, sandbox_id, self.lookup_table_id,
+                              NONE_STR, [dataset_id], RETRACTION_ONLY_EHR,
+                              False, self.client)

--- a/tests/unit_tests/data_steward/retraction/retract_utils_test.py
+++ b/tests/unit_tests/data_steward/retraction/retract_utils_test.py
@@ -176,19 +176,17 @@ class RetractUtilsTest(unittest.TestCase):
     @mock.patch('retraction.retract_utils.BigQueryClient')
     def test_get_datasets_list(self, mock_bq_client):
         #pre-conditions
-        removed_datasets = [
+        datasets = [
             data_ref('foo', 'vocabulary20201010'),
-            data_ref('foo', 'R2019q4r1_deid_sandbox')
-        ]
-        expected_datasets = [
+            data_ref('foo', 'R2019q4r1_deid_sandbox'),
             data_ref('foo', '2021q1r1_rdr'),
             data_ref('foo', 'C2020q1r1_deid'),
             data_ref('foo', 'R2019q4r1_deid'),
             data_ref('foo', '2018q4r1_rdr')
         ]
-        expected_list = [dataset.dataset_id for dataset in expected_datasets]
+        expected_list = [dataset.dataset_id for dataset in datasets]
 
-        mock_bq_client.list_datasets.return_value = removed_datasets + expected_datasets
+        mock_bq_client.list_datasets.return_value = datasets
         type(mock_bq_client).project = mock.PropertyMock(
             return_value='fake_project_id')
 

--- a/tests/unit_tests/data_steward/retraction/retract_utils_test.py
+++ b/tests/unit_tests/data_steward/retraction/retract_utils_test.py
@@ -176,17 +176,19 @@ class RetractUtilsTest(unittest.TestCase):
     @mock.patch('retraction.retract_utils.BigQueryClient')
     def test_get_datasets_list(self, mock_bq_client):
         #pre-conditions
-        datasets = [
+        removed_datasets = [
             data_ref('foo', 'vocabulary20201010'),
-            data_ref('foo', 'R2019q4r1_deid_sandbox'),
+            data_ref('foo', 'R2019q4r1_deid_sandbox')
+        ]
+        expected_datasets = [
             data_ref('foo', '2021q1r1_rdr'),
             data_ref('foo', 'C2020q1r1_deid'),
             data_ref('foo', 'R2019q4r1_deid'),
             data_ref('foo', '2018q4r1_rdr')
         ]
-        expected_list = [dataset.dataset_id for dataset in datasets]
+        expected_list = [dataset.dataset_id for dataset in expected_datasets]
 
-        mock_bq_client.list_datasets.return_value = datasets
+        mock_bq_client.list_datasets.return_value = removed_datasets + expected_datasets
         type(mock_bq_client).project = mock.PropertyMock(
             return_value='fake_project_id')
 


### PR DESCRIPTION
*See the comment in DC-2904 for how we can run these updated scripts.*
--

`run_retraction.py`
- Updated `create_lookup_table()` so it can accept `if not exists` condition for the `create table` statement.
- Updated comments and docstrings to the latest.

`retract_data_gcs.py`
- No update is needed.

`retract_data_bq.py`
- Updated so it also works for the datasets that are NOT `COMBINED`, `DEID`, and `FITBIT`.
- Rewrote some of the functions for simplicity.

`retract_utils.py`
- Removed [this condition](https://github.com/all-of-us/curation/pull/1455/files#diff-7d103e313f336b657fc1480eb54049d0c49533fd1b0bfb2611db42bab5b6f108L122) that was omitting `sandbox` datasets no matter what. `retract_utils_test.py` is updated accordingly.

`retract_data_bq_test.py`
- Added test cases for each dataset with each retraction option.

`main.py`
- Removed the cron job for retracting the output prod dataset. For output prod, we can run the retraction on the prod dataset and publish them to output prod.



