### PR TITLE
[DC-2799] Update cleaning rule for case-insensitive free text suppression

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -261,6 +261,7 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),
     (ExplicitIdentifierSuppression,),
+    (FreeTextSurveyResponseSuppression,),
     (CancerConceptSuppression,),
     (StringFieldsSuppression,),
     (DropOrphanedSurveyConductIds,),

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -261,9 +261,9 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),
     (ExplicitIdentifierSuppression,),
-    (FreeTextSurveyResponseSuppression,),
     (CancerConceptSuppression,),
     (StringFieldsSuppression,),
+    (FreeTextSurveyResponseSuppression,),
     (DropOrphanedSurveyConductIds,),
     (DropOrphanedPIDS,),
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
@@ -310,8 +310,6 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (GeneralizeZipCodes,),  # Should run after any data remapping rules
     (RaceEthnicityRecordSuppression,
     ),  # Should run after any data remapping rules
-    (FreeTextSurveyResponseSuppression,
-    ),  # Should run after any data remapping rules
     (MotorVehicleAccidentSuppression,),
     (VehicularAccidentConceptSuppression,),
     (ExplicitIdentifierSuppression,),
@@ -325,6 +323,7 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (StringFieldsSuppression,),
     (AggregateZipCodes,),
     (DeidentifyAIANZip3Values,),
+    (FreeTextSurveyResponseSuppression,),
     (DropOrphanedSurveyConductIds,),
     (DropOrphanedPIDS,),
     (RemoveExtraTables,),  # Should be last cleaning rule to be run

--- a/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression.py
@@ -1,7 +1,7 @@
 """
 To ensure participant privacy, remove any records containing concepts related to free text responses
 
-Original Issue: DC-1387
+Original Issue: DC-1387, DC-2799
 """
 
 # Python imports
@@ -24,7 +24,7 @@ FREE_TEXT_CONCEPT_QUERY = JINJA_ENV.from_string("""
 -- free text generated using REGEX --
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_dataset}}.{{concept_suppression_table}}` AS
 (SELECT * FROM `{{project_id}}.{{dataset_id}}.concept`
-WHERE REGEXP_CONTAINS(concept_code, r'(FreeText)|(TextBox)') OR concept_code = 'notes')
+WHERE REGEXP_CONTAINS(lower(concept_code), r'(freetext)|(textbox)') OR concept_code = 'notes')
 """)
 
 
@@ -49,9 +49,11 @@ class FreeTextSurveyResponseSuppression(AbstractBqLookupTableConceptSuppression
         desc = (f'Sandbox and record suppress any records containing '
                 f'concepts related to free text responses')
         super().__init__(
-            issue_numbers=['DC1387'],
+            issue_numbers=['DC1387', 'DC2799'],
             description=desc,
-            affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID],
+            affected_datasets=[
+                cdr_consts.CONTROLLED_TIER_DEID, cdr_consts.REGISTERED_TIER_DEID
+            ],
             affected_tables=[OBSERVATION],
             project_id=project_id,
             dataset_id=dataset_id,

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/free_text_survey_response_suppression_test.py
@@ -106,7 +106,13 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
            (444, 'Will Not Be Dropped', 'Observation', 'SNOWMED', 
             'Context-dependent', '0036T', '2016-05-01', '2016-05-02'),
            (555, 'Will Not Be Dropped', 'Observation', 'SNOWMED', 
-            'Context-dependent', '46938', '2016-05-01', '2016-05-02')
+            'Context-dependent', '46938', '2016-05-01', '2016-05-02'),
+            (666, 'Text Box 2', 'Observation', 'SNOWMED', 
+            'Context-dependent', 'Whitefreetext', '2016-05-01', '2016-05-02'),
+            (777, 'Text Box 3', 'Observation', 'SNOWMED', 
+            'Context-dependent', 'TexTBoX', '2016-05-01', '2016-05-02'),
+            (888, 'Text Box 3', 'Observation', 'SNOWMED', 
+            'Context-dependent', 'FreeTeXT', '2016-05-01', '2016-05-02')
         """)
 
         observation_table_tmpl = self.jinja_env.from_string("""
@@ -139,7 +145,10 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
                 (7, 8, 0, date('2017-05-02'), 0, 0, 0, 0, 0, 111),
             -- all valid *_concept_id, no records will dropped --
                 (8, 9, 444, date('2017-05-02'), 444, 444, 444, 444, 444, 444),
-                (9, 10, 555, date('2017-05-02'), 555, 555, 555, 555, 555, 555)
+                (9, 10, 555, date('2017-05-02'), 555, 555, 555, 555, 555, 555),
+                (10, 11, 666, date('2017-05-02'), 666, 666, 666, 666, 666, 666),
+                (11, 12, 777, date('2017-05-02'), 777, 777, 777, 777, 777, 777),
+                (12, 13, 777, date('2017-05-02'), 777, 777, 777, 777, 777, 777)
         """)
 
         insert_concept_query = concept_table_tmpl.render(
@@ -157,8 +166,8 @@ class FreeTextSurveyResponseSuppressionTest(BaseTest.CleaningRulesTestBase):
                 f'{self.fq_dataset_name}.observation',
             'fq_sandbox_table_name':
                 f'{self.fq_sandbox_name}.{self.rule_instance.sandbox_table_for(OBSERVATION)}',
-            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            'sandboxed_ids': [1, 2, 3, 4, 5, 6, 7],
+            'loaded_ids': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            'sandboxed_ids': [1, 2, 3, 4, 5, 6, 7, 10, 11, 12],
             'fields': [
                 'observation_id', 'person_id', 'observation_concept_id',
                 'observation_date', 'observation_type_concept_id',


### PR DESCRIPTION
* Update FreeTextSurveyResponseSuppression to suppress case-insensitive free text concept codes
* Add FreeTextSurveyResponseSuppression to registered tier cleaning classes
* Update integration tests to cover case-insensitive concept codes