### PR TITLE
[DST-347] Update rt_cdr_qc notebooks

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -13,10 +13,11 @@
 #     name: python3
 # ---
 
-# # These are queries to validate RT_deid_base_cdr
+# <div class='alert alert-info' style='font-family:Arial; font-size:30px' > These are queries to validate RT_deid_base_cdr </div>
 
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -27,11 +28,15 @@ project_id = ""
 com_cdr = ""
 deid_base_cdr=""
 pipeline=""
-run_as = ""
-# -
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#com_cdr = "2021q3r2_combined"
+#deid_base_cdr = "R2021q3r2_deid_base"
+#pipeline = "pipeline_tables"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -39,6 +44,9 @@ impersonation_creds = auth.get_impersonation_credentials(
 
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
+
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
 
 # # 1 Verify that if a person has multiple SELECTion(Hispanic + other race) in pre_deid_com_cdr, the output in deid_base_cdr observation table should result in two rows - one for Ethnicity AND one for race. 
 #
@@ -55,24 +63,24 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 #
 #
 
-# ## 1.1 step1
+# ## step1
 # - Verify the following columns in the deid_cdr Observation table have been set to null:
 # o   value_as_string
 # o   value_source_value
 #
 # has been done in first sql for deid, can be skipped here
 
-# # 1.2 step2  Find person_ids in pre_dedi_com_cdr person table who have ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586146 OR 1586142 OR 1586143) , then verify that the output in the deid_base_cdr observation table for that person_id after mapping  will results in 2-rows .
+# ## Query 1.2 step2  Find person_ids in pre_dedi_com_cdr person table who have ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586146 OR 1586142 OR 1586143) , then verify that the output in the deid_base_cdr observation table for that person_id after mapping  will results in 2-rows .
 #
 #   step 3
 # Verify that the 2-rows have 2-different value_source_concept_id values in the deid_base_cdr Observation table.
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id AS person_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m 
-JOIN `{project_id}.{com_cdr}.person` com 
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
+JOIN `{{project_id}}.{{com_cdr}}.person` com 
 ON m.person_id = com.person_id 
 WHERE com.ethnicity_source_concept_id = 1586147
 AND com.race_source_concept_id in (1586142, 1586143, 1586146 )
@@ -80,41 +88,33 @@ AND com.race_source_concept_id in (1586142, 1586143, 1586146 )
  
 df2 AS (
 SELECT DISTINCT person_id , COUNT (distinct value_source_concept_id ) AS countp
-FROM `{project_id}.{deid_base_cdr}.observation`
+FROM `{{project_id}}.{{deid_base_cdr}}.observation`
 WHERE  observation_source_value = 'Race_WhatRaceEthnicity' 
 GROUP BY person_id
  )
  
 SELECT COUNT (*) AS n_not_two_rows FROM df2
 WHERE person_id IN (SELECT person_id FROM df1) AND countp !=2 
-
-    '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query 1.2 these person_ids have 2-rows in observation',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query 1.2 these person_ids have 2-rows in observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query1.2 these person_ids have 2-rows in observation',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1.2 these person_ids have 2-rows in observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
 # ## one error in new cdr. this person_id fails to meet the rule.
 
 # +
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id AS person_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m 
-JOIN `{project_id}.{com_cdr}.person` com 
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
+JOIN `{{project_id}}.{{com_cdr}}.person` com 
 ON m.person_id = com.person_id 
 WHERE com.ethnicity_source_concept_id = 1586147
 AND com.race_source_concept_id in (1586142, 1586143, 1586146 )
@@ -122,32 +122,33 @@ AND com.race_source_concept_id in (1586142, 1586143, 1586146 )
  
 df2 AS (
 SELECT DISTINCT person_id , count (distinct value_source_concept_id ) AS countp
-FROM `{project_id}.{deid_base_cdr}.observation`
+FROM `{{project_id}}.{{deid_base_cdr}}.observation`
 WHERE  observation_source_value = 'Race_WhatRaceEthnicity' 
 GROUP BY person_id
  )
  
 SELECT distinct person_id, value_source_concept_id, value_source_value
-FROM `{project_id}.{deid_base_cdr}.observation`
+FROM `{{project_id}}.{{deid_base_cdr}}.observation`
 WHERE  observation_source_value = 'Race_WhatRaceEthnicity' 
 AND person_id IN (SELECT person_id from df2 where countp !=2 )
 AND person_id IN (SELECT person_id FROM df1) 
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
 
 df1
 # -
 
-# # 1.3 step : Verify that if a person_id has ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586145 OR 1586144)  in the pre_deid_com_cdr person table, the output in the deid_cdr observation table for that person_id  after mapping will result in 2-rows AND the 2000000001 race value is populated in value_source_concept_id field in the other row of observation table in the deid dataset.
+# ## Query 1.3 step : Verify that if a person_id has ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586145 OR 1586144)  in the pre_deid_com_cdr person table, the output in the deid_cdr observation table for that person_id  after mapping will result in 2-rows AND the 2000000001 race value is populated in value_source_concept_id field in the other row of observation table in the deid dataset.
 
 # +
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct m.research_id AS person_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m 
-join `{project_id}.{com_cdr}.person` com 
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
+join `{{project_id}}.{{com_cdr}}.person` com 
 ON m.person_id = com.person_id 
 WHERE com.ethnicity_source_concept_id = 1586147
 AND com.race_source_concept_id IN (1586145, 1586144) 
@@ -155,7 +156,7 @@ AND com.race_source_concept_id IN (1586145, 1586144)
  
 df2 AS (
 SELECT  person_id , count (distinct value_source_concept_id) AS countp
-FROM `{project_id}.{deid_base_cdr}.observation`
+FROM `{{project_id}}.{{deid_base_cdr}}.observation`
 WHERE  observation_source_value = 'Race_WhatRaceEthnicity' 
 AND value_source_concept_id IN (2000000001 ,1586147)
 GROUP BY person_id
@@ -163,152 +164,108 @@ GROUP BY person_id
  
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE person_id NOT IN (SELECT person_id FROM df2 WHERE countp=2)
-    '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query1.3 these person_ids have 2-rows in observation',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query1.3 these person_ids have 2-rows in observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query1.3 these person_ids have 2-rows in observation',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1.3 these person_ids have 2-rows in observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
-# # 1.4 Verify that if a person_id has ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS multiple SELECTions (2 or more) in the pre_deid_com_cdr person table, the output in the deid_base_cdr observation table for that person_id  will result in 2 OR MORE rows .
+# ## Query 1.4 Verify that if a person_id has ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS multiple SELECTions (2 or more) in the pre_deid_com_cdr person table, the output in the deid_base_cdr observation table for that person_id  will result in 2 OR MORE rows .
 #
 # observation_source_value = 'Race_WhatRaceEthnicity' AND value_source_concept_id
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct person_id
-FROM `{project_id}.{deid_base_cdr}.person` 
+FROM `{{project_id}}.{{deid_base_cdr}}.person` 
 WHERE ethnicity_source_concept_id = 1586147
 AND race_source_concept_id=2000000008
  ),
  
 df2 AS (
 SELECT DISTINCT person_id , count (distinct value_source_concept_id ) AS countp
-FROM `{project_id}.{deid_base_cdr}.observation`
+FROM `{{project_id}}.{{deid_base_cdr}}.observation`
 WHERE  observation_source_value = 'Race_WhatRaceEthnicity' 
 GROUP BY person_id
  )
  
 SELECT COUNT (*) AS n_row_not_pass FROM df2
 WHERE person_id IN (SELECT person_id FROM df1) AND countp <2 
-
-    '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query1.4 these person_ids have 2 or more rows in observation',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query1.4 these person_ids have 2 or more rows in observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query1.4 these person_ids have 2 or more rows in observation',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1.4 these person_ids have 2 or more rows in observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# # 1.5  GR_01_2	"Race Ethnicity:  Race non-responses DC-618
+# ## Query 1.5  GR_01_2	"Race Ethnicity:  Race non-responses DC-618
 #
 # Verify that if race_name / race_source_value field in deid_base_cdr PERSON table populates AS "None Indicated" , the race_concept_id field in deid_base_cdr person table should populate : 2100000001
 #
 # this test case can be verified only after the PERSON table is repopulated.
 
 # has to be deid_base
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct race_source_value,race_source_concept_id ,race_concept_id
-FROM `{project_id}.{deid_base_cdr}.person`
+FROM `{{project_id}}.{{deid_base_cdr}}.person`
 WHERE race_concept_id = 2100000001 )
 
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE  race_source_concept_id !=0 OR race_source_value !='None Indicated'
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query1.5 Race_source_concept_id suppresion in observation',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query1.5 Race_source_concept_id suppresion in observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query1.5 Race_source_concept_id suppresion in observation',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1.5 Race_source_concept_id suppresion in observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# ## 2 Gender Generalization Rule
+# # Query 2 Gender Generalization Rule
 #
 # objective: Account for new gender identify response option (DC-654)
 # The new concept ID in the gender question, “CloserGenderDescription_TwoSpirit” (value_source_concept_id=701374) needs to be generalized to value_source_concept_id = 2000000002 (GenderIdentity_GeneralizedDiffGender)
 
 # has to be deid_base
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 
 SELECT COUNT (distinct p.person_id) AS n_PERSON_ID_not_pass
-FROM  `{project_id}.{com_cdr}.observation` com
-JOIN  `{project_id}.{pipeline}.pid_rid_mapping` m 
+FROM  `{{project_id}}.{{com_cdr}}.observation` com
+JOIN  `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
 ON com.person_id=m.person_id
-JOIN  `{project_id}.{deid_base_cdr}.observation` p
+JOIN  `{{project_id}}.{{deid_base_cdr}}.observation` p
 ON p.person_id=m.research_id
 WHERE com.value_source_concept_id = 701374
 AND p.observation_source_value='Gender_GenderIdentity'
 AND p.value_source_concept_id !=2000000002
-
-
- '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query2 Gender_value_source_concept_id matched value_as_concept_id in observation',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query2 Gender_value_source_concept_id matched value_as_concept_id in observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query2 Gender_value_source_concept_id matched value_as_concept_id in observation',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query2 Gender_value_source_concept_id matched value_as_concept_id in observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# # 3 Sex/gender mismatch
+# # Query 3 Sex/gender mismatch
 #
 # Verify that if a person responds
 # 1. Male sex at birth AND female gender
@@ -322,17 +279,17 @@ df1
 # 1. look up for the pids with sexatBirth = female/male AND gender_male or female in pre_deid_com_cdr
 #
 #
-# 2. lookup for the mismatch PIDs in deid_base_cdr.PERSON table, whether these people keep sex_birth AND gender wAS generalized to gender_source_concept_id = 2000000002
+# 2. lookup for the mismatch PIDs in deid_base_cdr.PERSON table, whether these people keep sex_birth AND gender wAS generalized to gender_source_concept_id = 2000000002 
 #
-# 3. Lookup for the same pids in observation table AND Verify that if the value_source_concept_id field in OBSERVATION table populates: 2000000002  AND the value_as_concept_id field in deid_cdr table should populate  2000000002
+# 3. Lookup for the same pids in observation table AND Verify that if the value_source_concept_id field in OBSERVATION table populates: 2000000002  AND the value_as_concept_id field in deid_cdr table should populate  2000000002 
 
 # check in deid_base_cdr.person
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id AS person_id
-FROM  `{project_id}.{com_cdr}.observation` ob
-JOIN  `{project_id}.{pipeline}.pid_rid_mapping` m 
+FROM  `{{project_id}}.{{com_cdr}}.observation` ob
+JOIN  `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
 on ob.person_id=m.person_id
 WHERE value_source_value IN ('SexAtBirth_Female' ,'GenderIdentity_Man')
 GROUP BY m.research_id
@@ -340,134 +297,110 @@ HAVING count (distinct value_source_value)=2
 )
 
   
-SELECT COUNT (*) AS n_row_not_pass FROM `{project_id}.{deid_base_cdr}.person` 
-JOIN `{project_id}.{deid_base_cdr}.person_ext` using (person_id)
+SELECT COUNT (*) AS n_row_not_pass FROM `{{project_id}}.{{deid_base_cdr}}.person` 
+JOIN `{{project_id}}.{{deid_base_cdr}}.person_ext` using (person_id)
 WHERE person_id IN (SELECT person_id FROM df1)
 AND (sex_at_birth_source_value !='SexAtBirth_Female' AND gender_source_concept_id !=2000000002)
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3 Sex_female/gender_man mismatch in deid_base_cdr.person table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query3 Sex_female/gender_man mismatch in deid_base_cdr.person table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3 Sex_female/gender_man mismatch in deid_base_cdr.person table',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3 Sex_female/gender_man mismatch in deid_base_cdr.person table', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
 # +
-# check mismatched sex_male/gender_woman in deid_base_cdr.person
+# check mismatched sex_male/gender_woman in deid_base_cdr.person 
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 
 SELECT m.research_id AS person_id
