### PR TITLE
[DC-2749] Add COPESurveyVersionTask to combined cleaning classes to run at the end of all other cleaning classes.

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -224,10 +224,7 @@ COMBINED_CLEANING_CLASSES = [
     (GenerateExtTables,),
     (COPESurveyVersionTask,
     ),  # Should run after GenerateExtTables and before CleanMappingExtTables
-    # TODO: Uncomment rule after date-shift removed from deid module
-    # (SurveyConductDateShiftRule,),
-    (
-        PopulateSurveyConductExt,),
+    (PopulateSurveyConductExt,),
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
@@ -242,6 +239,8 @@ FITBIT_CLEANING_CLASSES = [
 REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     # Data mappings/re-mappings
     ####################################
+    # TODO: Uncomment rule after date-shift removed from deid module
+    # (SurveyConductDateShiftRule,),
     (
         QRIDtoRID,),  # Should run before any row suppression rules
 

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -221,6 +221,13 @@ COMBINED_CLEANING_CLASSES = [
     (RemoveNonMatchingParticipant,),
     (DropOrphanedSurveyConductIds,),
     (DropOrphanedPIDS,),
+    (GenerateExtTables,),
+    (COPESurveyVersionTask,
+    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
+    # TODO: Uncomment rule after date-shift removed from deid module
+    # (SurveyConductDateShiftRule,),
+    (
+        PopulateSurveyConductExt,),
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
@@ -236,14 +243,7 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     # Data mappings/re-mappings
     ####################################
     (
-        GenerateExtTables,),
-    (COPESurveyVersionTask,
-    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
-    # TODO: Uncomment rule after date-shift removed from deid module
-    # (SurveyConductDateShiftRule,),
-    (
-        PopulateSurveyConductExt,),
-    (QRIDtoRID,),  # Should run before any row suppression rules
+        QRIDtoRID,),  # Should run before any row suppression rules
 
     # Data generalizations
     ####################################
@@ -297,10 +297,6 @@ REGISTERED_TIER_FITBIT_CLEANING_CLASSES = [
 
 CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (RtCtPIDtoRID,),
-    (GenerateExtTables,),
-    (COPESurveyVersionTask,
-    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
-    (PopulateSurveyConductExt,),
     (QRIDtoRID,),  # Should run before any row suppression rules
     (TruncateEraTables,),
     (NullPersonBirthdate,),

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
@@ -68,7 +68,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 cope_lookup_dataset_id=None,
+                 clean_survey_dataset_id=None,
                  table_namer=None):
         """
         Initialize the class with proper info.
@@ -95,10 +95,10 @@ class COPESurveyVersionTask(BaseCleaningRule):
             depends_on=[GenerateExtTables],
             table_namer=table_namer)
 
-        if not cope_lookup_dataset_id:
-            raise RuntimeError("'cope_lookup_dataset_id' must be set")
+        if not clean_survey_dataset_id:
+            raise RuntimeError("'clean_survey_dataset_id' must be set")
 
-        self.cope_lookup_dataset_id = cope_lookup_dataset_id
+        self.clean_survey_dataset_id = clean_survey_dataset_id
 
     def get_query_specs(self):
         """
@@ -113,7 +113,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
                 VERSION_COPE_SURVEYS_QUERY.render(
                     project_id=self.project_id,
                     dataset_id=self.dataset_id,
-                    cope_table_dataset_id=self.cope_lookup_dataset_id,
+                    cope_table_dataset_id=self.clean_survey_dataset_id,
                     cope_survey_mapping_table=COPE_SURVEY_MAP)
         }
 
@@ -128,7 +128,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
         to use it in a cleaning query.
         """
         msg = ''
-        tables = client.list_tables(self.cope_lookup_dataset_id)
+        tables = client.list_tables(self.clean_survey_dataset_id)
         try:
             table_ids = [table.table_id for table in tables]
         except (BadRequest):
@@ -137,7 +137,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
             LOGGER.exception(msg)
         except (NotFound):
             msg = (f"{self.__class__.__name__} cannot execute because dataset: "
-                   f"'{self.cope_lookup_dataset_id}' "
+                   f"'{self.clean_survey_dataset_id}' "
                    f"does not exist in project: '{self.project_id}'")
             LOGGER.exception(msg)
         else:
@@ -145,7 +145,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
                 msg = (f"{self.__class__.__name__} cannot execute because the "
                        f"cope survey mapping table: '{COPE_SURVEY_MAP}' "
                        f"does not exist in "
-                       f"'{self.project_id}.{self.cope_lookup_dataset_id}'")
+                       f"'{self.project_id}.{self.clean_survey_dataset_id}'")
                 LOGGER.error(msg)
         finally:
             # raise the message to error out of a running shell script
@@ -187,9 +187,9 @@ if __name__ == '__main__':
 
     parser = ap.get_argument_parser()
     parser.add_argument(
-        '--cope_survey_dataset',
+        '--clean_survey_dataset',
         action='store',
-        dest='cope_survey_dataset_id',
+        dest='clean_survey_dataset_id',
         help=('Dataset containing the mapping table provided by RDR team.  '
               'These maps questionnaire_response_ids to cope_months.'),
         required=True)
@@ -204,7 +204,7 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(COPESurveyVersionTask,)],
-            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)
         for query_dict in query_list:
             LOGGER.info(query_dict.get(cdr_consts.QUERY))
     else:
@@ -212,4 +212,4 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(COPESurveyVersionTask,)],
-            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 UPDATE_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
 SET language = qrai.value
-FROM `{{project_id}}.{{cope_lookup_dataset_id}}.questionnaire_response_additional_info` AS qrai
+FROM `{{project_id}}.{{clean_survey_dataset_id}}.questionnaire_response_additional_info` AS qrai
 WHERE sce.survey_conduct_id = qrai.questionnaire_response_id
 AND UPPER(qrai.type) = 'LANGUAGE'
 """)
@@ -34,7 +34,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 cope_lookup_dataset_id=None,
+                 clean_survey_dataset_id=None,
                  table_namer=None):
         """
         Initialize the class with proper information.
@@ -57,10 +57,10 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                          depends_on=[GenerateExtTables, COPESurveyVersionTask],
                          table_namer=table_namer)
 
-        if not cope_lookup_dataset_id:
-            raise RuntimeError("'cope_lookup_dataset_id' must be set")
+        if not clean_survey_dataset_id:
+            raise RuntimeError("'clean_survey_dataset_id' must be set")
 
-        self.cope_lookup_dataset_id = cope_lookup_dataset_id
+        self.clean_survey_dataset_id = clean_survey_dataset_id
 
     def get_query_specs(self):
         """
@@ -69,7 +69,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
         update_query = UPDATE_SURVEY_CONDUCT_EXT_QUERY.render(
             project_id=self.project_id,
             dataset_id=self.dataset_id,
-            cope_lookup_dataset_id=self.cope_lookup_dataset_id)
+            clean_survey_dataset_id=self.clean_survey_dataset_id)
 
         update_query_dict = {cdr_consts.QUERY: update_query}
 
@@ -103,9 +103,9 @@ if __name__ == '__main__':
 
     ap = parser.get_argument_parser()
     ap.add_argument(
-        '--cope_survey_dataset',
+        '--clean_survey_dataset',
         action='store',
-        dest='cope_survey_dataset_id',
+        dest='clean_survey_dataset_id',
         help=
         ('Dataset containing the mapping table provided by RDR team.  '
          'These have additional info like language to questionnaire_response_id.'
@@ -122,7 +122,7 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(PopulateSurveyConductExt,)],
-            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)
         for query in query_list:
             LOGGER.info(query)
     else:
@@ -131,4 +131,4 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(PopulateSurveyConductExt,)],
-            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 UPDATE_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
 SET language = qrai.value
