### PR TITLE
[DC-3065] Update scripts to handle two-digit release (2022q4r10) correctly

### DIFF
--- a/data_steward/retraction/run_retraction.py
+++ b/data_steward/retraction/run_retraction.py
@@ -37,6 +37,7 @@ from retraction.retract_data_bq import run_bq_retraction, RETRACTION_ONLY_EHR, R
 from retraction.retract_utils import is_fitbit_dataset
 from utils import pipeline_logging
 from utils.auth import get_impersonation_credentials
+from utils.parameter_validators import validate_release_tag_param
 
 LOGGER = logging.getLogger(__name__)
 
@@ -189,6 +190,7 @@ def parse_args(raw_args=None):
         action='store',
         dest='new_release_tag',
         required=True,
+        type=validate_release_tag_param,
         help='Release tag for the new datasets after retraction.')
     parser.add_argument(
         '--lookup_creation_sql_file_path',

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -191,9 +191,8 @@ def generate_output_prod(tier,
             f'Copying fitbit tables from dataset {src_project_id}.{fitbit_dataset_id} to {src_project_id}.{src_dataset_id}...'
         )
 
-        _ = bq_client.copy_dataset(
-            f'{src_project_id}.{fitbit_dataset_id}',
-            f'{src_project_id}.{src_dataset_id}')
+        _ = bq_client.copy_dataset(f'{src_project_id}.{fitbit_dataset_id}',
+                                   f'{src_project_id}.{src_dataset_id}')
 
     #Copy tables from source to output-prod
     LOGGER.info(

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -191,7 +191,7 @@ def generate_output_prod(tier,
             f'Copying fitbit tables from dataset {src_project_id}.{fitbit_dataset_id} to {src_project_id}.{src_dataset_id}...'
         )
 
-        copy_fitbit_jobs = bq_client.copy_dataset(
+        _ = bq_client.copy_dataset(
             f'{src_project_id}.{fitbit_dataset_id}',
             f'{src_project_id}.{src_dataset_id}')
 
@@ -199,7 +199,7 @@ def generate_output_prod(tier,
     LOGGER.info(
         f'Copying tables from dataset {src_project_id}.{src_dataset_id} to {output_prod_project_id}.{output_dataset_name}...'
     )
-    copy_src_jobs = bq_client.copy_dataset(
+    _ = bq_client.copy_dataset(
         f'{src_project_id}.{src_dataset_id}',
         f'{output_prod_project_id}.{output_dataset_name}')
 

--- a/data_steward/tools/run_basics_remediation.py
+++ b/data_steward/tools/run_basics_remediation.py
@@ -27,6 +27,7 @@ from resources import ask_if_continue, get_new_dataset_name
 from retraction.retract_utils import is_combined_dataset, is_deid_dataset
 from utils import pipeline_logging
 from utils.auth import get_impersonation_credentials
+from utils.parameter_validators import validate_release_tag_param
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,6 +148,7 @@ def parse_args(raw_args=None):
         action='store',
         dest='new_release_tag',
         required=True,
+        type=validate_release_tag_param,
         help='Release tag for the new datasets after remediation.')
     parser.add_argument('-l',
                         '--console_log',


### PR DESCRIPTION
I searched our code base for any `release_tag` modifiers such as regex substitution, slicing, indexing, or modifiers such as upper() that would cause an error.  Fortunately, Lauren's [commit](https://github.com/all-of-us/curation/pull/1457/commits/415d719c3735ba5139c430119390eea599fff09f) already handled most of the cases, so the only contribution I could make was updating a single case check.

Other than that, I made a nitpick change to two unused variables.  By convention, `_` is often used.