-FROM  `{project_id}.{com_cdr}.observation` ob
-JOIN  `{project_id}.{pipeline}.pid_rid_mapping` m 
+FROM  `{{project_id}}.{{com_cdr}}.observation` ob
+JOIN  `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
 ON ob.person_id=m.person_id
 WHERE value_source_value IN ('SexAtBirth_Male' ,'GenderIdentity_Woman')
 GROUP BY m.research_id
 HAVING count (distinct value_source_value)=2 
   )
   
-SELECT COUNT (*) AS n_row_not_pass FROM `{project_id}.{deid_base_cdr}.person` 
-JOIN `{project_id}.{deid_base_cdr}.person_ext` using (person_id)
+SELECT COUNT (*) AS n_row_not_pass FROM `{{project_id}}.{{deid_base_cdr}}.person` 
+JOIN `{{project_id}}.{{deid_base_cdr}}.person_ext` using (person_id)
 WHERE person_id IN (SELECT person_id FROM df1) 
 AND (sex_at_birth_source_value !='SexAtBirth_Male' AND gender_source_concept_id !=2000000002) 
-
- '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3.2 Sex_male/gender_woman mismatch in deid_base_cdr.person',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr)
+df1=execute(client, q) 
+if df1.eq(0).any().any():
+ df = df.append({'query' : 'Query3.2 Sex_male/gender_woman mismatch in deid_base_cdr.person', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3.2 Sex_male/gender_woman mismatch in deid_base_cdr.person',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3.2 Sex_male/gender_woman mismatch in deid_base_cdr.person', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
 #
-# # 4  [DC-938] Verify that the COPE survey date is not date-shifted
+# # Query 4  [DC-938] Verify that the COPE survey date is not date-shifted
 #
 # related deid_report7_cope notebook
 #
 # observation_concept_id = 1333342, which is just the concept_id for COPE, nothing to do with detailed topics/questions
 # This test case will run with the De-id base cleaning rules
 #
-# expected result: no dateshift is applied
+# expected result: no dateshift is applied 
 #
 # result: pass if not shifted.
 #
 # ## in new cdr, need to fix survey_version_concept_id first.
 
 # has to be deid_base
-query = f'''
+query = JINJA_ENV.from_string("""
 
-WITH df1 as (
+WITH cope_survey_id AS (
+SELECT
+DISTINCT e.survey_version_concept_id, c.concept_name
+FROM `{{project_id}}.{{deid_base_cdr}}.observation_ext` e
+JOIN `{{project_id}}.{{deid_base_cdr}}.concept` c
+ON c.concept_id = e.survey_version_concept_id),
+
+df1 as (
 SELECT
 d.observation_date AS date_D,
 i.observation_date AS date_i,
 DATE_DIFF(DATE(i.observation_date), DATE(d.observation_date),day) AS diff,
- e.survey_version_concept_id AS version
-FROM `{project_id}.{com_cdr}.observation` i
-JOIN `{project_id}.{deid_base_cdr}.observation` d
+ e.survey_version_concept_id
+FROM `{{project_id}}.{{com_cdr}}.observation` i
+JOIN `{{project_id}}.{{deid_base_cdr}}.observation` d
 ON i.observation_id = d.observation_id
-JOIN `{project_id}.{deid_base_cdr}.observation_ext` e
+JOIN `{{project_id}}.{{deid_base_cdr}}.observation_ext` e
 ON e.observation_id = d.observation_id
-WHERE e.survey_version_concept_id IN (2100000002, 2100000003, 2100000004, 2100000005, 2100000006,
- 2100000007, 905047, 905055, 765936)
+WHERE e.survey_version_concept_id IN (SELECT survey_version_concept_id from cope_survey_id)
 )
 
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE diff !=0
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query4 date not shifited',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query4 date not shifited', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query4 date not shifited',
-        'result': ''
-    },
-                   ignore_index=True)
+ df = df.append({'query' : 'Query4 date not shifited', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# ##  4.2 [DC-1051] Verify that "PPI Drop Duplicates" Rule is excluded COPE responses
+# ##  Query 4.2 [DC-1051] Verify that "PPI Drop Duplicates" Rule is excluded COPE responses
 #
 # steps:
 #
-# 1. look up for person_id that have completed all the versions of COPE survey by joining observation and _ext table. (query1: col I)
-# 2. In Observation table of the person_id, look up for the COPE survey questions.  (query2: col J)
+# 1. look up for person_id that have completed all the versions of COPE survey by joining observation and _ext table. (query1: col I) 
+# 2. In Observation table of the person_id, look up for the COPE survey questions.  (query2: col J) 
 #  (Observation_source value  =
 # 'overallhealth_14b'
 # 'basics_12'
@@ -475,24 +408,24 @@ df1
 # 'cu_covid'
 # 'copect_58'
 #
-# 3. validate that the duplicate responses of those survey questions are retained for all the survey version
+# 3. validate that the duplicate responses of those survey questions are retained for all the survey version 
 #
 #
-# results: Found duplicate rows for survey QR.
+# results: Found duplicate rows for survey QR. 
 #
-# <font color='red'>
-#
+# <font color='red'> 
+#     
 # this part has to be done in deid_base_cdr, can not use deid, which has no results.
 #
 # in new cdr, need to fix survey_version_concept_id first.
 
 # has to be deid_base
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT d.person_id, COUNT(*) AS countp
-FROM `{project_id}.{deid_base_cdr}.observation` d
-JOIN  `{project_id}.{deid_base_cdr}.observation_ext` e
+FROM `{{project_id}}.{{deid_base_cdr}}.observation` d
+JOIN  `{{project_id}}.{{deid_base_cdr}}.observation_ext` e
 ON e.observation_id = d.observation_id
 WHERE e.survey_version_concept_id IN (2100000004, 2100000003, 2100000002)
 AND d.observation_source_value IN ('overallhealth_14b' , 'basics_12' ,'basics_11a' ,'cu_covid', 'copect_58')
@@ -501,82 +434,71 @@ GROUP BY person_id
 
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE countp=0
-    
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query4.2 PPI Drop Duplicates rule exclusion',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query4.2 PPI Drop Duplicates rule exclusion', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4.2 PPI Drop Duplicates rule exclusion',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4.2 PPI Drop Duplicates rule exclusion', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# ## extra
+# # Qury 5 equal counts for sex_at_birth columns
+#
+# to ensure that there are equal counts FROM both the observation and person_ext tables for the sex_at_birth_* columns that can be added to the RT validation notebook:
+#
+# **extra**
 #
 # https://precisionmedicineinitiative.atlassian.net/browse/DC-1404
 #
-# ## 5  RT CDR Base generation
+# **RT CDR Base generation**
 # https://precisionmedicineinitiative.atlassian.net/browse/DC-1402
-#
-# to ensure that there are equal counts FROM both the observation and person_ext tables for the sex_at_birth_* columns that can be added to the RT validation notebook:
 
-# +
-
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT 
 sex_at_birth_source_value AS sex_at_birth_value, count(*) AS countp1
-FROM `{project_id}.{deid_base_cdr}.person_ext`
-JOIN `{project_id}.{deid_base_cdr}.person` USING (person_id)
+FROM `{{project_id}}.{{deid_base_cdr}}.person_ext`
+JOIN `{{project_id}}.{{deid_base_cdr}}.person` USING (person_id)
 WHERE sex_at_birth_concept_id !=0
 GROUP BY sex_at_birth_source_value
--- order by sex_at_birth_source_value
+-- order by sex_at_birth_source_value --
 ),
 
 df2 AS (
 SELECT  value_source_value AS sex_at_birth_value, count(*) AS countp2
-FROM `{project_id}.{deid_base_cdr}.observation`
+FROM `{{project_id}}.{{deid_base_cdr}}.observation`
 WHERE observation_source_concept_id = 1585845
 GROUP BY value_source_value
--- order by value_source_value
+-- order by value_source_value --
 )
 
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 FULL JOIN df2 USING (sex_at_birth_value)
 WHERE countp1 !=countp2
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query5 equal counts for sex_at_birth columns',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_base_cdr=deid_base_cdr) 
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query5 equal counts for sex_at_birth columns', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query5 equal counts for sex_at_birth columns',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query5 equal counts for sex_at_birth columns', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
-# -
+
 
 # # Summary_deid_base_validation
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null', '']))
-df.style.highlight_null(null_color='red').set_properties(
-    **{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+# -
+
+

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -13,7 +13,7 @@
 #     name: python3
 # ---
 
-# <div class='alert alert-info' style='font-family:Arial; font-size:30px' > These are queries to validate RT_deid_base_cdr </div>
+# These are queries to validate RT_deid_base_cdr </div>
 
 import urllib
 import pandas as pd
@@ -29,14 +29,6 @@ com_cdr = ""
 deid_base_cdr=""
 pipeline=""
 run_as=""
-
-# +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#com_cdr = "2021q3r2_combined"
-#deid_base_cdr = "R2021q3r2_deid_base"
-#pipeline = "pipeline_tables"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -70,7 +62,7 @@ df = pd.DataFrame(columns = ['query', 'result'])
 #
 # has been done in first sql for deid, can be skipped here
 
-# ## Query 1.2 step2  Find person_ids in pre_dedi_com_cdr person table who have ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586146 OR 1586142 OR 1586143) , then verify that the output in the deid_base_cdr observation table for that person_id after mapping  will results in 2-rows .
+# ## Query 1.2 Find person_ids in pre_dedi_com_cdr person table who have ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586146 OR 1586142 OR 1586143) , then verify that the output in the deid_base_cdr observation table for that person_id after mapping  will results in 2-rows .
 #
 #   step 3
 # Verify that the 2-rows have 2-different value_source_concept_id values in the deid_base_cdr Observation table.

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
@@ -18,6 +18,7 @@
 # + papermill={"duration": 0.709639, "end_time": "2021-02-02T22:30:32.661373", "exception": false, "start_time": "2021-02-02T22:30:31.951734", "status": "completed"} tags=[]
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -25,12 +26,14 @@ pd.options.display.max_rows = 120
 
 # + papermill={"duration": 0.023643, "end_time": "2021-02-02T22:30:31.880820", "exception": false, "start_time": "2021-02-02T22:30:31.857177", "status": "completed"} tags=["parameters"]
 project_id = ""
-deid_clean = ""
-run_as = ""
-# -
+deid_clean_cdr = ""
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#deid_clean_cdr = "R2021q3r2_deid_clean"
+#run_as= "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -39,13 +42,16 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
 # ## QA queries on new CDR_deid_clean drop rows with 0 OR null
 
 # + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false, "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
 # # 1 Verify that in observation table if observation_source_concept_id AND the observation_concept_id, both of those fields are null OR zero, the row should be removed. 
 
 # + papermill={"duration": 4.105203, "end_time": "2021-02-02T22:30:36.813460", "exception": false, "start_time": "2021-02-02T22:30:32.708257", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT 
 SUM(CASE WHEN observation_source_concept_id = 0 AND observation_concept_id = 0 THEN 1 ELSE 0 END) AS n_observation_source_concept_id_both_0,
@@ -53,15 +59,15 @@ SUM(CASE WHEN observation_source_concept_id IS NULL AND observation_concept_id I
 SUM(CASE WHEN observation_source_concept_id = 0 AND observation_concept_id IS NULL THEN 1 ELSE 0 END) AS n_observation_source_concept_id_either_0,
 SUM(CASE WHEN observation_source_concept_id IS NULL AND observation_concept_id=0 THEN 1 ELSE 0 END) AS n_observation_source_concept_id_either_null
 
-
-FROM `{project_id}.{deid_clean}.observation`
-'''
-df1=execute(client, query)
+FROM `{{project_id}}.{{deid_clean_cdr}}.observation`
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query1 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query1 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query1 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 
@@ -69,7 +75,7 @@ df1.T
 # # 2   Verify that in condition_occurrence if condition_occurrence_source_concept_id AND the condition_occurrence_concept_id both of those fields are null OR zero, the row should be removed. 
 # -
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT  
 SUM(CASE WHEN condition_source_concept_id = 0 AND condition_concept_id = 0 THEN 1 ELSE 0 END) AS n_condition_source_concept_id_both_0,
@@ -78,22 +84,23 @@ SUM(CASE WHEN condition_source_concept_id = 0 AND condition_concept_id IS NULL T
 SUM(CASE WHEN condition_source_concept_id IS NULL AND condition_concept_id=0 THEN 1 ELSE 0 END) AS n_condition_source_concept_id_either_null
 
 
-FROM `{project_id}.{deid_clean}.condition_occurrence`
+FROM `{{project_id}}.{{deid_clean_cdr}}.condition_occurrence`
 WHERE (condition_source_concept_id = 0 AND  condition_concept_id=0)
 OR ( condition_source_concept_id IS NULL AND condition_concept_id IS NULL)
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query2 condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query2 condition', 'result' : ''},  
+ df = df.append({'query' : 'Query2 condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 
 # # 3  Verify that in procedure_occurrence table if procedure_occurrence_source_concept_id AND the procedure_occurrence_concept_id both of those fields are null OR zero, the row should be removed. 
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT 
 SUM(CASE WHEN procedure_source_concept_id = 0 AND procedure_concept_id = 0 THEN 1 ELSE 0 END) AS n_procedure_source_concept_id_both_0,
@@ -101,14 +108,15 @@ SUM(CASE WHEN procedure_source_concept_id IS NULL AND procedure_concept_id IS NU
 SUM(CASE WHEN procedure_source_concept_id = 0 AND procedure_concept_id IS NULL THEN 1 ELSE 0 END) AS n_procedure_source_concept_id_either_0,
 SUM(CASE WHEN procedure_source_concept_id IS NULL AND procedure_concept_id=0 THEN 1 ELSE 0 END) AS n_procedure_source_concept_id_either_null
 
-FROM `{project_id}.{deid_clean}.procedure_occurrence`
-'''
-df1=execute(client, query)
+FROM `{{project_id}}.{{deid_clean_cdr}}.procedure_occurrence`
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query3 procedure', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3 procedure', 'result' : ''},  
+ df = df.append({'query' : 'Query3 procedure', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 
@@ -116,21 +124,22 @@ df1.T
 # # 4 Verify that in visit_occurrence table if visit_occurrence_source_concept_id AND the visit_occurrence_concept_id both of those fields are null OR zero, the row should be removed. 
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT
 SUM(CASE WHEN visit_source_concept_id = 0 AND visit_concept_id = 0 THEN 1 ELSE 0 END) AS n_visit_source_concept_id_both_0,
 SUM(CASE WHEN visit_source_concept_id IS NULL AND visit_concept_id IS NULL THEN 1 ELSE 0 END) AS n_visit_source_concept_id_both_null,
 SUM(CASE WHEN visit_source_concept_id = 0 AND visit_concept_id IS NULL THEN 1 ELSE 0 END) AS n_visit_source_concept_id_either_0,
 SUM(CASE WHEN visit_source_concept_id IS NULL AND visit_concept_id =0 THEN 1 ELSE 0 END) AS n_visit_source_concept_id_either_null
-FROM `{project_id}.{deid_clean}.visit_occurrence`
-'''
-df1=execute(client, query)
+FROM `{{project_id}}.{{deid_clean_cdr}}.visit_occurrence`
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query4 visit', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query4 visit', 'result' : ''},  
+ df = df.append({'query' : 'Query4 visit', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 
@@ -139,21 +148,22 @@ df1.T
 # # 5 Verify that in drug_exposure table if drug_exposure_source_concept_id AND the drug_exposure_concept_id both of those fields are null OR zero, the row should be removed. 
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT 
 SUM(CASE WHEN drug_source_concept_id = 0 AND drug_concept_id = 0 THEN 1 ELSE 0 END) AS n_drug_source_concept_id_both_0,
 SUM(CASE WHEN drug_source_concept_id IS NULL AND drug_concept_id IS NULL THEN 1 ELSE 0 END) AS n_drug_source_concept_id_both_null,
 SUM(CASE WHEN drug_source_concept_id = 0 AND drug_concept_id IS NULL THEN 1 ELSE 0 END) AS n_drug_source_concept_id_either_0,
 SUM(CASE WHEN drug_source_concept_id IS NULL AND drug_concept_id =0 THEN 1 ELSE 0 END) AS n_drug_source_concept_id_either_null
-FROM `{project_id}.{deid_clean}.drug_exposure`
-'''
-df1=execute(client, query)
+FROM `{{project_id}}.{{deid_clean_cdr}}.drug_exposure`
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query5 drug_exposure', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query5 drug_exposure', 'result' : ''},  
+ df = df.append({'query' : 'Query5 drug_exposure', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 
@@ -161,21 +171,22 @@ df1.T
 # # 6 Verify that in device_exposure table if device_exposure_source_concept_id AND the device_exposure_concept_id both of those fields are null OR zero, the row should be removed. 
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT 
 SUM(CASE WHEN device_source_concept_id = 0 AND device_concept_id = 0 THEN 1 ELSE 0 END) AS n_device_source_concept_id_both_0,
 SUM(CASE WHEN device_source_concept_id IS NULL AND device_concept_id IS NULL THEN 1 ELSE 0 END) AS n_device_source_concept_id_both_null,
 SUM(CASE WHEN device_source_concept_id = 0 AND device_concept_id IS NULL THEN 1 ELSE 0 END) AS n_device_source_concept_id_either_0,
 SUM(CASE WHEN device_source_concept_id IS NULL AND device_concept_id =0 THEN 1 ELSE 0 END) AS n_device_source_concept_id_either_null
-FROM `{project_id}.{deid_clean}.device_exposure`
-'''
-df1=execute(client, query)
+FROM `{{project_id}}.{{deid_clean_cdr}}.device_exposure`
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query6 device', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query6 device', 'result' : ''},  
+ df = df.append({'query' : 'Query6 device', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 
@@ -183,21 +194,22 @@ df1.T
 # # 7 Verify that in measurement table if measurement_source_concept_id AND the measurement_concept_id both of those fields are null OR zero, the row should be removed. 
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT
 SUM(CASE WHEN measurement_source_concept_id = 0 AND measurement_concept_id = 0 THEN 1 ELSE 0 END) AS n_measurement_source_concept_id_both_0,
 SUM(CASE WHEN measurement_source_concept_id IS NULL AND measurement_concept_id IS NULL THEN 1 ELSE 0 END) AS n_measurement_source_concept_id_both_null,
 SUM(CASE WHEN measurement_source_concept_id = 0 AND measurement_concept_id IS NULL THEN 1 ELSE 0 END) AS n_measurement_source_concept_id_either_0,
 SUM(CASE WHEN measurement_source_concept_id IS NULL AND measurement_concept_id =0 THEN 1 ELSE 0 END) AS n_measurement_source_concept_id_either_null
-FROM`{project_id}.{deid_clean}.measurement`
-'''
-df1=execute(client, query)
+FROM`{{project_id}}.{{deid_clean_cdr}}.measurement`
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query7 measurement', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query7 measurement', 'result' : ''},  
+ df = df.append({'query' : 'Query7 measurement', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1.T
 # -
@@ -209,22 +221,23 @@ df1.T
 # +
 # how to COUNT NaN
 # in old cdr_clean , the value is NaN; in contrast, the value is empty in new cdr_clean
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT
 SUM(CASE WHEN cause_source_concept_id != 0 AND cause_concept_id != 0 THEN 1 ELSE 0 END) AS n_cause_source_concept_id_both_not_0,
 SUM(CASE WHEN cause_source_concept_id IS NOT NULL AND cause_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_source_concept_id_both_not_null,
 SUM(CASE WHEN cause_source_concept_id != 0 AND cause_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_source_concept_id_either_0,
 SUM(CASE WHEN cause_source_concept_id IS NOT NULL AND cause_concept_id !=0 THEN 1 ELSE 0 END) AS n_cause_source_concept_id_either_null
-FROM `{project_id}.{deid_clean}.death`
+FROM `{{project_id}}.{{deid_clean_cdr}}.death`
 
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query8 cause_source_concept_id/cause_concept_id is null in dealth table', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query8 cause_source_concept_id/cause_concept_id is null in dealth table', 'result' : ''},  
+ df = df.append({'query' : 'Query8 cause_source_concept_id/cause_concept_id is null in dealth table', 'result' : 'Failure'},  
                 ignore_index = True) 
  
 df1.T
@@ -240,26 +253,32 @@ df1.T
 # DC-1011
 
 # +
-query=f''' 
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_pass
-FROM  `{project_id}.{deid_clean}.person_ext` d
-JOIN `{project_id}.{deid_clean}.person` e
+FROM  `{{project_id}}.{{deid_clean_cdr}}.person_ext` d
+JOIN `{{project_id}}.{{deid_clean_cdr}}.person` e
 ON  d.person_id = e.person_id
 WHERE state_of_residence_concept_id IS NOT NULL OR state_of_residence_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_clean_cdr=deid_clean_cdr)  
+df1=execute(client, q) 
 
 if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query9 State_of_Residence in person_ext', 'result' : ' '},  
+ df = df.append({'query' : 'Query9 State_of_Residence in person_ext', 'result' : ' Failure'},  
                 ignore_index = True) 
 else:
  df = df.append({'query' : 'Query9 State_of_Residence in person_ext', 'result' : 'PASS'},  
                 ignore_index = True) 
 df1
+
+
 # -
 
 # # Summary_row_ICD_suppression
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null','']))
-df.style.highlight_null(null_color='red').set_properties(**{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
@@ -30,12 +30,6 @@ deid_clean_cdr = ""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#deid_clean_cdr = "R2021q3r2_deid_clean"
-#run_as= "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report10_extra.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report10_extra.py
@@ -19,12 +19,11 @@
 # https://precisionmedicineinitiative.atlassian.net/browse/DC-1404
 #
 #
+# -
 
-# + papermill={"duration": 0.709639, "end_time": "2021-02-02T22:30:32.661373", "exception": false, "start_time": "2021-02-02T22:30:31.951734", "status": "completed"} tags=[]
 import urllib
 import pandas as pd
-
-from common import PIPELINE_TABLES
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -32,636 +31,582 @@ pd.options.display.max_rows = 120
 
 # + papermill={"duration": 0.023643, "end_time": "2021-02-02T22:30:31.880820", "exception": false, "start_time": "2021-02-02T22:30:31.857177", "status": "completed"} tags=["parameters"]
 project_id = ""
-com_cdr = ""
-deid_cdr = ""
-ct_deid = ""
-ct_deid_sand = ""
-deid_sand = ""
-pipeline = ""
-run_as = ""
-# -
+rt_cdr_deid = ""
+ct_cdr_deid=""
+deid_sand=""
+pipeline=""
+rt_cdr_deid_clean=''
+reg_combine=''
+combine=''
+run_as=""
+cdr_cutoff_date=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#reg_combine = "reg_2022q2r4_combined"
+#combine = "2022q2r4_combined"
+#rt_cdr_deid = "R2022q2r4_deid"
+#ct_cdr_deid = "C2022q2r4_deid"
+#rt_cdr_deid_clean = "R2022q2r4_deid_clean"
+#pipeline = "pipeline_tables"
+#deid_sand = "2022q2r4_deid_sandbox"
+#cdr_cutoff_date="2022-07-01"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 
 client = BigQueryClient(project_id, credentials=impersonation_creds)
+# -
+
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
 
 # + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false, "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
-# # 1 No person exists over 89 in the dataset:
+# # Q1 No person exists over 89 in the dataset:
+# -
+
+cdr_cutoff_date
 
 # + papermill={"duration": 4.105203, "end_time": "2021-02-02T22:30:36.813460", "exception": false, "start_time": "2021-02-02T22:30:32.708257", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
-SELECT COUNT(*) as n_participants_over_89 FROM `{project_id}.{deid_cdr}.person`
-WHERE person_id IN (
-SELECT person_id FROM (
-SELECT DISTINCT person_id, {PIPELINE_TABLES}.calculate_age(CURRENT_DATE, EXTRACT(DATE FROM birth_datetime)) AS age
-FROM `{project_id}.{deid_cdr}.person`) WHERE age > 89)
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query1 No person exists over 89 in the dataset',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+SELECT COUNT(*) as n_participants_over_89 FROM `{{project_id}}.{{rt_cdr_deid}}.person`
+WHERE FLOOR(DATE_DIFF(DATE('{{cdr_cutoff_date}}'),DATE(birth_datetime), DAY)/365.25) > 89
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,cdr_cutoff_date=cdr_cutoff_date)
+
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query1 No person exists over 89 in the dataset', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query1 No person exists over 89 in the dataset',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1 No person exists over 89 in the dataset', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
 # + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false, "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
-# # 2   No original person_id exists in the de-identified dataset:
+# # Q2   No original person_id exists in the de-identified dataset:
+
+# +
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) as n_original_person_ids FROM `{{project_id}}.{{rt_cdr_deid}}.person`
+WHERE person_id IN (
+SELECT person_id FROM `{{project_id}}.{{combine}}.person`)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,combine=combine)
+df1=execute(client, q)
+
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query2 No original person_id exists', 'result' : 'PASS'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query2 No original person_id exists', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1
 # -
 
-query = f'''
-
-SELECT COUNT(*) as n_original_person_ids FROM `{project_id}.{deid_cdr}.person`
-WHERE person_id IN (
-SELECT person_id FROM `{project_id}.{com_cdr}.person`)
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query2 No original person_id exists',
-            'result': 'PASS'
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query': 'Query2 No original person_id exists',
-            'result': ''
-        },
-        ignore_index=True)
-df1
-
-# # 3  These columns should be null, zero, or blank, queries should return 0 results:
+# # Q3  These columns should be null, zero, or blank, queries should return 0 results:
 #
 # a. non null provider_id in condition_occurrence table:
 
-query = f'''
-
-SELECT COUNT(*) AS non_null_provider_ids FROM `{project_id}.{deid_cdr}.condition_occurrence`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_provider_ids FROM `{{project_id}}.{{rt_cdr_deid}}.condition_occurrence`
 WHERE provider_id IS NOT NULL
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3a non null provider_id in condition_occurrence table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3a non null provider_id in condition_occurrence table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3a non null provider_id in condition_occurrence table',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3a non null provider_id in condition_occurrence table', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
 # b. non null cause_concept_id, cause_source_value, cause_source_concept_id in death table:
 
-query = f'''
-
-SELECT COUNT(*) AS non_null_values FROM `{project_id}.{deid_cdr}.death`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_values FROM `{{project_id}}.{{rt_cdr_deid}}.death`
 WHERE cause_concept_id IS NOT NULL OR cause_source_value IS NOT NULL OR cause_source_concept_id IS NOT NULL
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3b non null cause_concept_id, cause_source_value, cause_source_concept_id in death table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3b non null cause_concept_id, cause_source_value, cause_source_concept_id in death table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3b non null cause_concept_id, cause_source_value, cause_source_concept_id in death table',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3b non null cause_concept_id, cause_source_value, cause_source_concept_id in death table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # c. non null provider_id in device_exposure table:
 
-query = f'''
-SELECT COUNT(*) AS non_null_provider_ids FROM `{project_id}.{deid_cdr}.device_exposure`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_provider_ids FROM `{{project_id}}.{{rt_cdr_deid}}.device_exposure`
 WHERE provider_id IS NOT NULL
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query3c non null provider_id in device_exposure table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3c non null provider_id in device_exposure table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3c non null provider_id in device_exposure table',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3c non null provider_id in device_exposure table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # d. non null value_source_value in measurement table:
 
-query = f'''
-SELECT COUNT(*) AS non_null_value_source_value FROM `{project_id}.{deid_cdr}.measurement`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_value_source_value FROM `{{project_id}}.{{rt_cdr_deid}}.measurement`
 WHERE value_source_value IS NOT NULL
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query3d non null value_source_value in measurement table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3d non null value_source_value in measurement table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3d non null value_source_value in measurement table',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3d non null value_source_value in measurement table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 #   e. non null value_source_value, value_as_string, and provider_id in observation table:
 
-query = f'''
-SELECT COUNT(*) AS non_null_values FROM `{project_id}.{deid_cdr}.observation`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_values FROM `{{project_id}}.{{rt_cdr_deid}}.observation`
 WHERE value_source_value IS NOT NULL OR value_as_string IS NOT NULL OR provider_id IS NOT NULL
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3e non null value_source_value, value_as_string, and provider_id in observation table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3e non null value_source_value, value_as_string, and provider_id in observation table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3e non null value_source_value, value_as_string, and provider_id in observation table',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3e non null value_source_value, value_as_string, and provider_id in observation table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # f. non null values in person table:
 
-query = f'''
-SELECT COUNT(*) AS non_null_values FROM `{project_id}.{deid_cdr}.person` WHERE
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_values FROM `{{project_id}}.{{rt_cdr_deid}}.person` WHERE
 month_of_birth IS NOT NULL OR day_of_birth IS NOT NULL OR location_id IS NOT NULL
 OR provider_id IS NOT NULL OR care_site_id IS NOT NULL OR person_source_value IS NOT NULL
 OR gender_source_value IS NOT NULL OR gender_source_concept_id IS NOT NULL OR race_source_value IS NOT NULL
 OR race_source_concept_id IS NOT NULL OR ethnicity_source_value IS NOT NULL OR ethnicity_source_concept_id IS NOT NULL
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query3f non null values in person table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3f non null values in person table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3f non null values in person table',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3f non null values in person table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # g. non zero year_of_birth, race_concept_id, and ethnicity_concept_id in person table:
 
-query = f'''
-SELECT COUNT(*) AS non_zero_values FROM `{project_id}.{deid_cdr}.person`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_zero_values FROM `{{project_id}}.{{rt_cdr_deid}}.person`
 WHERE race_concept_id != 0 OR ethnicity_concept_id != 0 OR year_of_birth != 0
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3g non zero year_of_birth, race_concept_id, and ethnicity_concept_id in person table:',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3g non zero year_of_birth, race_concept_id, and ethnicity_concept_id in person table:', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3g non zero year_of_birth, race_concept_id, and ethnicity_concept_id in person table:',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3g non zero year_of_birth, race_concept_id, and ethnicity_concept_id in person table:', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # h. non null provider_id in procedure_occurrence table:
 
-query = f'''
-SELECT COUNT(*) AS non_null_provider_ids FROM `{project_id}.{deid_cdr}.procedure_occurrence`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_provider_ids FROM `{{project_id}}.{{rt_cdr_deid}}.procedure_occurrence`
 WHERE provider_id IS NOT NULL
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3h non null provider_id in procedure_occurrence table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3h non null provider_id in procedure_occurrence table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3h non null provider_id in procedure_occurrence table',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3h non null provider_id in procedure_occurrence table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # i. non null provider_id and care_site_id in visit_occurrence table:
 
-query = f'''
-SELECT COUNT(*) AS non_null_values FROM `{project_id}.{deid_cdr}.visit_occurrence`
+query = JINJA_ENV.from_string("""
+SELECT COUNT(*) AS non_null_values FROM `{{project_id}}.{{rt_cdr_deid}}.visit_occurrence`
 WHERE provider_id IS NOT NULL OR care_site_id IS NOT NULL
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query3i non null provider_id and care_site_id in visit_occurrence table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3i non null provider_id and care_site_id in visit_occurrence table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query3i non null provider_id and care_site_id in visit_occurrence table',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3i non null provider_id and care_site_id in visit_occurrence table', 'result' : ''},  
+                ignore_index = True) 
 df1
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 4 In the extension tables the srce_id/<omop_table>_id pairs match between the RT and CT:
+# # Q4 In the extension tables the srce_id/<omop_table>_id pairs match between the RT and CT:
 # -
 
 # ## 4a observation_ext
 
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
-FROM `{project_id}.{ct_deid}.observation_ext` c
-LEFT JOIN `{project_id}.{deid_cdr}.observation_ext` r
+FROM `{{project_id}}.{{ct_cdr_deid}}.observation_ext` c
+LEFT JOIN `{{project_id}}.{{rt_cdr_deid}}.observation_ext` r
 USING (observation_id)
-WHERE c.src_id != r.src_id AND r.src_id is not null and c.src_id is not null
--- identify if RT and CT are USING the same masking values
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query4a src_id matching in observation between CT and RT',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+WHERE c.src_id != r.src_id AND r.src_id IS NOT NULL and c.src_id IS NOT NULL
+-- identify if RT and CT are USING the same masking values --
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,ct_cdr_deid=ct_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query4a src_id matching in observation between CT and RT', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4a src_id matching in observation between CT and RT',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4a src_id matching in observation between CT and RT', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# ## 4b pipeline_tables.site_maskings
+# ## 4b sandbox._site_mappings 
+# this rule was removed based on DC-2391 and no longer needed
+
+# ## 4c pipeline_tables.site_maskings
 
 # +
-query = f'''
-
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
-FROM `{project_id}.{pipeline}.site_maskings` as c
-LEFT JOIN `{project_id}.{deid_sand}.site_maskings` as r
+FROM `{{project_id}}.{{pipeline}}.site_maskings` as c
+LEFT JOIN `{{project_id}}.{{deid_sand}}.site_maskings` as r
 USING (hpo_id)
 WHERE c.src_id != r.src_id
--- registered tier did use the stabilized maskings for cross pipeline compatibility
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query4c pipeline_tables.site_maskings matching',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+-- registered tier did use the stabilized maskings for cross pipeline compatibility --
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,deid_sand=deid_sand)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query4c pipeline_tables.site_maskings matching', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4c pipeline_tables.site_maskings matching',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4c pipeline_tables.site_maskings matching', 'result' : 'Failure'},  
+                ignore_index = True) 
 
 df1
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 5 No participants should be FROM any of these states (1585299, 1585304, 1585284, 1585315, 1585271, 1585263, 1585306, 1585274, 1585270, 1585411, 1585313, 1585409, 1585262, 1585309, 1585307, 1585275):
+# # Q5 A participant should have only one gender identity record in the observation table:
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
-
-SELECT COUNT(1) as num_of_invalid_states
-FROM `{project_id}.{deid_cdr}.observation`
-WHERE
-observation_source_concept_id = 1585249 and
-value_source_concept_id IN (1585299, 1585304, 1585284, 1585315, 1585271, 1585263, 1585306, 1585274, 1585270, 
-1585411, 1585313, 1585409, 1585262, 1585309, 1585307, 1585275)
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query5 No participants in states',
-            'result': 'PASS'
-        },
-        ignore_index=True)
-else:
-    df = df.append({
-        'query': 'Query5 No participants in states',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
-
-# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 6 A participant should have only one gender identity record in the observation table:
-
-# + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT value_source_concept_id, value_as_concept_id, count(person_id) as n_answers
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{rt_cdr_deid}}.observation`
 WHERE observation_source_concept_id = 1585838
 GROUP BY person_id, value_source_concept_id, value_as_concept_id
 HAVING count(person_id) > 1)
 
 SELECT COUNT (*) AS n_row_not_pass FROM df1
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query6 only one gender identity record in the observation',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query5 only one gender identity record in the observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query':
-                'Query6 only one gender identity record in the observation',
-            'result':
-                ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query5 only one gender identity record in the observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 7  A participant has one race answer (excluding ethnicity answers) in observation table:
+# # Q6  A participant has one race answer (excluding ethnicity answers) in observation table:
 # -
 
 # correct one by francis
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT person_id, count(value_source_concept_id) as countp
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{rt_cdr_deid}}.observation`
 WHERE observation_source_concept_id = 1586140 AND value_as_concept_id !=1586147
 GROUP BY person_id
 )
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE countp >1
-
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query7 has one race answer in observation',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query6 has one race answer in observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query7 has one race answer in observation',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query6 has one race answer in observation', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# # 8  Any response that isn’t straight (1585900) should be generalized to (2000000003):
+# # Q7  Any response that isn’t straight (1585900) should be generalized to (2000000003):
 
 # +
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT person_id
-FROM `aou-res-curation-prod.{com_cdr}.observation` ob
+FROM `{{project_id}}.{{combine}}.observation` ob
 WHERE ob.observation_source_concept_id = 1585899
 AND value_source_concept_id !=1585900)
 
 SELECT COUNT (*) AS n_row_not_pass
-FROM `aou-res-curation-prod.{deid_cdr}.observation` ob_deid
+FROM `{{project_id}}.{{rt_cdr_deid}}.observation` ob_deid
 WHERE ob_deid.person_id in (SELECT person_id FROM df1)
 and ob_deid.observation_source_concept_id = 1585899
 and ob_deid.value_source_concept_id !=2000000003
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query8 non_straight gender be generalized',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,combine=combine)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query7 non_straight gender be generalized', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query8 non_straight gender be generalized',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query7 non_straight gender be generalized', 'result' : 'Failure'},  
+                ignore_index = True) 
 
 df1
 # -
 
-# # 9 Sex at birth should be limited to 1585847, 1585846, and 2000000009:
+# # Q8 Sex at birth should be limited to 1585847, 1585846, and 2000000009:
 #
 # need some work here
 #
 # is orignal sql answering the question?
 
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT COUNT(*) as n_row_not_pass
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{rt_cdr_deid}}.observation`
 WHERE observation_source_concept_id = 1585845
 AND value_source_concept_id not in (1585847, 1585846,2000000009)
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query9 correct sex_at_birth concept_id',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query8 correct sex_at_birth concept_id', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query9 correct sex_at_birth concept_id',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query8 correct sex_at_birth concept_id', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# # 10 Education levels ( value_source_concept_id) should be limited to 2000000007, 2000000006, 1585945, 43021808, 903079, 1177221, 1585946, 4260980, and 903096:
+# # Q9 Education levels ( value_source_concept_id) should be limited to 2000000007, 2000000006, 1585945, 43021808, 903079, 1177221, 1585946, 4260980, and 903096:
 
 # +
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) as n_row_not_pass
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{rt_cdr_deid}}.observation`
 WHERE observation_source_concept_id = 1585940
 AND value_source_concept_id NOT IN (2000000007, 2000000006, 1585945, 43021808, 903079, 
 1177221, 1585946, 4260980, 903096)
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query10 correct education level concept_id',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query9 correct education level concept_id', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query10 correct education level concept_id',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query9 correct education level concept_id', 'result' : 'Failure'},  
+                ignore_index = True) 
 
 df1
 # -
 
-# # 11. Employment records should be restricted to 2000000005 and 2000000004:
+# # Q10. Employment records should be restricted to 2000000005 and 2000000004:
 # need work
 #
 # questions: is other two ok?
 
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) as n_row_not_pass
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{rt_cdr_deid}}.observation`
 WHERE observation_source_concept_id = 1585952
 And value_source_concept_id not in (2000000005, 2000000004,903079,903096)
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query11 correct Employment records concept_id',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query10 correct Employment records concept_id', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query11 correct Employment records concept_id',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query10 correct Employment records concept_id', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
-# # 12. questionnaire_response_id should be the same between RT and CT:
+# # Q11. questionnaire_response_id should be the same between RT and CT:
 
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
-FROM `{project_id}.{ct_deid}.observation` c
-LEFT JOIN `{project_id}.{deid_cdr}.observation` r
+FROM `{{project_id}}.{{ct_cdr_deid}}.observation` c
+LEFT JOIN `{{project_id}}.{{rt_cdr_deid}}.observation` r
 USING (observation_id)
 WHERE c.questionnaire_response_id != r.questionnaire_response_id
 AND r.questionnaire_response_id IS NOT NULL
 AND c.questionnaire_response_id IS NOT NULL
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query12  same questionnaire_response_id in RT and CT ',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,ct_cdr_deid=ct_cdr_deid)
+df1=execute(client, q)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query11  same questionnaire_response_id in RT and CT ', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query12 same questionnaire_response_id in RT and CT',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query11 same questionnaire_response_id in RT and CT', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
+
+# # Q12 update The participant lives in one state should have no EHR records from another state.  
+#
+# DC-544/DC-512
+#
+# DC-2377
+#
+
+# +
+# step1, get OMOP tables
+query = JINJA_ENV.from_string("""
+
+WITH
+    table1 AS (
+    SELECT
+      table_name,
+      column_name
+    FROM
+      `{{project_id}}.{{rt_cdr_deid_clean}}.INFORMATION_SCHEMA.COLUMNS`
+    WHERE 
+      column_name='person_id' ),
+    table2 AS (
+    SELECT
+      table_id AS table_name,
+      row_count
+    FROM
+      `{{project_id}}.{{rt_cdr_deid_clean}}.__TABLES__`
+    WHERE 
+      row_count>1)
+      
+  SELECT
+    distinct table_name, column_name
+    
+  FROM
+    `{{project_id}}.{{rt_cdr_deid_clean}}.INFORMATION_SCHEMA.COLUMNS` c
+  WHERE 
+    table_name IN (
+    SELECT
+      DISTINCT table_name
+    FROM
+      table2
+    WHERE 
+      table_name IN (
+      SELECT
+        DISTINCT table_name
+      FROM
+        table1))
+    AND REGEXP_CONTAINS(column_name, r'(?i)(_id)')
+    AND NOT REGEXP_CONTAINS(table_name, r'(?i)(_ext)')
+    AND NOT REGEXP_CONTAINS(table_name, r'(?i)(steps)|(heart)|(activity)|(person)|death')
+    AND NOT REGEXP_CONTAINS(column_name, r'(?i)(person_id)|(concept_id)|(provider_id)|(visit_occurrence_id)|(care_site_id)|(response_id)|(source_id)|(device_id)|(visit_detail)')
+    
+     
+""")
+
+q = query.render(project_id=project_id, rt_cdr_deid_clean=rt_cdr_deid_clean)
+target_tables=execute(client, q)
+target_tables.shape
+# -
+
+# have to manully add visit talbes
+target_tables.loc[len(target_tables.index)] = ['visit_occurrence', 'visit_occurrence_id'] 
+target_tables.loc[len(target_tables.index)] = ['visit_detail', 'visit_detail_id'] 
+target_tables
+
+
+def my_sql(table_name,column_name):
+    
+    query = JINJA_ENV.from_string("""
+
+with df_person AS (
+SELECT distinct person_id, 
+state_of_residence_concept_id as state_id_1,
+state_of_residence_source_value
+
+FROM `{{project_id}}.{{rt_cdr_deid_clean}}.person_ext` p
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states` ON value_source_concept_id=state_of_residence_concept_id
+JOIN `{{project_id}}.{{deid_sand}}.site_maskings` m ON hpo_id=src_hpo_id
+WHERE state_of_residence_concept_id IS NOT NULL
+),
+
+df_omop AS (
+SELECT distinct person_id,ext.src_id,m.src_id,hpo_id,mhpo.src_hpo_id,m.hpo_id,
+State,mhpo.value_source_concept_id as state_id_2
+FROM `{{project_id}}.{{rt_cdr_deid_clean}}.{{table_name}}`
+JOIN `{{project_id}}.{{rt_cdr_deid_clean}}.{{table_name}}_ext` ext USING ({{column_name}})
+JOIN `{{project_id}}.{{deid_sand}}.site_maskings` m ON ext.src_id=m.src_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states` mhpo ON mhpo.src_hpo_id=m.hpo_id
+WHERE ext.src_id !='PPI/PM'
+)
+
+SELECT '{{table_name}}' AS table_name,
+COUNT(*) as row_counts,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 1 ELSE 0
+END
+ AS Failure_row_counts
+FROM df_omop
+LEFT JOIN df_person USING (person_id)
+WHERE state_id_2 !=state_id_1
+
+""")
+    q = query.render(project_id=project_id, reg_combine=reg_combine,deid_sand=deid_sand,rt_cdr_deid_clean=rt_cdr_deid_clean, table_name=table_name,column_name=column_name)
+    df11=execute(client, q)
+    return df11
+
+
+# +
+# use a loop to get table name AND column name AND run sql function
+
+result = [my_sql (table_name, column_name) for table_name, column_name in zip(target_tables['table_name'], target_tables['column_name'])]
+result
+
+# +
+# AND then get the result back FROM loop result list
+n=len(target_tables.index)
+res2 = pd.DataFrame(result[0])
+
+for x in range(1,n):    
+  res2=res2.append(result[x])
+    
+res2=res2.sort_values(by='Failure_row_counts', ascending=False)
+res2
+# -
+
+if res2['Failure_row_counts'].sum()==0:
+ df = df.append({'query' : 'Query12  person state info matches EHR state info', 'result' : 'PASS'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query12 person state info matches EHR state info', 'result' : 'Failure'},  
+                ignore_index = True) 
+
 
 # # Summary_deid_extra_validation
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null', '']))
-df.style.highlight_null(null_color='red').set_properties(
-    **{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report10_extra.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report10_extra.py
@@ -42,19 +42,6 @@ run_as=""
 cdr_cutoff_date=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#reg_combine = "reg_2022q2r4_combined"
-#combine = "2022q2r4_combined"
-#rt_cdr_deid = "R2022q2r4_deid"
-#ct_cdr_deid = "C2022q2r4_deid"
-#rt_cdr_deid_clean = "R2022q2r4_deid_clean"
-#pipeline = "pipeline_tables"
-#deid_sand = "2022q2r4_deid_sandbox"
-#cdr_cutoff_date="2022-07-01"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report11_covid_concept_no_suppression.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report11_covid_concept_no_suppression.py
@@ -21,6 +21,7 @@
 
 import pandas as pd
 from utils import auth
+from common import JINJA_ENV
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
 pd.set_option("max_colwidth", None)
@@ -29,6 +30,11 @@ pd.set_option("max_colwidth", None)
 project_id: str = ""  # identifies the project where datasets are located
 post_deid_dataset: str = ""  # the deid dataset
 run_as = ""
+
+# +
+#project_id = "aou-res-curation-prod"
+#post_deid_dataset = "R2021q3r2_deid_base"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 # -
 
 # df will have a summary in the end
@@ -44,18 +50,20 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 # #### 2. Executing the quality check SQL query
 # The concept IDs in the following query used to be suppressed until the Fall 2021 CDR. This query checks how many records exist for each of the concept IDs in the specified dataset.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 select drug_concept_id, count(*) as count
-from `{project_id}.{post_deid_dataset}.drug_exposure`
+from `{{project_id}}.{{post_deid_dataset}}.drug_exposure`
 where drug_concept_id in (
 19052425, 19052557, 19082103,19052425,19052557,19082103,19082104,19098973,19115035,36217210,
 46274363,46274409,724904,724906,724907,766231,766232,766233,766234,766235,766236,766237,
 766238,766239,766240,766241,821336,1201837,1214698,1217525,1227568,1230962,1230963,35894915,
 36388974,36394196,42639775,42639776,42639777,42639778,42639779,42639780,42795630,42796343)
 group by 1
-'''
+""")
 
-df_query = execute(client, query)
+q = query.render(project_id=project_id,post_deid_dataset=post_deid_dataset) 
+df_query=execute(client, q) 
+df_query.shape
 
 # #### 3. Result
 # If the following dataframe shows no data, these concept IDs are highly likely to remain suppressed. Reach out to Curation developers for troubleshooting.

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report11_covid_concept_no_suppression.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report11_covid_concept_no_suppression.py
@@ -31,11 +31,6 @@ project_id: str = ""  # identifies the project where datasets are located
 post_deid_dataset: str = ""  # the deid dataset
 run_as = ""
 
-# +
-#project_id = "aou-res-curation-prod"
-#post_deid_dataset = "R2021q3r2_deid_base"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-# -
 
 # df will have a summary in the end
 df = pd.DataFrame(columns=['QC category', 'Result'])

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report12_extra.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report12_extra.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.7.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+import urllib
+import pandas as pd
+from common import JINJA_ENV
+from utils import auth
+from gcloud.bq import BigQueryClient
+from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
+pd.options.display.max_rows = 120
+
+# + tags=["parameters"]
+project_id = ""
+combine=""
+pipeline=""
+rt_cdr_deid = ""
+deid_sand=""
+rdr_dataset=""
+rdr_sandbox=""
+run_as=""
+
+# +
+impersonation_creds = auth.get_impersonation_credentials(
+    run_as, target_scopes=IMPERSONATION_SCOPES)
+
+client = BigQueryClient(project_id, credentials=impersonation_creds)
+# -
+
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
+# # Query 1, whether AIAN pts are present AND are properly generalized 
+#
+# DST-692
+#
+# Someone selecting AI/AN should be generalized into Race 2000000008 if they have multiple race selections in the combined dataset.  They should be generalized into Race 2000000001 if they only have a single race selection.  
+#
+#
+
+query = JINJA_ENV.from_string("""
+SELECT 
+COUNT (*) row_counts_failure
+FROM   `{{project_id}}.{{rt_cdr_deid}}.observation` 
+WHERE observation_source_concept_id IN (1586140) 
+AND person_id IN 
+
+(SELECT DISTINCT research_id 
+FROM  `{{project_id}}.{{combine}}.observation` com
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` m ON com.person_id = m.person_id
+WHERE observation_source_concept_id = 1586140
+AND value_source_concept_id = 1586141
+)
+
+AND value_source_concept_id NOT IN (2000000008, 2000000001,1586147)
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,combine=combine,deid_sand=deid_sand)
+df1=execute(client, q)
+df1
+
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query1 AIAN are properly generalized', 'result' : 'PASS'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query1 AIAN are properly generalized', 'result' : 'Failure'},  
+                ignore_index = True) 
+df
+
+# # Query 2 new checks ON survey_conduct table
+#
+#
+# DST-690 new CDR deid check ON survey_conduct tables
+# **Background**
+# The survey_conduct AND survey_conduct_ext tables are new to the CDR for the Winter 2022 release.  The tables are related to each other with a foreign key ON survey_conduct_id.  The survey_conduct table is also related to the observation table via a foreign key relationship.  This relationship is survey_conduct.survey_conduct_id = observation.questionnaire_response_id.   The survey_conduct table entries should meet basic data quality checks, as well as privacy checks.
+#
+# **Scope**
+# Add notebook checks to verify the following data quality issues exist in the CDR.
+#
+# check 1 every non-null observation.questionnaire_response_id value maps to an existing survey_conduct.survey_conduct_id value.
+#
+# check 2 every survey_conduct.survey_conduct_id value maps to one or more observation.questionnaire_response_id values.
+#
+# check 3 every non-null survey_conduct_ext.survey_conduct_id value maps to an existing survey_conduct.survey_conduct_id value.
+#
+# check 4 every survey_conduct.survey_conduct_id value maps to one or more survey_conduct_ext.survey_conduct_id values.
+#
+# check 5 language:  survey_conduct_ext.language is “es” for participants who took the survey in Spanish AND “en” for participants who took the survey in English. 
+#
+# check 6 CATI:  Computer Assisted Telephone Interview.  42530794 is used to indicate this in the survey_conduct.assisted_concept_id table AND column for participants who had assistance.  Otherwise, 0.
+#
+# survey_conduct.collection_method_concept_id in (42530794, 42531021)  WHERE 42530794 is used if the survey was assisted AND 42531021 is used if the survey was unassisted.
+#
+# **Add or verify checks exist to de-identify the table**
+#
+# check 7 survey_conduct.survey_conduct_id must map to a research id value defined in {rdr_sandbox}._deid_questionnaire_response_map.research_response_id. 
+#
+# check 8 dates AND date times in survey_conduct are shifted in the Registered Tier deid dataset.  The COPE survey date values will be unshifted in the Registered Tier deid base dataset.
+#
+# check 9 vperson_ids are remapped in the survey_conduct table.
+
+query = JINJA_ENV.from_string("""
+
+#check 1 every non-null observation.questionnaire_response_id value maps to an existing survey_conduct.survey_conduct_id value.
+
+WITH df1 AS (
+SELECT 'check1' check , 'observation.questionnaire_response_id matches survey_conduct.survey_conduct_id' check_name,
+    COUNT (DISTINCT questionnaire_response_id) row_counts_failure
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.observation`
+    WHERE questionnaire_response_id IS NOT null
+    AND questionnaire_response_id NOT IN (SELECT DISTINCT survey_conduct_id
+    FROM   `{{project_id}}.{{rt_cdr_deid}}.survey_conduct`
+    WHERE survey_conduct_id IS NOT null)
+    
+   ),
+
+#every survey_conduct.survey_conduct_id value maps to one or more observation.questionnaire_response_id values
+
+df2 AS (
+SELECT 'check2' check , 'survey_conduct.survey_conduct_id matches observation.questionnaire_response_id' check_name,
+
+COUNT (DISTINCT survey_conduct_id) row_counts_failure
+    FROM   `{{project_id}}.{{rt_cdr_deid}}.survey_conduct`
+    WHERE survey_conduct_id IS NOT null
+    AND survey_conduct_id NOT IN (SELECT DISTINCT questionnaire_response_id
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.observation`
+    WHERE questionnaire_response_id IS NOT null)
+)  ,
+
+#every non-null survey_conduct_ext.survey_conduct_id value maps to an existing survey_conduct.survey_conduct_id value.
+
+df3 AS (
+SELECT 'check3' check , 'survey_conduct_ext.survey_conduct_id matches survey_conduct.survey_conduct_id' check_name,
+
+COUNT (DISTINCT ext.survey_conduct_id) row_counts_failure
+    FROM   `{{project_id}}.{{rt_cdr_deid}}.survey_conduct_ext` ext
+    WHERE survey_conduct_id IS NOT null
+    AND survey_conduct_id NOT IN (SELECT DISTINCT survey_conduct_id
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.survey_conduct`
+    WHERE survey_conduct_id IS NOT null)
+    ),
+    
+#every survey_conduct.survey_conduct_id value maps to one or more survey_conduct_ext.survey_conduct_id values.¶
+df4 AS (
+SELECT 'check4' check , 'survey_conduct.survey_conduct_id matches survey_conduct_ext.survey_conduct_id' check_name,
+
+COUNT (DISTINCT s.survey_conduct_id) row_counts_failure
+    FROM   `{{project_id}}.{{rt_cdr_deid}}.survey_conduct` s
+    WHERE survey_conduct_id IS NOT null
+    AND survey_conduct_id NOT IN (SELECT DISTINCT survey_conduct_id
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.survey_conduct_ext`
+    WHERE survey_conduct_id IS NOT null)
+    ),
+    
+    
+df5_1 AS (
+SELECT 'check5.1' check , 'survey_conduct_language_english' check_name,
+ COUNT (DISTINCT m.person_id) AS row_counts_failure
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.survey_conduct` deid
+   JOIN `{{project_id}}.{{rt_cdr_deid}}.survey_conduct_ext` using (survey_conduct_id)
+   JOIN `{{project_id}}.{{deid_sand}}._deid_map` m ON deid.person_id = m.research_id
+   WHERE language ='en'
+   AND m.person_id NOT IN (SELECT DISTINCT person_id
+    FROM  `{{project_id}}.{{rdr_dataset}}.observation`
+   JOIN  `{{project_id}}.{{rdr_dataset}}.questionnaire_response_additional_info` using (questionnaire_response_id)
+WHERE type='LANGUAGE' AND value='en')
+),
+
+df5_2 AS (
+SELECT 'check5.2' check , 'survey_conduct_language_spanish' check_name,
+
+COUNT (DISTINCT m.person_id) AS row_counts_failure
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.survey_conduct` deid
+   JOIN `{{project_id}}.{{rt_cdr_deid}}.survey_conduct_ext` using (survey_conduct_id)
+   JOIN `{{project_id}}.{{deid_sand}}._deid_map` m ON deid.person_id = m.research_id
+   WHERE language ='es'
+   AND m.person_id NOT IN (SELECT DISTINCT person_id
+    FROM  `{{project_id}}.{{rdr_dataset}}.observation`
+   JOIN  `{{project_id}}.{{rdr_dataset}}.questionnaire_response_additional_info` using (questionnaire_response_id)
+WHERE type='LANGUAGE' AND value='es')
+),
+
+df6 AS (
+SELECT 'check6' check , 'survey_conduct_CATI' check_name,
+
+
+COUNT (DISTINCT m.person_id) AS row_counts_failure
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.survey_conduct` deid
+   JOIN `{{project_id}}.{{rt_cdr_deid}}.survey_conduct_ext` using (survey_conduct_id)
+   JOIN `{{project_id}}.{{deid_sand}}._deid_map` m ON deid.person_id = m.research_id
+   WHERE ( assisted_source_value ='Telephone' or assisted_concept_id=42530794)
+   AND m.person_id NOT IN (SELECT DISTINCT person_id
+    FROM  `{{project_id}}.{{rdr_dataset}}.observation`
+   JOIN  `{{project_id}}.{{rdr_dataset}}.questionnaire_response_additional_info` using (questionnaire_response_id)
+WHERE value='CATI')
+),
+
+#survey_conduct.survey_conduct_id must map to a research id 
+
+
+df7 AS (
+SELECT 'check7' check , 'survey_conduct.survey_conduct_id maps a research_response_id' check_name,
+
+COUNT (DISTINCT survey_conduct_id) row_counts_failure
+    FROM   `{{project_id}}.{{rt_cdr_deid}}.survey_conduct`
+    WHERE survey_conduct_id IS NOT null
+    AND survey_conduct_id NOT IN (SELECT DISTINCT research_response_id
+    FROM  `{{project_id}}.{{rdr_sandbox}}._deid_questionnaire_response_map`
+    WHERE research_response_id IS NOT null)
+    ),
+    
+#check 8 dates AND date times in survey_conduct are shifted in the Registered Tier deid dataset.
+    
+df8 AS (
+
+
+SELECT 'check8' check , 'date are shifted' check_name,
+COUNT(*) AS row_counts_failure FROM  
+
+(
+SELECT 
+DATE_DIFF(DATE(i.survey_start_date), DATE(d.survey_start_date),day)-m.shift AS diff_start_date,
+DATE_DIFF(DATE(i.survey_end_date), DATE(d.survey_end_date),day)-m.shift AS diff_end_date,
+DATE_DIFF(DATE(i.survey_start_datetime), DATE(d.survey_start_datetime),day)-m.shift AS diff_start_datetime,
+DATE_DIFF(DATE(i.survey_end_datetime), DATE(d.survey_end_datetime),day)-m.shift AS diff_end_datetime
+
+FROM  `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{combine}}.survey_conduct` i
+ON m.person_id = i.person_id
+JOIN `{{project_id}}.{{rt_cdr_deid}}.survey_conduct` d
+ON d.survey_conduct_id = i.survey_conduct_id)
+
+WHERE diff_start_date !=0 or
+diff_end_date !=0 or
+diff_start_datetime !=0 or
+diff_end_datetime !=0
+),
+
+df9 AS (
+SELECT 'check9' check , 'person_ids are remapped' check_name,
+COUNT (DISTINCT person_id) AS row_counts_failure
+    FROM  `{{project_id}}.{{rt_cdr_deid}}.survey_conduct` d
+   WHERE person_id NOT IN (SELECT research_id  
+   FROM  `{{project_id}}.{{deid_sand}}._deid_map` ))
+   
+SELECT * FROM  df1
+UNION DISTINCT 
+SELECT * FROM  df2
+UNION DISTINCT 
+SELECT * FROM  df3
+UNION DISTINCT 
+SELECT * FROM  df4
+UNION DISTINCT 
+SELECT * FROM  df5_1
+UNION DISTINCT 
+SELECT * FROM  df5_2
+UNION DISTINCT 
+SELECT * FROM  df6
+UNION DISTINCT 
+SELECT * FROM  df7
+UNION DISTINCT 
+SELECT * FROM  df8
+UNION DISTINCT 
+SELECT * FROM  df9
+ORDER BY check
+
+""")
+q = query.render(project_id=project_id,rt_cdr_deid=rt_cdr_deid,combine=combine,deid_sand=deid_sand,rdr_dataset=rdr_dataset,rdr_sandbox=rdr_sandbox,pipeline=pipeline)
+df1=execute(client, q)
+df1.shape
+
+df1
+
+if df1.iloc[:,2].sum()==0:
+ df = df.append({'query' : 'Query2 new checks on survey_conduct table', 'result' : 'PASS'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query2 new checks on survey_conduct table', 'result' : 'Failure'},  
+                ignore_index = True) 
+df
+
+
+# # Summary
+
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+# -
+
+

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report1_generalization_rule.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report1_generalization_rule.py
@@ -31,14 +31,6 @@ pipeline=""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#com_cdr = "2021q3r2_combined"
-#deid_cdr = "R2021q3r2_deid"
-#pipeline = "pipeline_tables"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report1_generalization_rule.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report1_generalization_rule.py
@@ -17,6 +17,7 @@
 
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -26,13 +27,16 @@ pd.options.display.max_rows = 120
 project_id = ""
 com_cdr = ""
 deid_cdr=""
-# deid_base_cdr=""
 pipeline=""
 run_as=""
-# -
 
-# df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#com_cdr = "2021q3r2_combined"
+#deid_cdr = "R2021q3r2_deid"
+#pipeline = "pipeline_tables"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -40,6 +44,9 @@ impersonation_creds = auth.get_impersonation_credentials(
 
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
+
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
 
 # # 1 GR_01 Race Generalization Rule
 #
@@ -57,21 +64,22 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 # Null is the value poplulated in the value_as_string & value_source_value fields in the deid table.
 #
 
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT 
 
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null
 
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query1 GR01 Race_col_suppressoin in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query1 GR01 Race_col_suppression in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query1 GR01 Race_col_suppression in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -103,14 +111,14 @@ df1
 # the value_as_concept_id field in de-id table populates 1177221
 #
 # - Verify that if the value_source_concept_id field in OBSERVATION table populates: 903096 , 
-# the value_as_concept_id field in de-id table populates: 903096 or 2000000010
+# the value_as_concept_id field in de-id table populates: 903096
 #
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct value_source_concept_id,value_as_concept_id
- FROM `{project_id}.{deid_cdr}.observation`
+ FROM `{{project_id}}.{{deid_cdr}}.observation`
  WHERE value_source_concept_id in (2000000001,2000000008,1586142,1586143,1586146,1586147,1586148,903079,903096)
  )
 
@@ -123,15 +131,16 @@ WHERE (value_source_concept_id=2000000001 AND value_as_concept_id !=2000000001)
  OR (value_source_concept_id=1586147 AND value_as_concept_id !=1586147)
  OR (value_source_concept_id=1586148 AND value_as_concept_id !=45882607)
  OR (value_source_concept_id=903079 AND value_as_concept_id !=1177221)
- OR (value_source_concept_id=903096 AND value_as_concept_id NOT IN (903096, 2000000010))
+ OR (value_source_concept_id=903096 AND value_as_concept_id !=903096)
  
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query1.2 GR01 Race_value_source_concept_id matched value_as_concept_id in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query1.2 GR01 Race_value_source_concept_id matched value_as_concept_id in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query1.2 GR01 Race_value_source_concept_id matched value_as_concept_id in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -167,11 +176,11 @@ df1
 # 'SexualOrientation_GeneralizedNotStraight'
 
 # fine in both deid and deid_base
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct value_source_concept_id,value_as_concept_id
- FROM `{project_id}.{deid_cdr}.observation`
+ FROM `{{project_id}}.{{deid_cdr}}.observation`
  WHERE value_source_concept_id in (2000000003,1585900)
  )
  
@@ -179,13 +188,14 @@ SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE (value_source_concept_id=2000000003 AND value_as_concept_id !=2000000003)
 OR (value_source_concept_id=1585900 AND value_as_concept_id !=4069091)
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query2.2 GR02 TheBasics_SexualOrientation matched value_source_concept_id in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query2.2 GR02 TheBasics_SexualOrientation matched value_source_concept_id in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query2.2 GR02 TheBasics_SexualOrientation matched value_source_concept_id in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -205,19 +215,19 @@ df1
 # 3 AND then look up for those person_ids in the deid dataset to verify that the  value_as_concept_id field is generalized for those person_ids
 
 # fine in both deid and deid_base
-query=f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id AS person_id,count (distinct ob.value_source_value) AS countp
-FROM `{project_id}.{com_cdr}.observation` ob
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{com_cdr}}.observation` ob
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON ob.person_id = m.person_id
 WHERE REGEXP_CONTAINS(ob.observation_source_value, 'TheBasics_SexualOrientation')
 GROUP BY 1),
 
 df2 AS (
 SELECT person_id 
-FROM `{project_id}.{deid_cdr}.observation` 
+FROM `{{project_id}}.{{deid_cdr}}.observation` 
 WHERE value_as_concept_id =2000000003
 )
 
@@ -225,13 +235,14 @@ SELECT COUNT (distinct person_id) AS n_PERSON_ID_not_pass FROM df1
 WHERE countp >1
 AND person_id NOT IN (SELECT distinct person_id FROM df2 )
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query2.3 GR02 multiple_SexualOrientation matched value_source_concept_id in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query2.3 GR02 multiple_SexualOrientation matched value_source_concept_id in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query2.3 GR02 multiple_SexualOrientation matched value_source_concept_id in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -273,11 +284,11 @@ df1
 #
 
 # fine in both deid and deid_base
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct value_source_concept_id,value_as_concept_id
- FROM `{project_id}.{deid_cdr}.observation`
+ FROM `{{project_id}}.{{deid_cdr}}.observation`
  WHERE value_source_concept_id IN (2000000002,1585840,1585839)
  )
 
@@ -286,13 +297,14 @@ WHERE (value_source_concept_id=2000000002 AND value_as_concept_id !=2000000002)
 OR (value_source_concept_id=1585840 AND value_as_concept_id !=45878463)
 OR (value_source_concept_id=1585839 AND value_as_concept_id !=45880669)
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query3 GR03 Gender_value_source_concept_id matched value_as_concept_id in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3 GR03 Gender_value_source_concept_id matched value_as_concept_id in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query3 GR03 Gender_value_source_concept_id matched value_as_concept_id in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -319,11 +331,11 @@ df1
 # the value_as_concept_id field in de-id table populates : 45880669
 #
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct value_source_concept_id,value_as_concept_id
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE value_source_concept_id IN (2000000009,1585847,1585846)
  )
 
@@ -332,13 +344,14 @@ WHERE (value_source_concept_id=2000000009 AND value_as_concept_id !=2000000009)
 OR (value_source_concept_id=1585847 AND value_as_concept_id !=45878463)
 OR (value_source_concept_id=1585846 AND value_as_concept_id !=45880669)
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query3 Biological Sex Generalization Rule in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3 Biological Sex Generalization Rule in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query3 Biological Sex Generalization Rule in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -363,12 +376,12 @@ df1
 # +
 # in deid_cdr observation table
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id AS person_id
-FROM  `{project_id}.{com_cdr}.observation` ob
-JOIN  `{project_id}.{pipeline}.pid_rid_mapping` m 
+FROM  `{{project_id}}.{{com_cdr}}.observation` ob
+JOIN  `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
 ON ob.person_id=m.person_id
 WHERE value_source_value IN ('SexAtBirth_Female' ,'GenderIdentity_Man')
 GROUP BY m.research_id
@@ -376,48 +389,50 @@ HAVING count (distinct value_source_value)=2
   
   )
   
-SELECT COUNT (*) AS n_row_not_pass FROM `{project_id}.{deid_cdr}.observation` 
+SELECT COUNT (*) AS n_row_not_pass FROM `{{project_id}}.{{deid_cdr}}.observation` 
 WHERE person_id IN (SELECT person_id FROM df1)
 AND observation_source_value LIKE 'Gender_GenderIdentity'
 AND (value_as_concept_id !=2000000002 AND value_source_concept_id !=2000000002)
 
- '''
-df1=execute(client, query)  
+ """)
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query3.3.2 GR_03_1 Sex_female/gender_man mismatch in deid_cdr.observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3.3.2 GR_03_1 Sex_female/gender_man mismatch in deid_cdr.observation', 'result' : ''},  
+ df = df.append({'query' : 'Query3.3.2 GR_03_1 Sex_female/gender_man mismatch in deid_cdr.observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # +
 # in deid_cdr obs
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 
 SELECT m.research_id AS person_id
-FROM `{project_id}.{com_cdr}.observation` ob
-JOIN  `{project_id}.{pipeline}.pid_rid_mapping` m 
+FROM `{{project_id}}.{{com_cdr}}.observation` ob
+JOIN  `{{project_id}}.{{pipeline}}.pid_rid_mapping` m 
 ON ob.person_id=m.person_id
 WHERE value_source_value IN ('SexAtBirth_Male' ,'GenderIdentity_Woman')
 GROUP BY m.research_id
 HAVING count (distinct value_source_value)=2 
 )
   
-SELECT COUNT (*) AS n_row_not_pass FROM  `{project_id}.{deid_cdr}.observation`
+SELECT COUNT (*) AS n_row_not_pass FROM  `{{project_id}}.{{deid_cdr}}.observation`
 WHERE person_id IN (SELECT person_id FROM df1)
 AND observation_source_value LIKE 'Gender_GenderIdentity'
 AND (value_as_concept_id !=2000000002 AND value_source_concept_id !=2000000002)
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query3.3.4 GR_03_1 Sex_male/gender_woman mismatch in deid_cdr.observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3.3.4 GR_03_1 Sex_male/gender_woman mismatch in deid_cdr.observation', 'result' : ''},  
+ df = df.append({'query' : 'Query3.3.4 GR_03_1 Sex_male/gender_woman mismatch in deid_cdr.observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 # -
@@ -443,13 +458,13 @@ df1
 # the value_as_concept_id field in de-id table populates 1177221
 #
 # - Verify that if the value_source_concept_id in OBSERVATION table populates: 903096, 
-# the value_as_concept_id field in de-id table populates: 903096 or 2000000010
+# the value_as_concept_id field in de-id table populates 903096
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct value_source_concept_id,value_as_concept_id
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE value_source_concept_id IN (2000000007, 2000000006,1585945,1585946,903079,903096)
  )
   
@@ -458,16 +473,17 @@ WHERE (value_source_concept_id=2000000007 AND value_as_concept_id !=2000000007)
 OR (value_source_concept_id=2000000006 AND value_as_concept_id !=2000000006)
 OR (value_source_concept_id=1585945 AND value_as_concept_id !=43021808)
 OR (value_source_concept_id=1585946 AND value_as_concept_id !=4260980)
-OR (value_source_concept_id=903096 AND value_as_concept_id NOT IN (903096, 2000000010))
+OR (value_source_concept_id=903096 AND value_as_concept_id !=903096)
 OR (value_source_concept_id=903079 AND value_as_concept_id !=1177221)
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query4 Education Generalization Rule in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query4 Education Sex Generalization Rule in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query4 Education Sex Generalization Rule in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -489,14 +505,14 @@ df1
 # - Verify that if the value_source_concept_id in OBSERVATION table populates: 903079, 
 # the value_as_concept_id field in de-id table populates 1177221
 # - Verify that if the value_source_concept_id in OBSERVATION table populates: 903096, 
-# the value_as_concept_id field in de-id table populates: 903096 or 2000000010
+# the value_as_concept_id field in de-id table populates 903096
 #
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT distinct value_source_concept_id,value_as_concept_id
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE value_source_concept_id IN (2000000005, 2000000004,903079,903096)
  )
  
@@ -504,16 +520,17 @@ SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE (value_source_concept_id=2000000005 AND value_as_concept_id !=2000000005)
 OR (value_source_concept_id=2000000004 AND value_as_concept_id !=2000000004)
 OR (value_source_concept_id=903079 AND value_as_concept_id !=1177221)
-OR (value_source_concept_id=903096 AND value_as_concept_id NOT IN (903096, 2000000010))
+OR (value_source_concept_id=903096 AND value_as_concept_id !=903096)
 
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query5 Employment Generalization Rule in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query5 GR_06 Employment Generalization Rule in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query5 GR_06 Employment Generalization Rule in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -526,26 +543,32 @@ df1
 # If given a dataset where any person.gender_concept_id field is not 0 will produce a failure.
 
 # +
-query = f'''
+query = JINJA_ENV.from_string("""
 
 SELECT
 SUM(CASE WHEN gender_concept_id !=0 THEN 1 ELSE 0 END) AS n_gender_concept_id_not_zero,
 SUM(CASE WHEN gender_concept_id IS NULL THEN 1 ELSE 0 END) AS n_gender_concept_id_is_null
-FROM `{project_id}.{deid_cdr}.person`
-'''
-df1=execute(client, query)  
+FROM `{{project_id}}.{{deid_cdr}}.person`
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query6 Gender_concept_id should be 0 in person table', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query6 GR_06 Gender_concept_id should be 0 in person table', 'result' : ''},  
+ df = df.append({'query' : 'Query6 GR_06 Gender_concept_id should be 0 in person table', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
+
+
 # -
 
 # # Summary_cdr_deid_Generalization_rule
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null','']))
-df.style.highlight_null(null_color='red').set_properties(**{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report2_row_suppression.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report2_row_suppression.py
@@ -20,6 +20,7 @@
 
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -29,12 +30,15 @@ pd.options.display.max_rows = 120
 # Parameters
 project_id = ""
 deid_cdr = ""
-com_cdr =""
-run_as = ""
-# -
+com_cdr ="" 
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#com_cdr = "2021q3r2_combined"
+#deid_cdr = "R2021q3r2_deid_"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -43,12 +47,15 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
 # # 1 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM    `{project_id}.{com_cdr}.observation`
+FROM    `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE '%SitePairing%'
 OR observation_source_value LIKE '%ArizonaSpecific%'
 OR observation_source_value LIKE 'EastSoutheastMichigan%'
@@ -59,18 +66,19 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1)
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
- '''
-df1=execute(client, query)  
+ """)
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query1 three colmns suppression in observation table', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query1 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query1 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -78,10 +86,10 @@ df1
 
 # ## error in new cdr
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM    `{project_id}.{com_cdr}.observation`
+FROM    `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE 'PIIName_%'
 OR observation_source_value LIKE 'PIIAddress_%'
 OR observation_source_value LIKE 'StreetAddress_%'
@@ -97,26 +105,27 @@ SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_strin
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
 
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query2 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query2 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query2 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # +
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM    `{project_id}.{com_cdr}.observation`
+FROM    `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE 'PIIName_%'
 OR observation_source_value LIKE 'PIIAddress_%'
 OR observation_source_value LIKE 'StreetAddress_%'
@@ -128,13 +137,14 @@ OR observation_source_value LIKE 'SocialSecurity_%'
 )
 
 SELECT  distinct observation_source_value,value_source_value, value_as_string
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL) 
 OR (value_as_string IS NOT NULL)) 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 
 df1
 # -
@@ -143,10 +153,10 @@ df1
 
 # ## error in new cdr
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT  observation_id
-FROM    `{project_id}.{com_cdr}.observation`
+FROM    `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE '%_Signature'
 OR observation_source_value LIKE 'ExtraConsent__%' 
 )
@@ -155,49 +165,51 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query3 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query3 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # +
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT  observation_id
-FROM    `{project_id}.{com_cdr}.observation`
+FROM    `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE '%_Signature'
 OR observation_source_value LIKE 'ExtraConsent__%' 
 )
 
 SELECT 
 distinct observation_source_value,value_source_value, value_as_string
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 
 df1
 # -
 
 # # 4 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE '%Specific' 
 OR observation_source_value LIKE '%NoneOfTheseDescribeMe%' 
 OR observation_source_value LIKE '%RaceEthnicityNoneOfThese_%' 
@@ -209,18 +221,19 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query4 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query4 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query4 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -228,10 +241,10 @@ df1
 
 # ## error in new cdr
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE '%Gender%' 
 OR observation_source_value LIKE '%Sexuality%' 
 OR observation_source_value LIKE '%SexAtBirthNoneOfThese_%' 
@@ -240,48 +253,50 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
- FROM `{project_id}.{deid_cdr}.observation`
+ FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query5 Observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query5 Observation', 'result' : ''},  
+ df = df.append({'query' : 'Query5 Observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # +
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE '%Gender%' 
 OR observation_source_value LIKE '%Sexuality%' 
 OR observation_source_value LIKE '%SexAtBirthNoneOfThese_%' 
 )
 SELECT distinct observation_source_value,value_source_value, value_as_string
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)  
 OR (value_as_string IS NOT NULL))  
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 
 df1
 # -
 
 # # 6 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM  `{project_id}.{com_cdr}.observation`
+FROM  `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE '%ContactInfo_%' 
 OR observation_source_value LIKE 'PersonOneAddress_%' 
 OR observation_source_value LIKE 'SecondContactsAddress_%'  
@@ -290,54 +305,56 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query6 Observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query6 Observation', 'result' : ''},  
+ df = df.append({'query' : 'Query6 Observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 7 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM  `{project_id}.{com_cdr}.observation`
+FROM  `{{project_id}}.{{com_cdr}}.observation`
 WHERE observation_source_value LIKE 'EmploymentWorkAddress_%'  
 )
 SELECT 
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
- '''
-df1=execute(client, query) 
+ """)
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query7 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query7 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query7 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 8 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM  `{project_id}.{com_cdr}.observation`
+FROM  `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE 'PersonalMedicalHistory_AdditionalDiagnosis' 
 OR observation_source_value LIKE 'ActiveDuty_AvtiveDutyServeStatus' 
 OR observation_source_value LIKE 'OtherSpecify_OtherDrugsTextBox' 
@@ -347,27 +364,28 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null 
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query8 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query8 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query8 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 9 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE 'OrganTransplantDescription_OtherOrgan'
 OR observation_source_value LIKE 'OrganTransplantDescription_OtherTissue')
 
@@ -375,27 +393,28 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query9 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query9 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query9 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 10 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE 'LivingSituation_CurrentLiving'
 OR observation_source_value LIKE 'LivingSituation_LivingSituationFreeText')
 
@@ -403,28 +422,29 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
 
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query10 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query10 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query10 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 11 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM  `{project_id}.{com_cdr}.observation`
+FROM  `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE 'OutsideTravel6Month_OutsideTravel6MonthWhereTravel'
 OR observation_source_value LIKE 'OutsideTravel6Month_OutsideTravel6MonthWhere')
 
@@ -432,20 +452,21 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
 
 
-    '''
-df1=execute(client, query) 
+    """)
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query11 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query11 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query11 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -453,10 +474,10 @@ df1
 
 # ## error in new cdr
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE 'HowOldWereYou%FreeTextBox' 
 OR observation_source_value LIKE '%_WhichConditions%' 
 OR observation_source_value LIKE '%_OtherCancer%' 
@@ -468,26 +489,27 @@ SELECT
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null,
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL)  
 OR (value_source_value IS NOT NULL) 
 OR (value_as_string IS NOT NULL))  
- '''
-df1=execute(client, query) 
+ """)
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query12 observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query12 observation', 'result' : ''},  
+ df = df.append({'query' : 'Query12 observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # +
-query=f''' 
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT observation_id
-FROM `{project_id}.{com_cdr}.observation`
+FROM `{{project_id}}.{{com_cdr}}.observation`
 WHERE  observation_source_value LIKE 'HowOldWereYou%FreeTextBox' 
 OR observation_source_value LIKE '%_WhichConditions%' 
 OR observation_source_value LIKE '%_OtherCancer%' 
@@ -496,38 +518,44 @@ OR observation_source_value LIKE 'Other%FreeTextBox'
 OR observation_source_value LIKE 'Other%FreeText' )
 
 SELECT distinct observation_source_value,value_source_value,value_as_string
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE observation_id IN (SELECT observation_id FROM df1) 
 AND ((observation_source_value IS NOT NULL) 
 OR (value_source_value IS NOT NULL)
 OR (value_as_string IS NOT NULL))
- '''
-df1=execute(client, query) 
+ """)
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 
 df1
 # -
 
 # # 13 Verify all fields identified for suppression in the OBSERVATION table have been removed from the table in the deid dataset.
 