-FROM `{{project_id}}.{{additional_info_dataset}}.questionnaire_response_additional_info` AS qrai
+FROM `{{project_id}}.{{cope_lookup_dataset_id}}.questionnaire_response_additional_info` AS qrai
 WHERE sce.survey_conduct_id = qrai.questionnaire_response_id
 AND UPPER(qrai.type) = 'LANGUAGE'
 """)

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -34,7 +34,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 additional_info_dataset=None,
+                 cope_lookup_dataset_id=None,
                  table_namer=None):
         """
         Initialize the class with proper information.
@@ -57,7 +57,10 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                          depends_on=[GenerateExtTables, COPESurveyVersionTask],
                          table_namer=table_namer)
 
-        self.additional_info_dataset = additional_info_dataset
+        if not cope_lookup_dataset_id:
+            raise RuntimeError("'cope_lookup_dataset_id' must be set")
+
+        self.cope_lookup_dataset_id = cope_lookup_dataset_id
 
     def get_query_specs(self):
         """
@@ -66,7 +69,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
         update_query = UPDATE_SURVEY_CONDUCT_EXT_QUERY.render(
             project_id=self.project_id,
             dataset_id=self.dataset_id,
-            additional_info_dataset=self.additional_info_dataset)
+            cope_lookup_dataset_id=self.cope_lookup_dataset_id)
 
         update_query_dict = {cdr_consts.QUERY: update_query}
 
@@ -100,9 +103,9 @@ if __name__ == '__main__':
 
     ap = parser.get_argument_parser()
     ap.add_argument(
-        '--additional_info_dataset',
+        '--cope_survey_dataset',
         action='store',
-        dest='additional_info_dataset',
+        dest='cope_survey_dataset_id',
         help=
         ('Dataset containing the mapping table provided by RDR team.  '
          'These have additional info like language to questionnaire_response_id.'
@@ -119,7 +122,7 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(PopulateSurveyConductExt,)],
-            additional_info_dataset=ARGS.additional_info_dataset)
+            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
         for query in query_list:
             LOGGER.info(query)
     else:
@@ -128,4 +131,4 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(PopulateSurveyConductExt,)],
-            additional_info_dataset=ARGS.additional_info_dataset)
+            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -245,10 +245,6 @@ class BaseTest:
             """
             super().setUp()
 
