### PR TITLE
[DC-3007] Update clean_mapping cleaning rule to correctly handle EHR datasets

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/clean_mapping.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_mapping.py
@@ -145,10 +145,10 @@ class CleanMappingExtTables(BaseCleaningRule):
     @staticmethod
     def is_ehr_dataset(dataset_id):
         """
-        identifies unioned datasets
+        identifies ehr datasets
 
         :param dataset_id: identifies the dataset
-        :return: Boolean identifying if the dataset is a unioned dataset
+        :return: Boolean identifying if the dataset is an ehr dataset
         """
         return 'ehr' in dataset_id and 'unioned' not in dataset_id
 
@@ -164,15 +164,14 @@ class CleanMappingExtTables(BaseCleaningRule):
         """
         queries = []
 
-        # TODO modify based on new naming convention
         is_ehr = self.is_ehr_dataset(self.dataset_id)
 
         for table in table_list:
             cdm_table = self.get_cdm_table(table, table_type)
+            table_id = f"{cdm_table}_id"
+
             if is_ehr:
                 cdm_table = f"{UNIONED_EHR}_{cdm_table}"
-
-            table_id = f"{cdm_table}_id"
 
             if self.sandbox_dataset_id is not None:
                 sandbox_query = dict()

--- a/data_steward/resources.py
+++ b/data_steward/resources.py
@@ -12,7 +12,8 @@ from git import Repo, TagReference
 from google.cloud import bigquery
 
 from common import (VOCABULARY, ACHILLES, PROCESSED_TXT, RESULTS_HTML,
-                    FITBIT_TABLES, PID_RID_MAPPING, COPE_SURVEY_MAP)
+                    FITBIT_TABLES, PID_RID_MAPPING, COPE_SURVEY_MAP,
+                    UNIONED_EHR)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -150,6 +151,10 @@ def fields_for(table, sub_path=None):
         If provided, this directory will be searched.
     :returns: a json object representing the schemas for the named table
     """
+    # Added for unioned_ehr_xyz tables in EHR dataset
+    if table.startswith(UNIONED_EHR):
+        table = table.split(f'{UNIONED_EHR}_')[1]
+
     path = os.path.join(fields_path, sub_path if sub_path else '')
 
     # default setting

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_mapping_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/clean_mapping_test.py
@@ -95,3 +95,8 @@ class CleanMappingTest(unittest.TestCase):
         ]
         actual = self.rule_instance.get_query_specs()
         self.assertEqual(len(actual), len(cdm_tables) * 4)
+
+    def test_is_ehr_dataset(self):
+        self.assertTrue(self.rule_instance.is_ehr_dataset('dummy_ehr'))
+        self.assertFalse(self.rule_instance.is_ehr_dataset('dummy'))
+        self.assertFalse(self.rule_instance.is_ehr_dataset('dummy_unioned_ehr'))


### PR DESCRIPTION
- For EHR datasets, the `table_id` was overwritten to a wrong value.
- I fixed the logic. I added test cases to ensure the update is working as expected.
- I updated `fields_for()` in `resources.py` so it can work for `unioned_ehr_xyz` tables in EHR datasets.