-query=f''' 
+query = JINJA_ENV.from_string("""
 
 SELECT 
 SUM(CASE WHEN observation_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_concept_id_not_null
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE    observation_concept_id IN (4013886,4271761,4135376,1585559,43529714,1585917,1585913,43529731,43529729,
 43529730,1585933,1585929,1585965)
-'''
-df1=execute(client, query) 
+""")
+q = query.render(project_id=project_id,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query13 observation_concept_id suppression in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query13 observation_concept_id suppression in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query13 observation_concept_id suppression in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
+
 # # Summary_row_suppression
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null','']))
-df.style.highlight_null(null_color='red').set_properties(**{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report2_row_suppression.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report2_row_suppression.py
@@ -34,13 +34,6 @@ com_cdr =""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#com_cdr = "2021q3r2_combined"
-#deid_cdr = "R2021q3r2_deid_"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report3_col_suppression.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report3_col_suppression.py
@@ -31,12 +31,6 @@ deid_cdr=""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#deid_cdr = "R2022q2r4_deid"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report3_col_suppression.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report3_col_suppression.py
@@ -17,7 +17,9 @@
 #
 # (Query results: This query returned no results.)
 
+import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -25,12 +27,14 @@ pd.options.display.max_rows = 120
 
 # + tags=["parameters"]
 project_id = ""
-deid_cdr = ""
-run_as = ""
-# -
+deid_cdr=""
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#deid_cdr = "R2022q2r4_deid"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -38,6 +42,9 @@ impersonation_creds = auth.get_impersonation_credentials(
 
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
+
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
 
 # # 1 Verify the following columns in the OBSERVATION table have been set to null:
 # value_as_string,
@@ -48,7 +55,7 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 # unit_source_value
 
 # +
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 
 SUM(CASE WHEN value_as_string IS NOT NULL THEN 1 ELSE 0 END) AS n_value_as_string_not_null,
@@ -58,22 +65,17 @@ SUM(CASE WHEN qualifier_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_qualifi
 SUM(CASE WHEN observation_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_observation_source_value_not_null,
 SUM(CASE WHEN unit_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_unit_source_value_not_null
 
-FROM `{project_id}.{deid_cdr}.observation` 
- '''
-df1 = execute(client, query)
+FROM `{{project_id}}.{{deid_cdr}}.observation` 
+ """)
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query1 observation',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query1 observation', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query1 observation',
-        'result': ''
-    },
-                   ignore_index=True)
+ df = df.append({'query' : 'Query1 observation', 'result' :  'Failure'},  
+                ignore_index = True) 
 df1.T
 # -
 