-            # Variables for tracking loaded vocabulary tables
-            self.vocabulary_loaded = False
-            self.vocabulary_tables = []
-
         def default_test(self, tables_and_test_values):
             """
             Test passing the query specifications to the clean engine module.
@@ -353,18 +349,6 @@ class BaseTest:
                     destination, schema=schema),
                                                      exists_ok=True)
                 self.client.copy_table(src_table, dst_table)
-
-                self.vocabulary_tables.append(destination)
-
-            self.vocabulary_loaded = True
-
-        def tearDown(self):
-            super().tearDown()
-
-            # Remove all vocabulary tables if created
-            if self.vocabulary_loaded:
-                for table in self.vocabulary_tables:
-                    self.client.delete_table(table, not_found_ok=True)
 
     class DeidRulesTestBase(CleaningRulesTestBase):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -349,6 +349,7 @@ class BaseTest:
                     destination, schema=schema),
                                                      exists_ok=True)
                 self.client.copy_table(src_table, dst_table)
+                self.fq_table_names.append(destination)
 
     class DeidRulesTestBase(CleaningRulesTestBase):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -245,6 +245,10 @@ class BaseTest:
             """
             super().setUp()
 
+            # Variables for tracking loaded vocabulary tables
+            self.vocabulary_loaded = False
+            self.vocabulary_tables = []
+
         def default_test(self, tables_and_test_values):
             """
             Test passing the query specifications to the clean engine module.
@@ -349,6 +353,18 @@ class BaseTest:
                     destination, schema=schema),
                                                      exists_ok=True)
                 self.client.copy_table(src_table, dst_table)
+
+                self.vocabulary_tables.append(destination)
+
+            self.vocabulary_loaded = True
+
+        def tearDown(self):
+            super().tearDown()
+
+            # Remove all vocabulary tables if created
+            if self.vocabulary_loaded:
+                for table in self.vocabulary_tables:
+                    self.client.delete_table(table, not_found_ok=True)
 
     class DeidRulesTestBase(CleaningRulesTestBase):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
@@ -43,13 +43,13 @@ class COPESurveyVersionTaskTest(BaseTest.DeidRulesTestBase):
 
         dataset_id = os.environ.get('COMBINED_DATASET_ID')
         sandbox_id = f'{dataset_id}_sandbox'
-        cls.kwargs.update({'cope_lookup_dataset_id': cls.cope_dataset_id})
+        cls.kwargs.update({'clean_survey_dataset_id': cls.cope_dataset_id})
 
         cls.rule_instance = COPESurveyVersionTask(
             cls.project_id,
             dataset_id,
             sandbox_id,
-            cope_lookup_dataset_id=cls.cope_dataset_id)
+            clean_survey_dataset_id=cls.cope_dataset_id)
 
         cls.fq_table_names = [
             f"{cls.project_id}.{dataset_id}.observation",

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_route_ids_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_route_ids_test.py
@@ -11,7 +11,7 @@ from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.populate_route_ids import (
     DOSE_FORM_ROUTE_MAPPING_TABLE, DRUG_ROUTE_MAPPING_TABLE, PopulateRouteIds)
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
-from common import DRUG_EXPOSURE
+from common import DRUG_EXPOSURE, VOCABULARY_TABLES
 
 
 class PopulateRouteIdsTest(BaseTest.CleaningRulesTestBase):
@@ -36,6 +36,10 @@ class PopulateRouteIdsTest(BaseTest.CleaningRulesTestBase):
         cls.fq_table_names = [
             f'{cls.project_id}.{cls.dataset_id}.{DRUG_EXPOSURE}'
         ]
+
+        for table in VOCABULARY_TABLES:
+            cls.fq_table_names.append(
+                f'{cls.project_id}.{cls.dataset_id}.{table}')
 
         cls.fq_sandbox_table_names = []
         for table in cls.rule_instance.get_sandbox_tablenames():

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -24,7 +24,7 @@ INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
 """)
 
 INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
-    INSERT INTO `{{project}}.{{additional_info_dataset}}.questionnaire_response_additional_info`
+    INSERT INTO `{{project}}.{{cope_lookup_dataset_id}}.questionnaire_response_additional_info`
         (questionnaire_response_id, type, value)
     VALUES
         (11, 'LANGUAGE', 'en'),
@@ -48,9 +48,9 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
 
         cls.project_id = os.environ.get(PROJECT_ID)
         cls.dataset_id = os.environ.get('RDR_DATASET_ID')
-        cls.additional_info_dataset = os.environ.get('RDR_DATASET_ID')
+        cls.cope_lookup_dataset_id = os.environ.get('RDR_DATASET_ID')
         cls.kwargs.update(
-            {'additional_info_dataset': cls.additional_info_dataset})
+            {'cope_lookup_dataset_id': cls.cope_lookup_dataset_id})
         sandbox_id = f"{cls.dataset_id}_sandbox"
         cls.sandbox_id = sandbox_id
 
@@ -58,13 +58,13 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             cls.project_id,
             cls.dataset_id,
             sandbox_id,
-            additional_info_dataset=cls.additional_info_dataset)
+            cope_lookup_dataset_id=cls.cope_lookup_dataset_id)
 
         cls.fq_sandbox_table_names = []
 
         cls.fq_table_names = [
             f'{cls.project_id}.{cls.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
-            f'{cls.project_id}.{cls.additional_info_dataset}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
+            f'{cls.project_id}.{cls.cope_lookup_dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
         ]
 
         super().setUpClass()