@@ -83,7 +85,7 @@ df1.T
 #
 # I changed to detect 0 for now, but in the future, better set them to null, instead of 0.
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
   SUM(CASE WHEN year_of_birth !=0 THEN 1 ELSE 0 END) AS n_year_of_birth_not_null,
 SUM(CASE WHEN month_of_birth IS NOT NULL THEN 1 ELSE 0 END) AS n_month_of_birth_not_null,
@@ -99,87 +101,75 @@ SUM(CASE WHEN gender_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_gende
 SUM(CASE WHEN race_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_race_source_value_not_null,
 SUM(CASE WHEN ethnicity_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_ethnicity_source_value_not_null,
 SUM(CASE WHEN ethnicity_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_ethnicity_source_concept_id_not_null
-FROM `{project_id}.{deid_cdr}.person` 
-    '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query2 Person',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.person` 
+    """)
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query2 Person', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({'query': 'Query2 Person', 'result': ''}, ignore_index=True)
-df1.T
+ df = df.append({'query' : 'Query2 Person', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1.T              
 
 # # 3 Verify the following columns in the MEASUREMENT table have been set to null:
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 
 SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null,
 SUM(CASE WHEN measurement_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_measurement_source_value_not_null,
 SUM(CASE WHEN value_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_value_source_value_not_null
 
-FROM `{project_id}.{deid_cdr}.measurement`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query3 Measurement',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.measurement`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3 Measurement', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query3 Measurement',
-        'result': ''
-    },
-                   ignore_index=True)
-df1.T
+ df = df.append({'query' : 'Query3 Measurement', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1.T  
 
 # # 4 Verify the following columns in the DEATH table have been set to null:
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 SUM(CASE WHEN cause_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_concept_id_not_null,
 SUM(CASE WHEN cause_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_source_value_not_null,
 SUM(CASE WHEN cause_source_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_source_concept_id_not_null
 
-FROM `{project_id}.{deid_cdr}.death`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query4 Death',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.death`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query4 Death', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({'query': 'Query4 Death', 'result': ''}, ignore_index=True)
-df1
+ df = df.append({'query' : 'Query4 Death', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1        
 
 # # 5 Verify the following columnsin the CONDITION_OCCURRENCE table have been set to null:
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null
-FROM `{project_id}.{deid_cdr}.condition_occurrence`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query5 Condition provider_id',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.condition_occurrence`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query5 Condition provider_id', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query5 Condition provider_id',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
+ df = df.append({'query' : 'Query5 Condition provider_id', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1        
 
 # # 6 Verify the following columns in the DEVICE_EXPOSURE table have been set to null:
 #
@@ -188,102 +178,87 @@ df1
 # +
 # query6 has error
 # no this column called visit_detail_id?
-
-query = f''' 
+    
+query = JINJA_ENV.from_string("""
 SELECT
-SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null
--- SUM(CASE WHEN visit_detail_id IS NOT NULL THEN 1 ELSE 0 END) AS n_visit_detail_id_not_null
+SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null,
+SUM(CASE WHEN visit_detail_id IS NOT NULL THEN 1 ELSE 0 END) AS n_visit_detail_id_not_null
 
-FROM `{project_id}.{deid_cdr}.device_exposure`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query6 provider_id in Device',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.device_exposure`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query6 provider_id in Device', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query6 provider_id in Device',
-        'result': ''
-    },
-                   ignore_index=True)
+ df = df.append({'query' : 'Query6 provider_id in Device', 'result' :  'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
 # # 7 Verify the following columns in the DRUG_EXPOSURE table have been set to null:
 # provider_id
 #
-# <font color='red'> no visit_detail_id ?
-#
-#  Uncomment below when visit_detail_id is available
+# <font color='red'> no visit_detail_id in old CDR?
+#     
+#  Uncomment below when visit_detail_id is available in 2022 CDR
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
-SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null
---SUM(CASE WHEN visit_detail_id IS NOT NULL THEN 1 ELSE 0 END) AS n_visit_detail_id_not_null
-FROM `{project_id}.{deid_cdr}.drug_exposure`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query7 provider_id in Drug',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null,
+SUM(CASE WHEN visit_detail_id IS NOT NULL THEN 1 ELSE 0 END) AS n_visit_detail_id_not_null
+FROM `{{project_id}}.{{deid_cdr}}.drug_exposure`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query7 provider_id in Drug', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query7 provider_id in Drug',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
+ df = df.append({'query' : 'Query7 provider_id in Drug', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1        
 
 # # 8 Verify the following columns in the VISIT_OCCURRENCE table have been set to null:
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null,
 SUM(CASE WHEN care_site_id IS NOT NULL THEN 1 ELSE 0 END) AS n_care_site_id_not_null
-FROM `{project_id}.{deid_cdr}.visit_occurrence`
- '''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query8 Visit',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.visit_occurrence`
+ """)
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query8 Visit', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({'query': 'Query8 Visit', 'result': ''}, ignore_index=True)
-df1
+ df = df.append({'query' : 'Query8 Visit', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1        
 
 # # 9 Verify the following columns in the PROCEDURE_OCCURRENCE table have been set to null:
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 SUM(CASE WHEN provider_id IS NOT NULL THEN 1 ELSE 0 END) AS n_provider_id_not_null
-FROM `{project_id}.{deid_cdr}.procedure_occurrence`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query9 Procedure provider_id',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.procedure_occurrence`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query9 Procedure provider_id', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query9 Procedure provider_id',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
+ df = df.append({'query' : 'Query9 Procedure provider_id', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1        
 
 # # 10 Verify the following columns in the SPECIMEN  table have been set to null:
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 SUM(CASE WHEN specimen_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_specimen_source_value_not_null,
 SUM(CASE WHEN unit_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_unit_source_value_not_null,
@@ -291,97 +266,80 @@ SUM(CASE WHEN specimen_source_id IS NOT NULL THEN 1 ELSE 0 END) AS n_specimen_so
 SUM(CASE WHEN disease_status_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_disease_status_source_value_not_null,
 SUM(CASE WHEN anatomic_site_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_anatomic_site_source_value_not_null
 
-FROM `{project_id}.{deid_cdr}.specimen`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query10 Specimen',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.specimen`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query10 Specimen', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query10 Specimen',
-        'result': ''
-    },
-                   ignore_index=True)
-df1.T
+ df = df.append({'query' : 'Query10 Specimen', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1.T        
 
 # # 11 Verify the following columns in the CARE_SITE  table have been set to null
 
 # ## in new cdr, this table is empty?
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT
 SUM(CASE WHEN care_site_name IS NOT NULL THEN 1 ELSE 0 END) AS n_care_site_name_not_null,
 SUM(CASE WHEN care_site_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_care_site_source_value_not_null,
 SUM(CASE WHEN place_of_service_source_value IS NOT NULL THEN 1 ELSE 0 END) AS n_place_of_service_source_value_not_null
 
-FROM `{project_id}.{deid_cdr}.care_site`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query11 Care_site',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.care_site`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query11 Care_site', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query11 Care_site',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
+ df = df.append({'query' : 'Query11 Care_site', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1      
 
 # # 12 Verify the NOTE table is suppressed
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
-FROM `{project_id}.{deid_cdr}.note`
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query12 Note table',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+FROM `{{project_id}}.{{deid_cdr}}.note`
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query12 Note table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query12 Note table',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
+ df = df.append({'query' : 'Query12 Note table', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1     
 
 # # 13 Verify the NOTE_NLP table  is suppressed
-#
+# DC-2372 fixed
 
-query = f''' 
+query = JINJA_ENV.from_string("""
 SELECT row_count
-FROM `{project_id}.{deid_cdr}.__TABLES__`
+FROM `{{project_id}}.{{deid_cdr}}.__TABLES__`
 WHERE table_id='note_nlp'
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query13 Note_NLP table',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query13 Note_NLP table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query13 Note_NLP table',
-        'result': ''
-    },
-                   ignore_index=True)
-df1
+ df = df.append({'query' : 'Query13 Note_NLP table', 'result' :  'Failure'},  
+                ignore_index = True) 
+df1    
+
 
 # # Summary_column_suppression
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null', '']))
-df.style.highlight_null(null_color='red').set_properties(
-    **{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report4_dateshift.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report4_dateshift.py
@@ -35,15 +35,6 @@ pipeline=""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#com_cdr = "2022q4r3_combined"
-#deid_questionnaire_response_map_dataset = "2022q4r3_deid_sandbox"
-#deid_cdr = "R2022q4r4_deid"
-#pipeline = "pipeline_tables"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report4_dateshift.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report4_dateshift.py
@@ -20,6 +20,7 @@
 # + papermill={"duration": 0.709639, "end_time": "2021-02-02T22:30:32.661373", "exception": false, "start_time": "2021-02-02T22:30:31.951734", "status": "completed"} tags=[]
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -31,43 +32,53 @@ com_cdr = ""
 deid_cdr = ""
 deid_questionnaire_response_map_dataset = ""
 pipeline=""
-run_as = ""
-# -
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#com_cdr = "2022q4r3_combined"
+#deid_questionnaire_response_map_dataset = "2022q4r3_deid_sandbox"
+#deid_cdr = "R2022q4r4_deid"
+#pipeline = "pipeline_tables"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 
 client = BigQueryClient(project_id, credentials=impersonation_creds)
+# -
+
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
 
 # + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false, "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
 # # 1 DS_1 Verify that the field identified to follow the date shift rule as de-identification action in OBSERVATION table have been randomly date shifted.
 
 # + papermill={"duration": 4.105203, "end_time": "2021-02-02T22:30:36.813460", "exception": false, "start_time": "2021-02-02T22:30:32.708257", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.observation_date), DATE(d.observation_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.observation` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.observation` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.observation` d
+JOIN `{{project_id}}.{{deid_cdr}}.observation` d
 ON d.observation_id = i.observation_id)
 
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
 
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query1 OBSERVATION', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query1 OBSERVATION', 'result' : ''},  
+ df = df.append({'query' : 'Query1 OBSERVATION', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 # -
@@ -75,26 +86,27 @@ df1
 # # 3 DS_3 Verify that the field identified to follow the date shift rule as de-identification action in OBSERVATION_PERIOD table have been randomly date shifted.
 
 # + papermill={"duration": 2.136748, "end_time": "2021-02-02T22:30:39.044867", "exception": false, "start_time": "2021-02-02T22:30:36.908119", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.observation_period_start_date), DATE(d.observation_period_start_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.observation_period` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.observation_period` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.observation_period` d
+JOIN `{{project_id}}.{{deid_cdr}}.observation_period` d
 ON d.observation_period_id = i.observation_period_id)
 
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
 
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query3 OBSERVATION_PERIOD', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3 OBSERVATION_PERIOD', 'result' : ''},  
+ df = df.append({'query' : 'Query3 OBSERVATION_PERIOD', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -103,25 +115,26 @@ df1
 # # 4 DS_4 Verify that the field identified to follow the date shift rule as de-identification action in PERSON table have been randomly date shifted.
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.birth_datetime), DATE(d.birth_datetime),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.person` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.person` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.person` d
+JOIN `{{project_id}}.{{deid_cdr}}.person` d
 ON d.person_id = m.research_id
 )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query4 Person table', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query4 Person table', 'result' : ''},  
+ df = df.append({'query' : 'Query4 Person table', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -130,54 +143,56 @@ df1
 # # 5 DS_5 Verify that the field identified to follow the date shift rule as de-identification action in SPECIMEN table have been randomly date shifted.
 
 # + papermill={"duration": 2.338821, "end_time": "2021-02-02T22:30:41.501415", "exception": false, "start_time": "2021-02-02T22:30:39.162594", "status": "completed"} tags=[]
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.specimen_date), DATE(d.specimen_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.specimen` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.specimen` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.specimen` d
+JOIN `{{project_id}}.{{deid_cdr}}.specimen` d
 ON d.specimen_id = i.specimen_id
 )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
   
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query5 SPECIMEN', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query5 SPECIMEN', 'result' : ''},  
+ df = df.append({'query' : 'Query5 SPECIMEN', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 # -
 
 # # 6 DS_6 Verify that the field identified to follow the date shift rule as de-identification action in DEATH table have been randomly date shifted. 
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT 
 DATE_DIFF(DATE(i.death_date), DATE(d.death_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.death` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.death` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.death` d
+JOIN `{{project_id}}.{{deid_cdr}}.death` d
 ON m.research_id = d.person_id 
 AND i.death_type_concept_id = d.death_type_concept_id
  )
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE diff !=0
   
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query6 Death', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query6 Death', 'result' : ''},  
+ df = df.append({'query' : 'Query6 Death', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -185,287 +200,292 @@ df1
 # # 7 DS_7 Verify that the field identified to follow the date shift rule as de-identification action in VISIT OCCURENCE table have been randomly date shifted. 
 # -
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.visit_start_date), DATE(d.visit_start_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.visit_occurrence` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.visit_occurrence` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.visit_occurrence` d
+JOIN `{{project_id}}.{{deid_cdr}}.visit_occurrence` d
 ON d.visit_occurrence_id = i.visit_occurrence_id
 )
 SELECT COUNT (*) AS n_row_not_pass FROM df1
 WHERE diff !=0
   
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query7 Visit', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query7 Visit', 'result' : ''},  
+ df = df.append({'query' : 'Query7 Visit', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 8 DS_8 Verify that the field identified to follow the date shift rule as de-identification action in PROCEDURE OCCURENCE table have been randomly date shifted.
 #
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 as (
 SELECT
 DATE_DIFF(DATE(i.procedure_date), DATE(d.procedure_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.procedure_occurrence` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.procedure_occurrence` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.procedure_occurrence` d
+JOIN `{{project_id}}.{{deid_cdr}}.procedure_occurrence` d
 ON d.procedure_occurrence_id = i.procedure_occurrence_id
 )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
   
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query8 PROCEDURE', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query8 PROCEDURE', 'result' : ''},  
+ df = df.append({'query' : 'Query8 PROCEDURE', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 9 DS_9 Verify that the field identified to follow the date shift rule as de-identification action in DRUG EXPOSURE table have been randomly date shifted.
 
-query = f'''
+# +
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.drug_exposure_start_date), DATE(d.drug_exposure_start_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.drug_exposure` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.drug_exposure` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.drug_exposure` d
+JOIN `{{project_id}}.{{deid_cdr}}.drug_exposure` d
 ON i.drug_exposure_id = d.drug_exposure_id
 )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
-'''
-df9=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr) 
+df1=execute(client, q) 
+
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query9 Drug table', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query9 Drug table', 'result' : ''},  
+ df = df.append({'query' : 'Query9 Drug table', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
+# -
 
 
 # # 10 DS_10 Verify that the field identified to follow the date shift rule as de-identification action in DEVICE EXPOSURE table have been randomly date shifted.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
  DATE_DIFF(DATE(i.device_exposure_start_date), DATE(d.device_exposure_start_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.device_exposure` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.device_exposure` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.device_exposure` d
+JOIN `{{project_id}}.{{deid_cdr}}.device_exposure` d
 ON i.device_exposure_id = d.device_exposure_id
   )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
-  '''
-df1=execute(client, query)
+  """)
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query10 Device', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query10 Device', 'result' : ''},  
+ df = df.append({'query' : 'Query10 Device', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 11 DS_11 Verify that the field identified to follow the date shift rule as de-identification action in CONDITION OCCURENCE table have been randomly date shifted.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.condition_start_date), DATE(d.condition_start_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.condition_occurrence` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.condition_occurrence` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.condition_occurrence` d
+JOIN `{{project_id}}.{{deid_cdr}}.condition_occurrence` d
 ON i.condition_occurrence_id = d.condition_occurrence_id
   )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
   
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query11 Condition table', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query11 Condition table', 'result' : ''},  
+ df = df.append({'query' : 'Query11 Condition table', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 12 DS_12 Verify that the field identified to follow the date shift rule as de-identification action in MEASUREMENT table have been randomly date shifted.
 
 # +
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.measurement_date), DATE(d.measurement_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.measurement` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.measurement` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.measurement` d
+JOIN `{{project_id}}.{{deid_cdr}}.measurement` d
 ON d.measurement_id = i.measurement_id
   )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
   
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query12 Measurement', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query12 Measurement', 'result' : ''},  
+ df = df.append({'query' : 'Query12 Measurement', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 # -
 
-# # 13 DS_13 Verify that the field identified to follow the date shift rule as de-identification action in SURVEY_CONDUCT table have been randomly date shifted.
+# # Q13 DS_13 Verify that the field identified to follow the date shift rule as de-identification action in SURVEY_CONDUCT table have been randomly date shifted.
+#
+# this is a new table, only avaiable in new cdr 2022q4r4
 
 # +
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT
 DATE_DIFF(DATE(i.survey_start_date), DATE(d.survey_start_date),day)-m.shift as diff
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{com_cdr}.survey_conduct` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{com_cdr}}.survey_conduct` i
 ON m.person_id = i.person_id
-JOIN `{project_id}.{deid_cdr}.survey_conduct` d
+JOIN `{{project_id}}.{{deid_cdr}}.survey_conduct` d
 ON d.survey_conduct_id = i.survey_conduct_id
   )
 SELECT COUNT(*) AS n_row_not_pass FROM df1
 WHERE diff !=0
-  
-'''
-df1=execute(client, query)
+
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query13 Survey Conduct', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query13 Survey Conduct', 'result' : ''},  
+ df = df.append({'query' : 'Query13 Survey Conduct', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 # -
 
-# # 14 DS_14 Verify the date shift has been implemented following the date shift noted in the deid_map table in the non-deid dataset.
+# # Q14 DS_14 Verify the date shift has been implemented following the date shift noted in the deid_map table in the non-deid dataset.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{pipeline}.pid_rid_mapping`
+FROM  `{{project_id}}.{{pipeline}}.pid_rid_mapping`
 WHERE shift <=0
 
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
- df = df.append({'query' : 'Query14 date shifted in non_deid', 'result' : 'PASS'},  
+ df = df.append({'query' : 'Query13 date shifted in non_deid', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query14 date shifited in non_deid', 'result' : ''},  
+ df = df.append({'query' : 'Query13 date shifited in non_deid', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
-# # 15 DS_15 Verify that  person_id has been replaced by research_id
+# # Q15 DS_15 Verify that  person_id has been replaced by research_id
 #
 #
 # checked total 8 tables including  specimen etc tables in deid. However will be hard to check person or death tables without row_id.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.observation` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.observation` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.observation` deid USING(observation_id)
+JOIN `{{project_id}}.{{deid_cdr}}.observation` deid USING(observation_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df2 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.measurement` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.measurement` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.measurement` deid USING(measurement_id)
+JOIN `{{project_id}}.{{deid_cdr}}.measurement` deid USING(measurement_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df3 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.condition_occurrence` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.condition_occurrence` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.condition_occurrence` deid USING(condition_occurrence_id)
+JOIN `{{project_id}}.{{deid_cdr}}.condition_occurrence` deid USING(condition_occurrence_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df4 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.drug_exposure` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.drug_exposure` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.drug_exposure` deid USING(drug_exposure_id)
+JOIN `{{project_id}}.{{deid_cdr}}.drug_exposure` deid USING(drug_exposure_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df5 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.device_exposure` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.device_exposure` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.device_exposure` deid USING(device_exposure_id)
+JOIN `{{project_id}}.{{deid_cdr}}.device_exposure` deid USING(device_exposure_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df6 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.procedure_occurrence` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.procedure_occurrence` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.procedure_occurrence` deid USING(procedure_occurrence_id)
+JOIN `{{project_id}}.{{deid_cdr}}.procedure_occurrence` deid USING(procedure_occurrence_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df7 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.visit_occurrence` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.visit_occurrence` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.visit_occurrence` deid USING(visit_occurrence_id)
+JOIN `{{project_id}}.{{deid_cdr}}.visit_occurrence` deid USING(visit_occurrence_id)
 WHERE deid.person_id !=m.research_id
 ),
 
 df8 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.specimen` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM  `{{project_id}}.{{com_cdr}}.specimen` non_deid
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.specimen` deid USING(specimen_id)
+JOIN `{{project_id}}.{{deid_cdr}}.specimen` deid USING(specimen_id)
 WHERE deid.person_id !=m.research_id
-),
-
-df9 AS (
-SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.survey_conduct` non_deid
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
-ON m.person_id=non_deid.person_id
-JOIN `{project_id}.{deid_cdr}.survey_conduct` deid USING(survey_conduct_id)
-WHERE deid.person_id !=m.research_id
+)
 
 
 SELECT * FROM df1
@@ -476,46 +496,46 @@ JOIN df5 USING(n_row_not_pass)
 JOIN df6 USING(n_row_not_pass)
 JOIN df7 USING(n_row_not_pass)
 JOIN df8 USING(n_row_not_pass)
-JOIN df9 USING(n_row_not_pass)
 
 
 
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
- df = df.append({'query' : 'Query15.3 person_id replaed by research_id in other 9 tables', 'result' : 'PASS'},  
+ df = df.append({'query' : 'Query14.3 person_id replaed by research_id in other 8 tables', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query15.3 person_id replaed by research_id in other 9 tables', 'result' : ''},  
+ df = df.append({'query' : 'Query14.3 person_id replaed by research_id in other 8 tables', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
-# # 16 Verify that  questionnaire_response_id/survey_conduct_id has been replaced by research_response_id
+# # Q16 Verify that  questionnaire_response_id/survey_conduct_id has been replaced by research_response_id
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.survey_conduct` non_deid
-JOIN `{project_id}.{deid_questionnaire_response_map_dataset}._deid_questionnaire_response_map` m
+FROM  `{{project_id}}.{{com_cdr}}.survey_conduct` non_deid
+JOIN `{{project_id}}.{{deid_questionnaire_response_map_dataset}}._deid_questionnaire_response_map` m
 ON m.questionnaire_response_id=non_deid.survey_conduct_id
-JOIN `{project_id}.{deid_cdr}.survey_conduct` deid USING(survey_conduct_id)
+JOIN `{{project_id}}.{{deid_cdr}}.survey_conduct` deid USING(survey_conduct_id)
 WHERE deid.survey_conduct_id != m.research_response_id
 ),
 
 df2 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.survey_conduct` non_deid
-JOIN `{project_id}.{deid_questionnaire_response_map_dataset}._deid_questionnaire_response_map` m
+FROM  `{{project_id}}.{{com_cdr}}.survey_conduct` non_deid
+JOIN `{{project_id}}.{{deid_questionnaire_response_map_dataset}}._deid_questionnaire_response_map` m
 ON m.questionnaire_response_id=non_deid.survey_conduct_id
-JOIN `{project_id}.{deid_cdr}.survey_conduct` deid USING(survey_conduct_id)
-WHERE deid.survey_source_identifier != m.research_response_id
+JOIN `{{project_id}}.{{deid_cdr}}.survey_conduct` deid USING(survey_conduct_id)
+WHERE SAFE_CAST(deid.survey_source_identifier AS FLOAT64) != m.research_response_id
 ),
 df3 AS (
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{com_cdr}.observation` non_deid
-JOIN `{project_id}.{deid_questionnaire_response_map_dataset}._deid_questionnaire_response_map` m
+FROM  `{{project_id}}.{{com_cdr}}.observation` non_deid
+JOIN `{{project_id}}.{{deid_questionnaire_response_map_dataset}}._deid_questionnaire_response_map` m
 ON m.questionnaire_response_id=non_deid.questionnaire_response_id
-JOIN `{project_id}.{deid_cdr}.observation` deid USING(observation_id)
+JOIN `{{project_id}}.{{deid_cdr}}.observation` deid USING(observation_id)
 WHERE deid.questionnaire_response_id != m.research_response_id
 )
 
@@ -523,19 +543,26 @@ SELECT * FROM df1
 JOIN df2 USING(n_row_not_pass)
 JOIN df3 USING(n_row_not_pass)
 
-
-'''
-df1=execute(client, query)
+""")
+q = query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,deid_questionnaire_response_map_dataset=deid_questionnaire_response_map_dataset)  
+df1=execute(client, q) 
 if df1.eq(0).any().any():
  df = df.append({'query' : 'Query16 questionnaire_response_id/survey_conduct_id/survey_source_identifier replaced by research_response_id', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query16 questionnaire_response_id/survey_conduct_id/survey_source_identifier replaced by research_response_id', 'result' : ''},  
+ df = df.append({'query' : 'Query16 questionnaire_response_id/survey_conduct_id/survey_source_identifier replaced by research_response_id', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
+
 # # Summary_dateshift
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null','']))
-df.style.highlight_null(null_color='red').set_properties(**{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+# -
+
+

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report5_row_suppression_icd.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report5_row_suppression_icd.py
@@ -18,6 +18,7 @@
 
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -26,11 +27,13 @@ pd.options.display.max_rows = 120
 # + tags=["parameters"]
 project_id = ""
 deid_cdr=""
-run_as = ""
-# -
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#deid_cdr = "R2021q3r2_deid"
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -39,13 +42,16 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
 # # 1 PRC_1 Verify all ICD9(764 -779)/ICD10(P) concept_codes used to specify other conditions originating In the perinatal period (including birth trauma),are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE 
 (vocabulary_id='ICD9CM' AND 
     (concept_code LIKE '764%' OR concept_code LIKE '765%' OR concept_code LIKE '766%' OR 
@@ -58,26 +64,27 @@ OR (vocabulary_id='ICD10CM' AND
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query1 ICD9(764 -779)/ICD10(P) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query1 ICD9(764 -779)/ICD10(P) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query1 ICD9(764 -779)/ICD10(P) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 2 PRC_2 Verify all ICD9(764 -779)/ICD10(P) concept_codes used to specify other conditions originating In the perinatal period (including birth trauma),are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE 
 (vocabulary_id='ICD9CM' AND 
     (concept_code LIKE '765%' OR concept_code LIKE '766%' OR 
@@ -89,98 +96,102 @@ OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'P%')
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation` p1
+FROM  `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query2 ICD9(764 -779)/ICD10(P)', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query2 ICD9(764 -779)/ICD10(P)', 'result' : ''},  
+ df = df.append({'query' : 'Query2 ICD9(764 -779)/ICD10(P)', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 3 PRC_3 Verify all CD9(V3)/ICD10(Z38) concept_codes  used to specify Liveborn infants according to type of birth are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE 
 (vocabulary_id='ICD9CM' AND (concept_code LIKE 'V3%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'Z38%')
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query3 CD9(V3)/ICD10(Z38) in obs', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query3 CD9(V3)/ICD10(Z38) in obs', 'result' : ''},  
+ df = df.append({'query' : 'Query3 CD9(V3)/ICD10(Z38) in obs', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 4 PRC_4 Verify all CD9(V3)/ICD10(Z38) concept_codes  used to specify Liveborn infants according to type of birth  are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE 
 (vocabulary_id='ICD9CM' AND (concept_code LIKE 'V3%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'Z38%')
  )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query4 CD9(V3)/ICD10(Z38) in condition ', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query4 CD9(V3)/ICD10(Z38) in condition ', 'result' : ''},  
+ df = df.append({'query' : 'Query4 CD9(V3)/ICD10(Z38) in condition ', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 5 PRC_5 Verify all ICD9(798)/ICD10(R99) concept_codes  used to specify Unknown cause of death are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE 
 (vocabulary_id='ICD9CM' AND (concept_code LIKE '798%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'R99%')
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query5 ICD9(798)/ICD10(R99) in obs', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query5 ICD9(798)/ICD10(R99) in obs', 'result' : ''},  
+ df = df.append({'query' : 'Query5 ICD9(798)/ICD10(R99) in obs', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
@@ -190,218 +201,226 @@ df1
 #  
 # after test in the new cdr, should be ICD798 not 799. The original title was wrong. 
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE '798%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'R99%')
  )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query6 ICD9(799)/ICD10(R99) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query6 ICD9(799)/ICD10(R99) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query6 ICD9(799)/ICD10(R99) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 7 PRC_7 Verify all ICD10(Y36) codes used to specify Injury due to war operations are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
 FROM 
-   `{project_id}.{deid_cdr}.concept`
+   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E99%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'Y36%')
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM  `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query7 ICD10(Y36) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query7 ICD10(Y36) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query7 ICD10(Y36) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 8 PRC_8 Verify all ICD10(Y36) codes used to specify Injury due to war operations  are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND ( concept_code LIKE 'E100%' )) 
 OR (vocabulary_id='ICD10CM' AND  concept_code LIKE 'Y36%')
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query8 ICD10(Y36) in obs', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query8 ICD10(Y36) in obs', 'result' : ''},  
+ df = df.append({'query' : 'Query8 ICD10(Y36) in obs', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 9 PRC_9 Verify all ICD10(Y37) codes used to specify Military operations are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM    `{project_id}.{deid_cdr}.concept`
+FROM    `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD10CM' AND  concept_code LIKE 'Y37%')
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query9 ICD10(Y37)  in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query9 ICD10(Y37)  in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query9 ICD10(Y37)  in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 10 PRC_10 Verify all ICD10(Y37) codes used to specify Military operations are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD10CM' AND   concept_code LIKE 'Y37%')
     )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query10 ICD10(Y37) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query10 ICD10(Y37) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query10 ICD10(Y37) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 11 PRC_11 Verify all ICD10(Y35) codes used to specify Legal intervention are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM    `{project_id}.{deid_cdr}.concept`
+FROM    `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND ( concept_code LIKE 'E97%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'Y35%')
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query11 ICD10(Y35) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query11 ICD10(Y35) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query11 ICD10(Y35) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 12 PRC_12 Verify all ICD10(Y38)/ICD9CM(E979)  codes used to specify Terrorism are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM    `{project_id}.{deid_cdr}.concept`
+FROM    `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND ( concept_code LIKE 'E979%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'Y38%')
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query12 ICD10(Y38)/ICD9CM(E979) in obs', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query12 ICD10(Y38)/ICD9CM(E979) in obs', 'result' : ''},  
+ df = df.append({'query' : 'Query12 ICD10(Y38)/ICD9CM(E979) in obs', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 13 PRC_13 Verify all ICD10(Y38)/ICD9CM(E979) codes used to specify Terrorism are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND ( concept_code LIKE 'E979%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'Y38%')
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query13 ICD10(Y38)/ICD9CM(E979) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query13 ICD10(Y38)/ICD9CM(E979) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query13 ICD10(Y38)/ICD9CM(E979) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 14 PRC_14 Verify all ICD9(E96)/ICD10(X92-Y09) codes used to specify Assault/Homicide are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E96%' )) 
 OR (vocabulary_id='ICD10CM' AND (concept_code LIKE 'X92%' OR 
      concept_code LIKE 'X93%' OR concept_code LIKE 'X94%' OR concept_code LIKE 'X95%' OR 
@@ -413,28 +432,29 @@ OR (vocabulary_id='ICD10CM' AND (concept_code LIKE 'X92%' OR
     )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query14 ICD9(E96)/ICD10(X92-Y09) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query14 ICD9(E96)/ICD10(X92-Y09) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query14 ICD9(E96)/ICD10(X92-Y09) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 15 PRC_15 Verify all ICD9(E96)/ICD10(X92-Y09) codes used to specify Assault/Homicide are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM    `{project_id}.{deid_cdr}.concept`
+FROM    `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E96%' )) 
 OR (vocabulary_id='ICD10CM' AND (concept_code LIKE 'X92%' OR 
      concept_code LIKE 'X93%' OR concept_code LIKE 'X94%' OR concept_code LIKE 'X95%' OR 
@@ -446,130 +466,135 @@ OR (vocabulary_id='ICD10CM' AND (concept_code LIKE 'X92%' OR
     )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query15 ICD9(E96)/ICD10(X92-Y09) in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query15 ICD9(E96)/ICD10(X92-Y09) in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query15 ICD9(E96)/ICD10(X92-Y09) in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 16 PRC_16 Verify all ICD9(E95) codes used to specify Suicide are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM  `{project_id}.{deid_cdr}.concept`
+FROM  `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND  (concept_code LIKE 'E95%' )) )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation` p1
+FROM  `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query16 ICD9(E95) in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query16 ICD9(E95) in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query16 ICD9(E95) in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 17 PRC_17 Verify all ICD9(E95) codes used to specify Suicide are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE vocabulary_id='ICD9CM' AND concept_code LIKE 'E95%' )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM  `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query17 ICD9(E95) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query17 ICD9(E95) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query17 ICD9(E95) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 18 PRC_18 Verify all ICD9(E928.0)/ICD10(X52) codes used to specify Prolonged stay in weightlessness are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E928.0' )) 
      OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'X52%')
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM    `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM    `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query18 ICD9(E928.0)/ICD10(X52)  in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query18 in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query18 in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 19 PRC_19 Verify all ICD9(E928.0)/ICD10(X52) codes used to specify Prolonged stay in weightlessness are not generated/displayed as observation_source_value in the OBSERVATION  table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E928.0' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'X52%')
  )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation` p1
+FROM  `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query19 ICD9(E928.0)/ICD10(X52)  in obs', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query19 ICD9(E928.0)/ICD10(X52)  in obs', 'result' : ''},  
+ df = df.append({'query' : 'Query19 ICD9(E928.0)/ICD10(X52)  in obs', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 20 PRC_20 Verify all ICD9(E910)/ICD10(W65-W74) codes used to specify Drowning are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM  `{project_id}.{deid_cdr}.concept`
+FROM  `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND ( concept_code LIKE 'E910%' )) 
 OR (vocabulary_id='ICD10CM' AND (concept_code LIKE 'W65%' OR concept_code LIKE 'W66%' OR 
      concept_code LIKE 'W67%' OR concept_code LIKE 'W68%' OR concept_code LIKE 'W69%' OR concept_code LIKE 'W70%' OR 
@@ -577,134 +602,139 @@ OR (vocabulary_id='ICD10CM' AND (concept_code LIKE 'W65%' OR concept_code LIKE '
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation` p1
+FROM  `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query20 ICD9(E910)/ICD10(W65-W74) in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query20 ICD9(E910)/ICD10(W65-W74) in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query20 ICD9(E910)/ICD10(W65-W74) in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 21 PRC_21 Verify all ICD9(E910)/ICD10(W65-W74) codes used to specify Drowning are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM  `{project_id}.{deid_cdr}.concept`
+FROM  `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E910%' )) 
 OR    (vocabulary_id='ICD10CM' AND (concept_code LIKE 'W65%' OR concept_code LIKE 'W66%' OR 
      concept_code LIKE 'W67%' OR concept_code LIKE 'W68%' OR concept_code LIKE 'W69%' OR concept_code LIKE 'W70%' OR 
      concept_code LIKE 'W71%' OR concept_code LIKE 'W72%' OR concept_code LIKE 'W73%' OR concept_code LIKE 'W74%'))
     )
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM  `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query21 ICD9(E910)/ICD10(W65-W74) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query21 ICD9(E910)/ICD10(W65-W74) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query21 ICD9(E910)/ICD10(W65-W74) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 22 PRC_22 Verify all ICD9(E983)/ICD10(T71) codes used to specify Suffocation are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E913%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'T71%' )
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
 
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query22 ICD9(E983)/ICD10(T71) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query22 ICD9(E983)/ICD10(T71) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query22 ICD9(E983)/ICD10(T71) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 23 PRC_23 Verify all ICD9(E913)/ICD10(T71) codes used to specify Suffocation  are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND (concept_code LIKE 'E913%' )) 
 OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'T71%' )
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.observation` p1
+FROM   `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query23 ICD9(E913)/ICD10(T71) in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query23 ICD9(E913)/ICD10(T71) in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query23 ICD9(E913)/ICD10(T71) in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 24 PRC_24 Verify all ICD9(E80-E84)/ICD10(V) codes used to specify Vehicle accident are not generated/displayed as condition_source_value in the CONDITION_OCCURENCE table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM  `{project_id}.{deid_cdr}.concept`
+FROM  `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND 
     (concept_code LIKE 'E80%' OR concept_code LIKE 'E81%' OR concept_code LIKE 'E82%' OR 
      concept_code LIKE 'E83%' OR concept_code LIKE 'E84%'  )) 
 OR    (vocabulary_id='ICD10CM' AND concept_code LIKE 'V%' )
 )
 SELECT COUNT (*) AS n_row_not_pass
-FROM   `{project_id}.{deid_cdr}.condition_occurrence` p1
+FROM   `{{project_id}}.{{deid_cdr}}.condition_occurrence` p1
 JOIN ICD_suppressions p2
 ON p1.condition_source_concept_id=p2.concept_id
 WHERE condition_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query24 ICD9(E80-E84)/ICD10(V) in condition', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query24 ICD9(E80-E84)/ICD10(V) in condition', 'result' : ''},  
+ df = df.append({'query' : 'Query24 ICD9(E80-E84)/ICD10(V) in condition', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
 # # 25 PRC_25 Verify all ICD9(E80-E84)/ICD10(V) codes used to specify Vehicle accident are not generated/displayed as observation_source_value in the OBSERVATION table
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH ICD_suppressions AS (
 SELECT concept_id 
-FROM   `{project_id}.{deid_cdr}.concept`
+FROM   `{{project_id}}.{{deid_cdr}}.concept`
 WHERE (vocabulary_id='ICD9CM' AND 
     (concept_code LIKE 'E80%' OR concept_code LIKE 'E81%' OR concept_code LIKE 'E82%' OR 
      concept_code LIKE 'E83%' OR concept_code LIKE 'E84%'  )) 
@@ -712,22 +742,27 @@ OR (vocabulary_id='ICD10CM' AND concept_code LIKE 'V%' )
 )
     
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation` p1
+FROM  `{{project_id}}.{{deid_cdr}}.observation` p1
 JOIN ICD_suppressions p2
 ON p1.observation_source_concept_id=p2.concept_id
 WHERE observation_source_value IS NOT NULL
-'''
-df1=execute(client, query)  
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)  
+df1=execute(client, q)  
 if df1.loc[0].sum()==0:
  df = df.append({'query' : 'Query25 ICD9(E80-E84)/ICD10(V) in observation', 'result' : 'PASS'},  
                 ignore_index = True) 
 else:
- df = df.append({'query' : 'Query25 ICD9(E80-E84)/ICD10(V) in observation', 'result' : ''},  
+ df = df.append({'query' : 'Query25 ICD9(E80-E84)/ICD10(V) in observation', 'result' : 'Failure'},  
                 ignore_index = True) 
 df1
 
+
 # # Summary_Row_Suppression-ICD9/10
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null','']))
-df.style.highlight_null(null_color='red').set_properties(**{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report5_row_suppression_icd.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report5_row_suppression_icd.py
@@ -30,12 +30,6 @@ deid_cdr=""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#deid_cdr = "R2021q3r2_deid"
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report6_fitdata.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report6_fitdata.py
@@ -38,21 +38,6 @@ fitbit_dataset = ""
 run_as=""
 
 # +
-# Parameters
-#project_id = "aou-res-curation-prod"
-#pipeline = "pipeline_tables"
-#non_deid_fitbit = "2022q4r3_fitbit"
-#deid_cdr_fitbit = "R2022q2r6_fitbit_deid"
-#com_cdr = "2022q4r3_combined_release"
-#deid_cdr = "R2022q4r4_deid"
-#truncation_date = "2019-11-26"
-#maximum_age = "89"
-#fitbit_sandbox_dataset = "2022q4r3_fitbit_sandbox"
-#sleep_level_sandbox_table = "fitbit_dc1910_sleep_level"
-#fitbit_dataset = "2022q4r3_fitbit"
-#run_as="data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report6_fitdata.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report6_fitdata.py
@@ -17,8 +17,7 @@
 
 import urllib
 import pandas as pd
-
-from common import PIPELINE_TABLES
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -26,21 +25,32 @@ pd.options.display.max_rows = 120
 
 # + tags=["parameters"]
 project_id = ""
-pipeline = ""
-non_deid_fitbit = ""
-deid_cdr_fitbit = ""
-deid_cdr = ""
-com_cdr = ""
-truncation_date = ""
-maximum_age = ""
-run_as = ""
+pipeline=""
+non_deid_fitbit=""
+deid_cdr_fitbit=""
+deid_cdr=""
+com_cdr=""
+truncation_date=""
+maximum_age=""
 fitbit_sandbox_dataset = ""
 sleep_level_sandbox_table = ""
 fitbit_dataset = ""
-# -
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# +
+# Parameters
+#project_id = "aou-res-curation-prod"
+#pipeline = "pipeline_tables"
+#non_deid_fitbit = "2022q4r3_fitbit"
+#deid_cdr_fitbit = "R2022q2r6_fitbit_deid"
+#com_cdr = "2022q4r3_combined_release"
+#deid_cdr = "R2022q4r4_deid"
+#truncation_date = "2019-11-26"
+#maximum_age = "89"
+#fitbit_sandbox_dataset = "2022q4r3_fitbit_sandbox"
+#sleep_level_sandbox_table = "fitbit_dc1910_sleep_level"
+#fitbit_dataset = "2022q4r3_fitbit"
+#run_as="data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -49,7 +59,10 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
-# This notebook was updated per [DC-1786].
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
+# This notebook was updated per [DC-1786]. 
 #
 #
 
@@ -59,132 +72,118 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 #
 # by adding m.shift back to deid_table and see if any date is newer than cutoff date.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 WITH df1 AS (
 SELECT '1' as col ,COUNT (*) AS n_row_not_pass_activity_summary
-FROM `{project_id}.{deid_cdr_fitbit}.activity_summary`  a
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.activity_summary`  a
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = a.person_id
-WHERE DATE_ADD(date(a.date), INTERVAL m.shift DAY) > '{truncation_date}'),
+WHERE DATE_ADD(date(a.date), INTERVAL m.shift DAY) > '{{truncation_date}}'),
 
 df2 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_heart_rate_summary
-FROM `{project_id}.{deid_cdr_fitbit}.heart_rate_summary`  a
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_summary`  a
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = a.person_id
-WHERE DATE_ADD(date(a.date), INTERVAL m.shift DAY) > '{truncation_date}' ),
+WHERE DATE_ADD(date(a.date), INTERVAL m.shift DAY) > '{{truncation_date}}' ),
 
 df3 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_heart_rate_minute_level
-FROM `{project_id}.{deid_cdr_fitbit}.heart_rate_minute_level`  a
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_minute_level`  a
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = a.person_id
-WHERE DATE_ADD(date(a.datetime), INTERVAL m.shift DAY) > '{truncation_date}'),
+WHERE DATE_ADD(date(a.datetime), INTERVAL m.shift DAY) > '{{truncation_date}}'),
 
 df4 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_steps_intraday
-FROM `{project_id}.{deid_cdr_fitbit}.steps_intraday`  a
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.steps_intraday`  a
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = a.person_id
-WHERE DATE_ADD(date(a.datetime), INTERVAL m.shift DAY) > '{truncation_date}' )
+WHERE DATE_ADD(date(a.datetime), INTERVAL m.shift DAY) > '{{truncation_date}}' )
 
 SELECT * from df1
 JOIN df2 USING (col)
 JOIN df3 USING (col)
 JOIN df4 USING (col)
 
-'''
-df1 = execute(client, query)
-df1 = df1.iloc[:, 1:5]
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query1 cutoff date in fitbit datasets',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
+df1=df1.iloc[:,1:5]
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query1 cutoff date in fitbit datasets', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query1 cutoff date in fitbit datasets',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1 cutoff date in fitbit datasets', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 
 # # Verify if that the fitdata data is removed FROM the fitbit tables for participants exceeding allowable age (maximum_age, i.e.,89). ((row counts = 0))
 #
 # DC-1001
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_activity_summary
-FROM `{project_id}.{deid_cdr_fitbit}.activity_summary` d
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.activity_summary` d
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = d.person_id
-JOIN `{project_id}.{com_cdr}.person` i
+JOIN `{{project_id}}.{{com_cdr}}.person` i
 ON m.person_id = i.person_id
-WHERE {PIPELINE_TABLES}.calculate_age(CURRENT_DATE, EXTRACT(DATE FROM i.birth_datetime)) >{maximum_age}),
+WHERE  FLOOR(DATE_DIFF(CURRENT_DATE(),DATE(i.birth_datetime), YEAR)) >{{maximum_age}}),
 
 df2 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_heart_rate_summary
-FROM `{project_id}.{deid_cdr_fitbit}.heart_rate_summary` d
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_summary` d
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = d.person_id
-JOIN `{project_id}.{com_cdr}.person` i
+JOIN `{{project_id}}.{{com_cdr}}.person` i
 ON m.person_id = i.person_id
-WHERE {PIPELINE_TABLES}.calculate_age(CURRENT_DATE, EXTRACT(DATE FROM i.birth_datetime)) >{maximum_age}),
+WHERE  FLOOR(DATE_DIFF(CURRENT_DATE(),DATE(i.birth_datetime), YEAR)) >{{maximum_age}}),
 
 df3 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_heart_rate_minute_level
-FROM `{project_id}.{deid_cdr_fitbit}.heart_rate_minute_level` d
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_minute_level` d
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = d.person_id
-JOIN `{project_id}.{com_cdr}.person` i
+JOIN `{{project_id}}.{{com_cdr}}.person` i
 ON m.person_id = i.person_id
-WHERE {PIPELINE_TABLES}.calculate_age(CURRENT_DATE, EXTRACT(DATE FROM i.birth_datetime)) >{maximum_age}),
+WHERE  FLOOR(DATE_DIFF(CURRENT_DATE(),DATE(i.birth_datetime), YEAR)) >{{maximum_age}}),
 
 df4 AS (
 SELECT '1' as col ,COUNT (*) n_row_not_pass_steps_intraday
-FROM `{project_id}.{deid_cdr_fitbit}.steps_intraday` d
-JOIN `{project_id}.{pipeline}.pid_rid_mapping` m
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.steps_intraday` d
+JOIN `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
 ON m.research_id = d.person_id
-JOIN `{project_id}.{com_cdr}.person` i
+JOIN `{{project_id}}.{{com_cdr}}.person` i
 ON m.person_id = i.person_id
-WHERE {PIPELINE_TABLES}.calculate_age(CURRENT_DATE, EXTRACT(DATE FROM i.birth_datetime)) >{maximum_age})
+WHERE  FLOOR(DATE_DIFF(CURRENT_DATE(),DATE(i.birth_datetime), YEAR)) >{{maximum_age}})
 
 SELECT * from df1
 JOIN df2 USING (col)
 JOIN df3 USING (col)
 JOIN df4 USING (col)
 
-'''
-df1 = execute(client, query)
-df1 = df1.iloc[:, 1:5]
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query2 no maximum_age in fitbit datasets',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
+df1=df1.iloc[:,1:5]
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query2 no maximum_age in fitbit datasets', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query2 no maximum_age in fitbit datasets',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query2 no maximum_age in fitbit datasets', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1               
 
 # # Verify that correct date shift is applied to the fitbit data
 #
 # DC-1005
 #
-# objective:
+# objective: 
 #
-# find the difference between the non-deid date and the deid date to validate that the dateshift is applied as specified in the map .
+# find the difference between the non-deid date and the deid date to validate that the dateshift is applied as specified in the map . 
 #
 # the original code uses min(date) to have the difference, but not sure why min(), not max(), or any date.
 #
@@ -192,314 +191,258 @@ df1
 # [DC-1786] date shifting should be checked against activity_summary, heart_rate_summary, heart_rate_minute_level, and steps_intraday.
 
 # activity_summary
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id,
 CONCAT(m.research_id, '_', i.date) as i_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.activity_summary` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.activity_summary` i
 ON m.person_id = i.person_id
 ),
 
 df2 AS (
 SELECT d.person_id,
 CONCAT(d.person_id, '_', DATE_ADD(d.date, INTERVAL m.shift DAY))  d_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.activity_summary` d
-ON m.research_id = d.person_id
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.activity_summary` d
+ON m.research_id = d.person_id 
 )
 
 SELECT COUNT (*) n_row_not_pass FROM df2
 WHERE d_newc NOT IN (SELECT i_newc FROM df1)
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query3.1 Date shifted in activity_summary',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3.1 Date shifted in activity_summary', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3.1 Date shifted in activity_summary',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query3.1 Date shifted in activity_summary', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1        
 
 # heart_rate_summary
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id,
 CONCAT(m.research_id, '_', i.date) as i_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.heart_rate_summary` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.heart_rate_summary` i
 ON m.person_id = i.person_id
 ),
 
 df2 AS (
 SELECT d.person_id,
 CONCAT(d.person_id, '_', DATE_ADD(d.date, INTERVAL m.shift DAY)) AS d_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.heart_rate_summary` d
-ON m.research_id = d.person_id
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_summary` d
+ON m.research_id = d.person_id 
 )
 
 SELECT COUNT (*) n_row_not_pass FROM df2
 WHERE d_newc NOT IN (SELECT i_newc FROM df1)
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query3.2 Date shifted in heart_rate_summary',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3.2 Date shifted in heart_rate_summary', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3.2 Date shifted in heart_rate_summary',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query3.2 Date shifted in heart_rate_summary', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1        
 
 # +
 # heart_rate_minute_level
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id,
 CONCAT(m.research_id, '_', i.datetime) as i_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.heart_rate_minute_level` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.heart_rate_minute_level` i
 ON m.person_id = i.person_id
 ),
 
 df2 AS (
 SELECT d.person_id,
 CONCAT(d.person_id, '_', DATE_ADD(d.datetime, INTERVAL m.shift DAY)) AS d_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.heart_rate_minute_level` d
-ON m.research_id = d.person_id
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_minute_level` d
+ON m.research_id = d.person_id 
 )
 
 SELECT COUNT (*) n_row_not_pass FROM df2
 WHERE d_newc NOT IN (SELECT i_newc FROM df1)
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query3.3 Date shifted in heart_rate_minute_level',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3.3 Date shifted in heart_rate_minute_level', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3.3 Date shifted in heart_rate_minute_level',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query3.3 Date shifted in heart_rate_minute_level', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1       
 
 # +
 # steps_intraday
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT m.research_id,
 CONCAT(m.research_id, '_', i.datetime) as i_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.steps_intraday` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.steps_intraday` i
 ON m.person_id = i.person_id
 ),
 
 df2 AS (
 SELECT d.person_id,
 CONCAT(d.person_id, '_', DATE_ADD(d.datetime, INTERVAL m.shift DAY)) AS d_newc
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.steps_intraday` d
-ON m.research_id = d.person_id
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.steps_intraday` d
+ON m.research_id = d.person_id 
 )
 
 SELECT COUNT (*) n_row_not_pass FROM df2
 WHERE d_newc NOT IN (SELECT i_newc FROM df1)
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query3.4 Date shifted in steps_intraday',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3.4 Date shifted in steps_intraday', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3.4 Date shifted in steps_intraday',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query3.4 Date shifted in steps_intraday', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1   
 # -
 
-# # Verify that the participants are correctly mapped to their Research ID
+# # Verify that the participants are correctly mapped to their Research ID 
 #
 # DC-1000
 
 # activity_summary
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT DISTINCT i.person_id  AS non_deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.activity_summary` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.activity_summary` i
 ON m.person_id = i.person_id ),
 
 df2 AS (
 SELECT DISTINCT d.person_id  AS deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.activity_summary` d
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.activity_summary` d
 ON d.person_id = m.research_id)
 
 SELECT COUNT (*) n_row_not_pass_activity_summary FROM df1
 JOIN df2 USING (research_id)
 WHERE research_id != deid_pid
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query4.1 resarch_id=person_id in activity_summary',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4.1 resarch_id=person_id in activity_summary', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4.1 resarch_id=person_id in activity_summary',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query4.1 resarch_id=person_id in activity_summary', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1        
 
 # heart_rate_summary
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT DISTINCT i.person_id  AS non_deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.heart_rate_summary` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.heart_rate_summary` i
 ON m.person_id = i.person_id ),
 
 df2 AS (
 SELECT DISTINCT d.person_id  AS deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.heart_rate_summary` d
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_summary` d
 ON d.person_id = m.research_id)
 
 SELECT COUNT (*) n_row_not_pass_heart_rate_summary FROM df1
 JOIN df2 USING (research_id)
 WHERE research_id != deid_pid
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query4.2 resarch_id=person_id in heart_rate_summary',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4.2 resarch_id=person_id in heart_rate_summary', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4.2 resarch_id=person_id in heart_rate_summary',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query4.2 resarch_id=person_id in heart_rate_summary', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1     
 
 # heart_rate_minute_level
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT DISTINCT i.person_id  AS non_deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.heart_rate_minute_level` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.heart_rate_minute_level` i
 ON m.person_id = i.person_id ),
 
 df2 AS (
 SELECT DISTINCT d.person_id  AS deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.heart_rate_minute_level` d
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_minute_level` d
 ON d.person_id = m.research_id)
 
 SELECT COUNT (*) n_row_not_pass_heart_rate_minute_level FROM df1
 JOIN df2 USING (research_id)
 WHERE research_id != deid_pid
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_bcdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query4.3 resarch_id=person_id in heart_rate_minute_level',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4.3 resarch_id=person_id in heart_rate_minute_level', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4.3 resarch_id=person_id in heart_rate_minute_level',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query4.3 resarch_id=person_id in heart_rate_minute_level', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1     
 
 # steps_intraday
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT DISTINCT i.person_id  AS non_deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{non_deid_fitbit}.steps_intraday` i
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{non_deid_fitbit}}.steps_intraday` i
 ON m.person_id = i.person_id ),
 
 df2 AS (
 SELECT DISTINCT d.person_id  AS deid_pid,m.research_id
-FROM `{project_id}.{pipeline}.pid_rid_mapping` m
-JOIN `{project_id}.{deid_cdr_fitbit}.steps_intraday` d
+FROM `{{project_id}}.{{pipeline}}.pid_rid_mapping` m
+JOIN `{{project_id}}.{{deid_cdr_fitbit}}.steps_intraday` d
 ON d.person_id = m.research_id)
 
 SELECT COUNT (*) n_row_not_pass_steps_intraday FROM df1
 JOIN df2 USING (research_id)
 WHERE research_id != deid_pid
 
-'''
-df1 = execute(client, query)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
 if df1.eq(0).any().any():
-    df = df.append(
-        {
-            'query': 'Query4.4 resarch_id=person_id in steps_intraday',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4.4 resarch_id=person_id in steps_intraday', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4.4 resarch_id=person_id in steps_intraday',
-            'result': ''
-        },
-        ignore_index=True)
-df1
+ df = df.append({'query' : 'Query4.4 resarch_id=person_id in steps_intraday', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1     
 
 # # Verify all person_ids in fitbit datasets exsit in deid_cdr person table
 #
@@ -507,50 +450,43 @@ df1
 #
 # This check should fail if a person_id in the activity_summary, heart_rate_summary, heart_rate_minute_level, or steps_intra_day tables does not exist in a corresponding RT de-identified dataset.
 
-query = f'''
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
 SELECT '1' AS col , COUNT (DISTINCT person_id)  AS n_person_id_not_pass_activity_summary
-FROM `{project_id}.{deid_cdr_fitbit}.activity_summary`
-WHERE person_id NOT IN (SELECT person_id FROM `{project_id}.{deid_cdr}.person`)),
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.activity_summary` 
+WHERE person_id NOT IN (SELECT person_id FROM `{{project_id}}.{{deid_cdr}}.person`)),
 
 df2 AS (
 SELECT '1' AS col, COUNT (DISTINCT person_id)  AS n_person_id_not_pass_heart_rate_summary
-FROM `{project_id}.{deid_cdr_fitbit}.heart_rate_summary`
-WHERE person_id NOT IN (SELECT person_id FROM `{project_id}.{deid_cdr}.person`)),
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_summary` 
+WHERE person_id NOT IN (SELECT person_id FROM `{{project_id}}.{{deid_cdr}}.person`)),
 
 df3 AS (
 SELECT '1' AS col,COUNT (DISTINCT person_id)  AS n_person_id_not_pass_heart_rate_minute_level
-FROM `{project_id}.{deid_cdr_fitbit}.heart_rate_minute_level`
-WHERE person_id NOT IN (SELECT person_id FROM `{project_id}.{deid_cdr}.person`)),
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.heart_rate_minute_level` 
+WHERE person_id NOT IN (SELECT person_id FROM `{{project_id}}.{{deid_cdr}}.person`)),
 
 df4 AS (
 SELECT '1' AS col,COUNT (DISTINCT person_id) AS n_person_id_not_pass_steps_intraday
-FROM `{project_id}.{deid_cdr_fitbit}.steps_intraday` a
-WHERE person_id NOT IN (SELECT person_id FROM `{project_id}.{deid_cdr}.person`))
+FROM `{{project_id}}.{{deid_cdr_fitbit}}.steps_intraday` a
+WHERE person_id NOT IN (SELECT person_id FROM `{{project_id}}.{{deid_cdr}}.person`))
 
 SELECT * FROM df1
 JOIN df2 USING (col)
 JOIN df3 USING (col)
 JOIN df4 USING (col)
-'''
-df1 = execute(client, query)
-df1 = df1.iloc[:, 1:5]
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query5 person_ids in fitbit exist in deid.person table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+""")
+q =query.render(project_id=project_id,pipeline=pipeline,com_cdr=com_cdr,deid_cdr=deid_cdr,non_deid_fitbit=non_deid_fitbit,deid_cdr_fitbit=deid_cdr_fitbit,truncation_date=truncation_date,maximum_age=maximum_age)  
+df1=execute(client, q)  
+df1=df1.iloc[:,1:5]
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query5 person_ids in fitbit exist in deid.person table', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query5 person_ids in fitbit exist in deid.person table',
-            'result': ''
-        },
-        ignore_index=True)
-df1.T
+ df = df.append({'query' : 'Query5 person_ids in fitbit exist in deid.person table', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1.T             
 
 # # Verify that all records with invalid level values are being dropped from sleep_level table
 #
@@ -560,13 +496,14 @@ df1.T
 # are being dropped due to invalid level values. It also outputs any records in the sleep_level table that should
 # have been dropped but were not.
 
-query = f'''
+# +
+query = JINJA_ENV.from_string("""
 
 WITH df1 AS (
   SELECT 
     level, 'dropped' AS dropped_status, count(*) as n_violations
   FROM 
-    `{project_id}.{fitbit_sandbox_dataset}.{sleep_level_sandbox_table}`
+    `{{project_id}}.{{fitbit_sandbox_dataset}}.{{sleep_level_sandbox_table}}`
   GROUP BY 1, 2
   ORDER BY n_violations
 ),
@@ -575,7 +512,7 @@ df2 AS (
   SELECT 
     level, 'not dropped' AS dropped_status, count(*) as n_violations
   FROM 
-    `{project_id}.{fitbit_dataset}.sleep_level`
+    `{{project_id}}.{{fitbit_dataset}}.sleep_level`
   WHERE 
   (
       LOWER(level) NOT IN 
@@ -589,8 +526,12 @@ from df1
 UNION ALL
 select *
 from df2
-'''
-df2 = execute(client, query)
+""")
+
+q =query.render(project_id=project_id,fitbit_sandbox_dataset=fitbit_sandbox_dataset,fitbit_dataset=fitbit_dataset,sleep_level_sandbox_table=sleep_level_sandbox_table)  
+
+df2 = execute(client, q)
+
 if 'not dropped' not in set(df2['dropped_status']):
     df = df.append(
         {
@@ -602,14 +543,22 @@ else:
     df = df.append(
         {
             'query': 'Query6 no invalid level records in sleep_level table',
-            'result': ''
+            'result': 'Failure'
         },
         ignore_index=True)
 df2
 
+
+# -
+
 # # Summary_fitdata
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null', '']))
-df.style.highlight_null(null_color='red').set_properties(
-    **{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+# -
+
+

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -13,470 +13,414 @@
 #     name: python3
 # ---
 
-# + [markdown] papermill={"duration": 0.024011, "end_time": "2021-02-02T22:30:31.951734", "exception": false,
-# "start_time": "2021-02-02T22:30:31.927723", "status": "completed"} tags=[]
+# + [markdown] papermill={"duration": 0.024011, "end_time": "2021-02-02T22:30:31.951734", "exception": false, "start_time": "2021-02-02T22:30:31.927723", "status": "completed"} tags=[]
 # #  QA queries on new CDR_deid COPE Survey
 #
 # Quality checks performed on a new CDR_deid dataset using QA queries
 
-# + papermill={"duration": 0.709639, "end_time": "2021-02-02T22:30:32.661373", "exception": false,
-# "start_time": "2021-02-02T22:30:31.951734", "status": "completed"} tags=[]
-
+# + papermill={"duration": 0.709639, "end_time": "2021-02-02T22:30:32.661373", "exception": false, "start_time": "2021-02-02T22:30:31.951734", "status": "completed"} tags=[]
+import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
 pd.options.display.max_rows = 120
 
-# + tags=["parameters"]
+# + papermill={"duration": 0.023643, "end_time": "2021-02-02T22:30:31.880820", "exception": false, "start_time": "2021-02-02T22:30:31.857177", "status": "completed"} tags=["parameters"]
+# Parameters
 project_id = ""
 com_cdr = ""
 deid_cdr = ""
-deid_sandbox = ""
-run_as = ""
-# deid_base_cdr=""
-# -
+#deid_sandbox=""
+sandbox=""
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# +
+# Parameters
+
+#project_id = "aou-res-curation-prod"
+#deid_cdr = "R2022q2r4_deid"
+#com_cdr = "2022q2r4_combined"
+#com_cdr = "2022q2r4_combined"
+#deid_sandbox = "R2021q3r1_deid_sandbox"
+#sandbox='curation_sandbox'
+#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 
 client = BigQueryClient(project_id, credentials=impersonation_creds)
+# -
 
-# + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false,
-# "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
-# # 1 Verify that the COPE Survey Data identified to be suppressed as
-# the de-identification action in OBSERVATION table have been removed from the de-id dataset.
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
+# + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false, "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
+# # 1 done Verify that the COPE Survey Data identified to be suppressed as de-identification action in OBSERVATION table have been removed from the de-id dataset.
 #
-# see spread sheet COPE - All Surveys Privacy Rules for details
+# these concept_ids should be suppressed as shown in the spread sheet 'COPE - All Surveys Privacy Rules', and was temporally saved to curation_sandbox.temp_cope_privacy_rules. Moving forward, we only need to update this table accordingly. 
 #
 # https://docs.google.com/spreadsheets/d/1UuUVcRdlp2HkBaVdROFsM4ZX_bfffg6ZoEbqj94MlXU/edit#gid=0
 #
-#  Related tickets [DC-892] [DC-1752]
-#
-# [DC-1752] Refactor analysis 1 so that it provides the observation_source_concept_id, concept_code, concept_name, vocabulary_id,
-# row count per cope survey concept (example query below).
-# Reword the title text to read:
-# Verify that the COPE Survey concepts identified to be suppressed as de-identification action have been removed.
-#
-#  [DC-1784] 1310144, 1310145, 1310148, 715725, 715724
-#
-# The following concepts should be suppressed
-#
-# 715711, 1333327, 1333326, 1333014, 1333118, 1332742,1333324 ,1333012 ,1333234,
-#
-# 903632,702686,715714, 715724, 715725, 715726, 1310054, 1310058, 1310066, 1310146, 1310147, 1333234, 1310065,
-#
-# 596884, 596885, 596886, 596887, 596888, 596889, 1310137,1333016,1310148,1310145,1310144
-#
-# From DC-2109
-# 765938,765939, 765940, 765941, 765942, 765943, 765944, 765945, 765946, 765947, 765948, 765949, 765950, 765951, 765952
-#
-# DC-2113
-# RT suppression
-# +
+# DC-2373, DC-2374 done
+# -
 
-rt_concepts_dict = {
-    'dc_1752': [
-        715711, 1333327, 1333326, 1333014, 1333118, 1332742, 1333324, 1333012,
-        1333234
-    ],
-    'dc_1784': [1310144, 1310145, 1310148, 715725, 715724],
-    'dc_1666': [
-        1310058, 1333325, 1333235, 1310065, 1333012, 1333234, 1332769, 702686,
-        1333156, 713888, 1333327, 1333118, 1310054, 1333326, 1310066, 596884,
-        596885, 596886, 596887, 596888, 596889, 1310137, 1310146, 1333015,
-        1333023, 1333016, 715714, 1310147, 715726
-    ],
-    'dc_1641': [903632],
-    'dc_2113': [  # 596886, 596887, 
-        765946, 765947, 765948, 765949, 765950, 765951, 765952, 765938, 765939,
-        765940, 765941, 765942, 765943, 765944, 765945
-    ],
-    'dc_2112': [
-        766006, 765982, 766032, 40192502, 766040, 765996, 765984, 766020,
-        766008, 766036, 766044, 766024, 905060, 766062, 766028, 766002, 766014,
-        766052, 766034, 765988, 766038, 766058, 905050, 766060, 766046, 766054,
-        766042, 765978, 766050, 766056, 765980, 905049, 766022, 765990, 766018,
-        766010, 766048, 766064, 765998, 765986, 765976, 765994, 766030, 905041,
-        766026, 766016, 905059, 766066, 766000, 766012, 765992, 765974
-    ]
-}
+# these concept_ids should be suppressed
+query = JINJA_ENV.from_string("""
+select OMOP_conceptID,New_Requirement
+from  `{{project_id}}.{{sandbox}}.temp_cope_privacy_rules` 
+where New_Requirement like 'suppress%' or New_Requirement like 'row suppression'
+""")
+q = query.render(project_id=project_id,sandbox=sandbox)
+df1=execute(client, q)
+df1.shape
 
-rt_concepts_list = []
-for concepts in rt_concepts_dict.values():
-    rt_concepts_list.extend(concepts)
-
-# Remove duplicates
-rt_concepts_list = list(set(rt_concepts_list))
-
-query = f'''
-
-SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,observation_concept_id,COUNT(1) AS n_row_not_pass FROM 
-`{project_id}.{deid_cdr}.observation` ob
-JOIN `{project_id}.{deid_cdr}.concept` c
-ON ob.observation_source_concept_id=c.concept_id
-WHERE observation_source_concept_id IN
-({','.join(map(str, rt_concepts_list))})
-OR observation_concept_id IN
-({','.join(map(str, rt_concepts_list))})
-GROUP BY 1,2,3,4,5
-ORDER BY n_row_not_pass DESC
-
-'''
-df1 = execute(client, query)
-
-if df1['n_row_not_pass'].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query1 No COPE in deid_observation table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query': 'Query1 No COPE in deid_observation table',
-            'result': ''
-        },
-        ignore_index=True)
 df1
 
-# + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false,
-# "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
-# # 2   Verify if a survey version is provided for the COPE survey.
+
+query = JINJA_ENV.from_string("""
+SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,
+observation_concept_id,
+COUNT(1) AS n_row_not_pass 
+FROM `{{project_id}}.{{deid_cdr}}.observation` ob
+JOIN `{{project_id}}.{{deid_cdr}}.concept` c
+ON ob.observation_source_concept_id=c.concept_id
+WHERE observation_source_concept_id IN
+(select OMOP_conceptID from `{{project_id}}.{{sandbox}}.temp_cope_privacy_rules`  
+where New_Requirement like 'suppress%' or New_Requirement like 'row suppression')
+OR observation_concept_id IN
+(select OMOP_conceptID from `{{project_id}}.{{sandbox}}.temp_cope_privacy_rules`  
+where New_Requirement like 'suppress%' or New_Requirement like 'row suppression')
+GROUP BY 1,2,3,4,5
+ORDER BY n_row_not_pass DESC
+""")
+q = query.render(project_id=project_id,sandbox=sandbox,deid_cdr=deid_cdr)
+df1=execute(client, q)
+df1.shape
+
+df1
+
+if df1['n_row_not_pass'].sum()==0:
+ df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},  
+                ignore_index = True) 
+
+# + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false, "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
+# # 2 done   Verify if a survey version is provided for the COPE survey.
 #
 # [DC-1040]
 #
-# expected results: all the person_id and the questionnaire_response_id has a survey_version_concept_id
+# expected results: all the person_id and the questionnaire_response_id has a survey_version_concept_id 
 # original sql missed something.
 #
 # these should be generalized 2100000002,2100000003,2100000004
+#
+# new update/question as 05062022, there are more survey version which are not included in the original table? shoud I bring this up in the meeting??
 # -
 
-query = f'''
-WITH df1 as (
-SELECT distinct survey_version_concept_id
-FROM `{project_id}.{deid_cdr}.concept` c1
-LEFT JOIN `{project_id}.{deid_cdr}.concept_relationship` cr ON cr.concept_id_2 = c1.concept_id
-JOIN `{project_id}.{deid_cdr}.observation` ob on ob.observation_concept_id=c1.concept_id
-LEFT JOIN `{project_id}.{deid_cdr}.observation_ext` ext USING(observation_id)
+query = JINJA_ENV.from_string("""
+SELECT survey_version_concept_id, 
+count (*) row_counts,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 0 ELSE 1
+END
+ AS Failure_row_counts
+
+FROM `{{project_id}}.{{deid_cdr}}.concept` c1
+LEFT JOIN `{{project_id}}.{{deid_cdr}}.concept_relationship` cr ON cr.concept_id_2 = c1.concept_id
+JOIN `{{project_id}}.{{deid_cdr}}.observation` ob on ob.observation_concept_id=c1.concept_id
+LEFT JOIN `{{project_id}}.{{deid_cdr}}.observation_ext` ext USING(observation_id)
 WHERE
  cr.concept_id_1 IN (1333174,1333343,1333207,1333310,1332811,1332812,1332715,1332813,1333101,1332814,1332815,1332816,1332817,1332818)
  AND cr.relationship_id = "PPI parent code of" 
- )
- 
-SELECT COUNT (*) AS n_row_not_pass FROM df1
-WHERE survey_version_concept_id=0 or survey_version_concept_id IS NULL
-'''
-df1 = execute(client, query)
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query2 survey version provided',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
-else:
-    df = df.append({
-        'query': 'Query2 survey version provided',
-        'result': ''
-    },
-                   ignore_index=True)
+ group by 1
+ order by row_counts
+ """)
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
+df1.shape
+
 df1
 
-# +
-# new cdr
-query = f'''
-SELECT
- distinct survey_version_concept_id
-FROM  `{project_id}.{deid_cdr}.observation` d
-JOIN  `{project_id}.{deid_cdr}.observation_ext` e
-ON  e.observation_id = d.observation_id
+if df1['Failure_row_counts'].sum()==0:
+ df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},  
+                ignore_index = True) 
 
-'''
-df1 = execute(client, query)
-
-df1.style.format("{:.0f}")
-
-# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false,
-# "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 3 Verify that all structured concepts related  to COVID are NOT suppressed in EHR tables
-#
+# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
+# # 3 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR tables
+#   
 #   DC-891
 #
 # 756055,4100065,37311061,439676,37311060,45763724
 #
 # update, Remove analyses 3, 4, and 5 as suppression of COVID concepts is no longer part of RT privacy requirements,[DC-1752]
+# -
 
-# +
-query = f'''
+query = JINJA_ENV.from_string("""
 
-SELECT measurement_concept_id, concept_name,concept_code,vocabulary_id,COUNT(1) AS n_row_not_pass FROM 
-`{project_id}.{deid_cdr}.measurement` ob
-JOIN `{project_id}.{deid_cdr}.concept` c
+SELECT measurement_concept_id, concept_name,concept_code,vocabulary_id,
+COUNT(1) AS n_row_not_pass,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 0 ELSE 1
+END
+ AS Failure_row_counts
+FROM `{{project_id}}.{{deid_cdr}}.measurement` ob
+JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.measurement_concept_id=c.concept_id
 WHERE measurement_concept_id=756055
 GROUP BY 1,2,3,4
 ORDER BY n_row_not_pass DESC
 
-'''
-df1 = execute(client, query)
+ """)
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
+df1.shape
 
-if df1['n_row_not_pass'].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query3 No COPE in deid_measurement table',
-            'result': ''
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query': 'Query3 No COPE in deid_measurement table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
 df1
 
-# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false,
-# "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 4 Verify that all structured concepts related  to COVID are NOT suppressed in EHR condition_occurrence
-#
+if df1['Failure_row_counts'].sum()==0:
+ df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},  
+                ignore_index = True) 
+
+# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
+# # 4 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR condition_occurrence
+#   
 #   DC-891
 #
 # 756055,4100065,37311061,439676,37311060,45763724
 #
 # update, Remove analyses 3, 4, and 5 as suppression of COVID concepts is no longer part of RT privacy requirements,[DC-1752]
+# -
 
-# +
-query = f'''
+query = JINJA_ENV.from_string("""
 
-SELECT condition_concept_id, concept_name,concept_code,vocabulary_id,COUNT(1) AS n_row_not_pass FROM 
-`{project_id}.{deid_cdr}.condition_occurrence` ob
-JOIN `{project_id}.{deid_cdr}.concept` c
+SELECT condition_concept_id, concept_name,concept_code,vocabulary_id,
+COUNT(1) AS n_row_not_pass,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 0 ELSE 1
+END
+ AS Failure_row_counts
+FROM  `{{project_id}}.{{deid_cdr}}.condition_occurrence` ob
+JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.condition_concept_id=c.concept_id
 WHERE condition_concept_id IN  (4100065, 37311061, 439676)
 GROUP BY 1,2,3,4
 ORDER BY n_row_not_pass DESC
 
-'''
-df1 = execute(client, query)
+ """)
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
+df1.shape
 
-if df1['n_row_not_pass'].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query4 COVID concepts suppression in deid_observation table',
-            'result':
-                ''
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query':
-                'Query4 COVID concepts suppression in deid_observation table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
 df1
 
-# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false,
-# "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
-# # 5 Verify that all structured concepts related  to COVID are NOT suppressed in EHR observation
-#
+if df1['Failure_row_counts'].sum()==0:
+ df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},  
+                ignore_index = True) 
+
+
+# + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
+# # 5 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR observation
+#   
 #   DC-891
 #
 # 756055,4100065,37311061,439676,37311060,45763724
 #
 # update, Remove analyses 3, 4, and 5 as suppression of COVID concepts is no longer part of RT privacy requirements,[DC-1752]
+# -
 
-# +
-query = f'''
+query = JINJA_ENV.from_string("""
 
-SELECT observation_concept_id, concept_name,concept_code,vocabulary_id,observation_source_concept_id,COUNT(1) AS n_row_not_pass FROM 
-`{project_id}.{deid_cdr}.observation` ob
-JOIN `{project_id}.{deid_cdr}.concept` c
+SELECT observation_concept_id, concept_name,concept_code,vocabulary_id,observation_source_concept_id,
+COUNT(1) AS n_row_not_pass,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 0 ELSE 1
+END
+ AS Failure_row_counts
+FROM `{{project_id}}.{{deid_cdr}}.observation` ob
+JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.observation_concept_id=c.concept_id
 WHERE observation_concept_id IN  (37311060, 45763724) OR observation_source_concept_id IN  (37311060, 45763724)
 GROUP BY 1,2,3,4,5
 ORDER BY n_row_not_pass DESC
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
+df1.shape
 
-'''
-df1 = execute(client, query)
 
-if df1['n_row_not_pass'].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query5 COVID concepts suppression in observation table',
-            'result': ''
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query': 'Query5 COVID concepts suppression in observation table',
-            'result': 'PASS'
-        },
-        ignore_index=True)
 df1
-# -
 
-# # 6 Verify these concepts are NOT suppressed in EHR observation
-#
+if df1['Failure_row_counts'].sum()==0:
+ df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},  
+                ignore_index = True) 
+
+# # 6 done updated Verify these concepts are NOT suppressed in EHR observation
+#   
 # [DC-1747]
 # these concepts 1333015, 	1333023	are not longer suppressed
 #
-# 1332737, [DC-1665]
+# 1332737, [DC-1665] 
 #
 # 1333291
 #
-# 1332904,1333140 should be generalized to 1332737
+# 1332904,1333140 should be generalized to 1332737 , # update ?need to rewrite??
 #
-# 1332843 should be generalized.
+# 1332843 should be generalized. 
 
-# +
-query = f'''
+query = JINJA_ENV.from_string("""
 
-SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,observation_concept_id,COUNT(1) AS n_row_not_pass FROM 
-`{project_id}.{deid_cdr}.observation` ob
-JOIN `{project_id}.{deid_cdr}.concept` c
+SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,observation_concept_id,
+COUNT(1) AS n_row_pass,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 0 ELSE 1
+END
+ AS Failure_row_counts
+
+FROM `{{project_id}}.{{deid_cdr}}.observation` ob
+JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.observation_source_concept_id=c.concept_id
 WHERE observation_source_concept_id IN  (1333015, 1333023, 1332737,1333291,1332904,1333140,1332843) 
 OR observation_concept_id IN  (1333015, 1333023,1332737,1333291,1332904,1333140,1332843 )
 GROUP BY 1,2,3,4,5
-ORDER BY n_row_not_pass DESC
+ORDER BY n_row_pass DESC
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
+df1.shape
 
-'''
-df1 = execute(client, query)
 
-if df1['n_row_not_pass'].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query6 The concepts are not suppressed in observation table',
-            'result':
-                ''
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query':
-                'Query6 The concepts are not suppressed in observation table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
 df1
-# -
 
-# # 7 Vaccine-related concepts as these EHR-submitted COVID concepts are disallowed from RT
-#
-# DC-1752
-#
+if (df1['Failure_row_counts'].sum()==0) and (df1[df1['observation_source_concept_id'].isin(['1332904','1333140'])].empty) :
+ df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},  
+                ignore_index = True) 
 
-# +
+# # 7 done Vaccine-related concepts as these EHR-submitted COVID concepts are allowed from RT 
+# DC-2374
+# this query was from DC-1752 
 
-query = f'''
+query = JINJA_ENV.from_string("""
+
 DECLARE vocabulary_tables DEFAULT ['vocabulary', 'concept', 'source_to_concept_map', 
                                    'concept_class', 'concept_synonym', 'concept_ancestor',
                                    'concept_relationship', 'relationship', 'drug_strength'];
+SELECT table_name,column_name
 
-DECLARE query STRING;
-
-CREATE OR REPLACE TABLE `{project_id}.{deid_sandbox}.concept_usage` (
- concept_id   INT64
-,table_name   STRING NOT NULL
-,column_name  STRING NOT NULL
-,row_count    INT64 NOT NULL
-)
-OPTIONS (
-  description='Concept usage counts in deid_cdr'
- ,expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
-);
-
-SET query = (
-SELECT 
- STRING_AGG('SELECT ' 
-     || column_name         || '  AS concept_id '
-            || ',"' || table_name  || '" AS table_name '
-     || ',"' || column_name || '" AS column_name '
-     || ', COUNT(1) AS row_count '
-     || 'FROM `' || table_schema || '.' || table_name || '` t '
-     || 'GROUP BY 1, 2, 3',
-           ' UNION ALL ')
-FROM `{deid_cdr}.INFORMATION_SCHEMA.COLUMNS` c
-JOIN `{deid_cdr}.__TABLES__` t
+FROM `{{project_id}}.{{deid_cdr}}.INFORMATION_SCHEMA.COLUMNS` c
+JOIN `{{project_id}}.{{deid_cdr}}.__TABLES__` t
  ON c.table_name = t.table_id
 WHERE 
-      table_name NOT IN UNNEST(vocabulary_tables)
-  AND t.row_count > 0
+     table_name NOT IN UNNEST(vocabulary_tables) and 
+  t.row_count > 0
   AND table_name NOT LIKE '\\\_%'
-  AND LOWER(column_name) LIKE '%concept_id%'
-);
+  AND table_name in ('procedure_occurrence','drug_exposure')
+  AND column_name in ('procedure_concept_id','procedure_source_concept_id','drug_concept_id','drug_source_concept_id')
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+target_tables=execute(client, q)
+target_tables.shape
 
-EXECUTE IMMEDIATE 'INSERT `{project_id}.{deid_sandbox}.concept_usage`' || query;
 
-WITH 
-vaccine_concept AS
-(
- SELECT *
- FROM `{project_id}.{deid_cdr}.concept` 
+# +
+#table_name="drug_exposure"
+#@column_name="drug_concept_id"
+
+def my_sql(table_name,column_name):
+
+    query = JINJA_ENV.from_string("""
+    
+SELECT 
+'{{table_name}}' AS table_name,
+'{{column_name}}' AS column_name,
+COUNT(*) AS row_counts,
+CASE WHEN 
+  COUNT(*) > 0
+  THEN 0 ELSE 1
+END
+ AS Failure_row_counts
+ 
+FROM `{{project_id}}.{{deid_cdr}}.{{table_name}}` c
+JOIN  `{{project_id}}.{{deid_cdr}}.concept` on concept_id={{column_name}}
  WHERE (
-        -- done by name and vocab -- this alone should be enough, no need for others--
+        -- done by name and vocab -- -- this alone should be enough, no need for others --
         REGEXP_CONTAINS(concept_name, r'(?i)(COVID)') AND
         REGEXP_CONTAINS(concept_name, r'(?i)(VAC)') AND 
         vocabulary_id not in ('PPI')
     ) OR (
         -- done by code  and vocab --
-        REGEXP_CONTAINS(concept_code, r'(207)|(208)|(210)|(212)|(213)') --not 211--
+        REGEXP_CONTAINS(concept_code, r'(207)|(208)|(210)|(212)|(213)') -- not 211 --
         and vocabulary_id = 'CVX'
     ) OR (
         -- done by code and vocab --
-        REGEXP_CONTAINS(concept_code, r'(91300)|(91301)|(91302)|(91303)|(0031A)|(0021A)|(0022A)|(0002A)|(0001A)|(0012A)|(0011A)')
-        --no 91304--
+        REGEXP_CONTAINS(concept_code, r'(91300)|(91301)|(91302)|(91303)|(0031A)|(0021A)|(0022A)|(0002A)|(0001A)|(0012A)|(0011A)')   -- no 91304 --
         and vocabulary_id = 'CPT4'
      )
-)
 
-SELECT u.* 
-FROM
-`{project_id}.{deid_sandbox}.concept_usage` u
-JOIN vaccine_concept c
-USING (concept_id)
-ORDER BY row_count DESC
+""")
+    q = query.render(project_id=project_id,deid_cdr=deid_cdr,table_name=table_name,column_name=column_name)
+    df11=execute(client, q)
+    return df11
 
-'''
-df1 = execute(client, query)
-if df1['row_count'].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query7 COVID Vaccine-related concepts suppression in EHR tables',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query':
-                'Query7 COVID Vaccine-related concepts suppression in EHR tables',
-            'result':
-                ''
-        },
-        ignore_index=True)
-df1
+
 # -
+
+# use a loop to get table name AND column name AND run sql function
+result = [my_sql (table_name, column_name) for table_name, column_name in zip(target_tables['table_name'], target_tables['column_name'])]
+result
+
+# +
+# AND then get the result back FROM loop result list
+n=len(target_tables.index)
+res2 = pd.DataFrame(result[0])
+
+for x in range(1,n):    
+  res2=res2.append(result[x])
+    
+#res2=res2.sort_values(by='row_counts_failure', ascending=False)
+res2
+# -
+
+if res2['Failure_row_counts'].sum()==0:
+ df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},  
+                ignore_index = True) 
+
 
 # # Summary_deid_COPE_survey
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null', '']))
-df.style.highlight_null(null_color='red').set_properties(
-    **{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+# -
+
+

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -32,20 +32,9 @@ pd.options.display.max_rows = 120
 project_id = ""
 com_cdr = ""
 deid_cdr = ""
-#deid_sandbox=""
 sandbox=""
 run_as=""
 
-# +
-# Parameters
-
-#project_id = "aou-res-curation-prod"
-#deid_cdr = "R2022q2r4_deid"
-#com_cdr = "2022q2r4_combined"
-#com_cdr = "2022q2r4_combined"
-#deid_sandbox = "R2021q3r1_deid_sandbox"
-#sandbox='curation_sandbox'
-#run_as = "data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
@@ -34,16 +34,6 @@ pid_threshold=""
 run_as=""
 
 # +
-#project_id = "aou-res-curation-prod"
-#deid_cdr = "R2022q4r4_deid"
-#combine = "2022q4r3_combined"
-#pid_threshold='200'
-#reg_combine='reg_2022q4r3_combined'
-#pipeline = "pipeline_tables"
-#deid_sand = "2022q4r3_deid_sandbox"
-#run_as="data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
-
-# +
 impersonation_creds = auth.get_impersonation_credentials(
     run_as, target_scopes=IMPERSONATION_SCOPES)
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
 #   jupytext:
@@ -12,10 +13,11 @@
 #     name: python3
 # ---
 
-# # QA queries on new CDR_deid household AND state general
+# # QA queries on new CDR_deid household AND state generalization
 
 import urllib
 import pandas as pd
+from common import JINJA_ENV
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -23,14 +25,23 @@ pd.options.display.max_rows = 120
 
 # + tags=["parameters"]
 project_id = ""
-deid_cdr = ""
-# deid_clean=""
-com_cdr = ""
-run_as = ""
-# -
+deid_cdr=""
+combine = ""
+reg_combine=''
+pipeline = ""
+deid_sand = ""
+pid_threshold=""
+run_as=""
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# +
+#project_id = "aou-res-curation-prod"
+#deid_cdr = "R2022q4r4_deid"
+#combine = "2022q4r3_combined"
+#pid_threshold='200'
+#reg_combine='reg_2022q4r3_combined'
+#pipeline = "pipeline_tables"
+#deid_sand = "2022q4r3_deid_sandbox"
+#run_as="data-analytics@aou-res-curation-prod.iam.gserviceaccount.com"
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -39,47 +50,43 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
-# # 1 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585890, the value_as_concept_id field in de-id table should populate : 2000000012
+# df will have a summary in the end
+df = pd.DataFrame(columns = ['query', 'result']) 
+
+# # Query1 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585890, the value_as_concept_id field in de-id table should populate : 2000000012
 #
 # DC-1049
 #
 # Expected result:
 #
-# Null is the value poplulated in the value_as_number fields
+# Null is the value poplulated in the value_as_number fields 
 #
 # AND 2000000012, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field  in the deid table.
 #
-# Per Francis, the other two values are valid. so it is pass.
+# Per Francis, the other two values are valid. so it is pass. 
 
 # +
-query = f''' 
+query=JINJA_ENV.from_string("""
 
 SELECT COUNT (*) AS n_row_not_pass
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE
   observation_source_concept_id = 1585890
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
-'''
-df1 = execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
 
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query1 observation_source_concept_id 1585890',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query1 observation_source_concept_id 1585890', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query1 observation_source_concept_id 1585890',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query1 observation_source_concept_id 1585890', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
-# # 2 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1333023 , the value_as_concept_id field in de-id table should populate : 2000000012
+# # Query2 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1333023 , the value_as_concept_id field in de-id table should populate : 2000000012
 #
 # expected results:
 #
@@ -87,205 +94,247 @@ df1
 #
 # AND 2000000012, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 #
+# ## one row had error in new cdr
 
 # +
-query = f''' 
+query=JINJA_ENV.from_string("""
 
 SELECT COUNT (*) AS n_row_not_pass
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE
   observation_source_concept_id = 1333023
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
-'''
-df1 = execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
 
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query2 observation_source_concept_id 1333023',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query2 observation_source_concept_id 1333023', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query2 observation_source_concept_id 1333023',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query2 observation_source_concept_id 1333023', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
-query = f''' 
+query=JINJA_ENV.from_string("""
 
 SELECT *
-FROM `{project_id}.{deid_cdr}.observation`
+FROM `{{project_id}}.{{deid_cdr}}.observation`
 WHERE
   observation_source_concept_id = 1333023
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
-'''
-df1 = execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
 df1
 
-# # 3 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585889,  the value_as_concept_id field in de-id table should populate : 2000000013
+# # Query3 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585889,  the value_as_concept_id field in de-id table should populate : 2000000013
 #
 # DC-1059
 #
 # expected results:
 #
-# Null is the value poplulated in the value_as_number fields
+# Null is the value poplulated in the value_as_number fields 
 #
 # AND 2000000013, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 
 # +
-query = f''' 
-
+query=JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation`
+FROM  `{{project_id}}.{{deid_cdr}}.observation`
 WHERE
   observation_source_concept_id = 1585889
   AND value_as_concept_id NOT IN (2000000013,2000000010,903096)
-'''
-df1 = execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
 
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query3 observation_source_concept_id 1585889',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query3 observation_source_concept_id 1585889', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query3 observation_source_concept_id 1585889',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query3 observation_source_concept_id 1585889', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
-# # 4 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1333015,  the value_as_concept_id field in de-id table should populate : 2000000013
+# # Query4 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1333015,  the value_as_concept_id field in de-id table should populate : 2000000013
 #
-# Generalization Rules for reference
+# Generalization Rules for reference 
 #
 # Living Situation: COPE survey Generalize household size >10
 #
 # expected results:
 #
-# Null is the value poplulated in the value_as_number fields
+# Null is the value poplulated in the value_as_number fields 
 #
 # AND 2000000013, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 
 # +
-query = f''' 
+query=JINJA_ENV.from_string("""
 
 SELECT COUNT (*) AS n_row_not_pass
-FROM  `{project_id}.{deid_cdr}.observation`
+FROM  `{{project_id}}.{{deid_cdr}}.observation`
 WHERE
   observation_source_concept_id = 1333015
   AND value_as_concept_id NOT IN (2000000013,2000000010,903096)
-'''
-df1 = execute(client, query)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr)
+df1=execute(client, q)
 
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query': 'Query4 observation_source_concept_id 1333015',
-            'result': 'PASS'
-        },
-        ignore_index=True)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query4 observation_source_concept_id 1333015', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append(
-        {
-            'query': 'Query4 observation_source_concept_id 1333015',
-            'result': ''
-        },
-        ignore_index=True)
+ df = df.append({'query' : 'Query4 observation_source_concept_id 1333015', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
 # -
 
-# # state generalizaion
+# # Query5 update to verifie that value_as_concept_id and value_source_concept_id are set to 2000000011 for states with less than 200 participants.
+#
+# Set the value_source_concept_id = 2000000011 and value_as_concept_id =2000000011 
+#
+# DC-2377 and DC-1614, DC-2782, DC-2785
 
-# # 5 Verify that in Observation table where observation_source_concept_id = 1585249, value_source_concept_id that populates are none of the ones listed in the J column AND one of the value_source_concept_id popluates as 2000000011.
-#
-# DC-1045
-#
-# For rows in the pre_deid_com_cdr OBSERVATION table where observation_source_concept_id = 1585249 (StreetAddress_PIIState)  where the value_source_concept_id is one of the values listed in the query,  (generalize value_source_concept_id to XXX (Unspecified state))
-#
-# step1:
-#
-# 1. query with the condition
-# observation_source_concept_id = 1585249
-# 2. verify that none value_source_concept_id listed in J show up in the results.
-#
-# expected results:
-#
-# 1. value_source_concept_id of the States that are not generalized show up AND
-#
-# 2.only one row displays the generalized value_source_concept_id :  2000000011.
-#
-# step2
-#
-# 1. query using the listed value_source_concept_id as condition
-#
-# 2. these are the states that are generalized.
-#
-# expected results: returns no results
+# ## Query5.1 Generalize state info (2000000011) for participants who have EHR data from states other than the state they are currently living in.
 
 # +
-query = f''' 
-WITH df1 AS (
-SELECT distinct deid.value_source_concept_id
-FROM
-  `{project_id}.{com_cdr}.observation` com
-  JOIN `{project_id}.{deid_cdr}.observation` deid 
-  ON com.observation_id=deid.observation_id
-  
-WHERE
-  com.observation_source_value LIKE 'StreetAddress_PIIState'
-  AND com.observation_source_concept_id = 1585249
-  AND ( com.value_source_concept_id =         1585299
-OR com.value_source_concept_id =        1585304
-OR com.value_source_concept_id =        1585284
-OR com.value_source_concept_id =        1585315
-OR com.value_source_concept_id =        1585271
-OR com.value_source_concept_id =        1585263
-OR com.value_source_concept_id =        1585306
-OR com.value_source_concept_id =        1585274
-OR com.value_source_concept_id =        1585270
-OR com.value_source_concept_id =        1585411
-OR com.value_source_concept_id =        1585313
-OR com.value_source_concept_id =        1585409
-OR com.value_source_concept_id =        1585262
-OR com.value_source_concept_id =        1585309
-OR com.value_source_concept_id =        1585307
-OR com.value_source_concept_id =        1585275)
+query = JINJA_ENV.from_string("""
+
+with df_ehr_site as (
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'observation' table
+FROM `{{project_id}}.{{reg_combine}}.observation` com
+join `{{project_id}}.{{reg_combine}}._mapping_observation` map on map.observation_id=com.observation_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+
+union distinct 
+
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'condition' table
+FROM `{{project_id}}.{{reg_combine}}.condition_occurrence` com
+join `{{project_id}}.{{reg_combine}}._mapping_condition_occurrence` map on map.condition_occurrence_id=com.condition_occurrence_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+
+union distinct 
+
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'measurement' table
+FROM `{{project_id}}.{{reg_combine}}.measurement` com
+join `{{project_id}}.{{reg_combine}}._mapping_measurement` map on map.measurement_id=com.measurement_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+
+union distinct 
+
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'device_exposure' table
+FROM `{{project_id}}.{{reg_combine}}.device_exposure` com
+join `{{project_id}}.{{reg_combine}}._mapping_device_exposure` map on map.device_exposure_id=com.device_exposure_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+
+union distinct 
+
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'drug_exposure' table
+FROM `{{project_id}}.{{reg_combine}}.drug_exposure` com
+join `{{project_id}}.{{reg_combine}}._mapping_drug_exposure` map on map.drug_exposure_id=com.drug_exposure_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+
+union distinct 
+
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'procedure' table
+FROM `{{project_id}}.{{reg_combine}}.procedure_occurrence` com
+join `{{project_id}}.{{reg_combine}}._mapping_procedure_occurrence` map on map.procedure_occurrence_id=com.procedure_occurrence_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+
+union distinct 
+
+SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'visit' table
+FROM `{{project_id}}.{{reg_combine}}.visit_occurrence` com
+join `{{project_id}}.{{reg_combine}}._mapping_visit_occurrence` map on map.visit_occurrence_id=com.visit_occurrence_id
+JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
+JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+),
+
+df2 as (
+
+SELECT distinct deid.person_id,
+com.value_source_concept_id, 
+com.value_source_value com_residency_state, EHR_site_state
+FROM `{{project_id}}.{{deid_cdr}}.observation` deid
+join `{{project_id}}.{{reg_combine}}.observation` com on com.observation_id=deid.observation_id
+join df_ehr_site on deid.person_id=df_ehr_site.deid_pid
+where deid.observation_source_concept_id = 1585249
+and deid.value_source_concept_id !=2000000011
+and com.value_source_value !=EHR_site_state 
+)
+   
+select count (*) AS row_counts_failure_state_generalization from df2
+
+""")
+
+q = query.render(project_id=project_id,deid_cdr=deid_cdr,reg_combine=reg_combine,deid_sand=deid_sand,pipeline=pipeline)
+
+df1=execute(client, q)
+
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query5.1 state generalization to 2000000011', 'result' : 'PASS'},  
+                ignore_index = True) 
+else:
+ df = df.append({'query' : 'Query5.1 state generalization to 2000000011', 'result' : 'Failure'},  
+                ignore_index = True) 
+df1
+
+# -
+
+# ## Query5.2 Generalize state info for participants where the identified number of participants living in the state without EHR records from a different state < 200 (the generalization threshold)”
+
+# +
+query=JINJA_ENV.from_string(""" 
+with df_state_pid_200 as (
+select value_source_concept_id,
+count(distinct person_id) as participant_count
+FROM `{{project_id}}.{{reg_combine}}.observation` 
+where observation_source_concept_id = 1585249
+group by 1
+having participant_count < 200
 )
 
-SELECT COUNT (*) AS n_row_not_pass FROM df1
-WHERE value_source_concept_id !=2000000011
-'''
-df1 = execute(client, query)
+SELECT COUNT (*) AS n_row_not_pass_state_pid_200
+FROM `{{project_id}}.{{deid_cdr}}.observation` 
+WHERE observation_source_concept_id = 1585249
+and (value_source_concept_id !=2000000011 or value_as_concept_id !=2000000011) 
+and value_source_concept_id in (select value_source_concept_id from df_state_pid_200)
+""")
+q = query.render(project_id=project_id,deid_cdr=deid_cdr,pid_threshold=pid_threshold,reg_combine=reg_combine)
+df1=execute(client, q)
 
-if df1.loc[0].sum() == 0:
-    df = df.append({
-        'query': 'Query5_state_generalization',
-        'result': 'PASS'
-    },
-                   ignore_index=True)
+if df1.loc[0].sum()==0:
+ df = df.append({'query' : 'Query5.2 state generalization if counts <200', 'result' : 'PASS'},  
+                ignore_index = True) 
 else:
-    df = df.append({
-        'query': 'Query5_state_generalization',
-        'result': ''
-    },
-                   ignore_index=True)
+ df = df.append({'query' : 'Query5.2 state generalization if counts <200', 'result' : 'Failure'},  
+                ignore_index = True) 
 df1
+
+
 # -
 
 # # Summary_deid_household AND state generalization
 
-# if not pass, will be highlighted in red
-df = df.mask(df.isin(['Null', '']))
-df.style.highlight_null(null_color='red').set_properties(
-    **{'text-align': 'left'})
+# +
+def highlight_cells(val):
+    color = 'red' if 'Failure' in val else 'white'
+    return f'background-color: {color}' 
+
+df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})


### PR DESCRIPTION
1 changed the format by using JINJA_ENV and impersonation
2 main changes include the following

1) DC-2374, DC-2373, these two were basically same, 
The rule has changed and now we are including COVID concepts. Update the notebook to include the latest rule, based on The latest list is COPE - All Surveys Privacy Rules, which I put into curation_sandbox.temp_cope_privacy_rules

as seen in cdr_deid_qa_report7_cope_survey.py

2)  DC-2377, DC-2785
changes can be seen in the cdr_deid_qa_report8_household_state_genera.py (query5.1, 5.2)
and  cdr_deid_qa_report10_extra.py, 

3) DC-2391
Remove 4b sandbox._site_mappings from cdr_deid_qa_report10_extra.py

4)DC-2372
cdr_deid_qa_report3_col_suppression.py has this check 13 Verify the NOTE_NLP table is suppressed.