@@ -76,7 +76,7 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             project=self.project_id, dataset=self.dataset_id)
         insert_questionnaire_response_additional_info = INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO.render(
             project=self.project_id,
-            additional_info_dataset=self.additional_info_dataset)
+            cope_lookup_dataset_id=self.cope_lookup_dataset_id)
 
         queries = [
             insert_survey_conduct_ext,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -24,7 +24,7 @@ INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
 """)
 
 INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
-    INSERT INTO `{{project}}.{{cope_lookup_dataset_id}}.questionnaire_response_additional_info`
+    INSERT INTO `{{project}}.{{clean_survey_dataset_id}}.questionnaire_response_additional_info`
         (questionnaire_response_id, type, value)
     VALUES
         (11, 'LANGUAGE', 'en'),
@@ -48,9 +48,9 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
 
         cls.project_id = os.environ.get(PROJECT_ID)
         cls.dataset_id = os.environ.get('RDR_DATASET_ID')
-        cls.cope_lookup_dataset_id = os.environ.get('RDR_DATASET_ID')
+        cls.clean_survey_dataset_id = os.environ.get('RDR_DATASET_ID')
         cls.kwargs.update(
-            {'cope_lookup_dataset_id': cls.cope_lookup_dataset_id})
+            {'clean_survey_dataset_id': cls.clean_survey_dataset_id})
         sandbox_id = f"{cls.dataset_id}_sandbox"
         cls.sandbox_id = sandbox_id
 
@@ -58,13 +58,13 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             cls.project_id,
             cls.dataset_id,
             sandbox_id,
-            cope_lookup_dataset_id=cls.cope_lookup_dataset_id)
+            clean_survey_dataset_id=cls.clean_survey_dataset_id)
 
         cls.fq_sandbox_table_names = []
 
         cls.fq_table_names = [
             f'{cls.project_id}.{cls.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
-            f'{cls.project_id}.{cls.cope_lookup_dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
+            f'{cls.project_id}.{cls.clean_survey_dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
         ]
 
         super().setUpClass()
@@ -76,7 +76,7 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             project=self.project_id, dataset=self.dataset_id)
         insert_questionnaire_response_additional_info = INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO.render(
             project=self.project_id,
-            cope_lookup_dataset_id=self.cope_lookup_dataset_id)
+            clean_survey_dataset_id=self.clean_survey_dataset_id)
 
         queries = [
             insert_survey_conduct_ext,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid_test.py
@@ -90,13 +90,14 @@ class RepopulatePersonPostDeidTest(BaseTest.CleaningRulesTestBase):
         super().setUpClass()
 
     def setUp(self):
+        super().setUp()
+
         fq_dataset_name = self.fq_table_names[0].split('.')
         self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
 
         self.date = parser.parse('2020-05-05').date()
 
         self.copy_vocab_tables(self.vocabulary_dataset)
-        super().setUp()
 
     def test_repopulate_person_post_deid(self):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/repopulate_person_post_deid_test.py
@@ -90,14 +90,13 @@ class RepopulatePersonPostDeidTest(BaseTest.CleaningRulesTestBase):
         super().setUpClass()
 
     def setUp(self):
-        super().setUp()
-
         fq_dataset_name = self.fq_table_names[0].split('.')
         self.fq_dataset_name = '.'.join(fq_dataset_name[:-1])
 
         self.date = parser.parse('2020-05-05').date()
 
         self.copy_vocab_tables(self.vocabulary_dataset)
+        super().setUp()
 
     def test_repopulate_person_post_deid(self):
         """


### PR DESCRIPTION
Note: I also moved the currently commented `SurveyConductDateShiftRule` rule from the original data stages to the combined date stage. If this needs to remain in the original stages, request a change.