### PR TITLE
[DC-3060] Remove unused variables in `deid_runner.sh`

### DIFF
--- a/data_steward/analytics/cdr_ops/incremental_load_qc.py
+++ b/data_steward/analytics/cdr_ops/incremental_load_qc.py
@@ -1,0 +1,584 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.7.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# # Incremental load validation notebook
+# This notebook is for validating 2022q4 "missing basics" hotfix.
+# See [DC-3016](https://precisionmedicineinitiative.atlassian.net/browse/DC-3016)
+# and its subtasks for details.
+
+# + tags=["parameters"]
+run_as: str = ""  # service account email to impersonate
+project_id: str = ""  # project where datasets are located
+new_dataset: str = ""  # dataset we created during this hotfix
+source_dataset: str = ""  # dataset that new_dataset is based off of
+sandbox_dataset: str = ""  # sandbox dataset that is used for this hotfix
+sandbox_obs: str = ""  # sandbox table for observation used for this hotfix
+aian_lookup_dataset: str = ""  # dataset where we have aian lookup table
+aian_lookup_table: str = ""  # table that has PIDs/RIDs of AIAN participants
+incremental_dataset: str = ""  # dataset so-called "incremental"
+includes_aian: str = ""  # True if AIAN participants' data is in the dataset, False if not
+# -
+
+# +
+from IPython.display import display, HTML
+
+from common import JINJA_ENV, OBSERVATION, PERSON, SURVEY_CONDUCT
+from analytics.cdr_ops.notebook_utils import (execute, IMPERSONATION_SCOPES,
+                                              render_message)
+from utils import auth
+from gcloud.bq import BigQueryClient
+from resources import ext_table_for, mapping_table_for
+from retraction.retract_utils import (is_combined_release_dataset,
+                                      is_deid_dataset, is_deid_release_dataset,
+                                      is_rdr_dataset)
+# -
+
+impersonation_creds = auth.get_impersonation_credentials(
+    run_as, target_scopes=IMPERSONATION_SCOPES)
+client = BigQueryClient(project_id, credentials=impersonation_creds)
+pid_or_rid = 'research_id' if is_deid_dataset(new_dataset) else 'person_id'
+
+# ## QC 1. (Only for `includes_aian == False`) Confirm no AIAN participants data is included in the new dataset
+# `incremental_dataset` contains AIAN participants' records. <br>We must exclude those in `new_dataset`
+# when creating a WITHOUT AIAN dataset.
+
+# +
+if includes_aian == "True":
+    success_msg = "Skipping this check because the new dataset can include AIAN participants.<br><br>"
+    render_message('', success_msg=success_msg)
+
+else:
+    person_id_tables_query = JINJA_ENV.from_string('''
+        SELECT table_name
+        FROM `{{project}}.{{new_dataset}}.INFORMATION_SCHEMA.COLUMNS`
+        WHERE column_name = "person_id"
+        ORDER BY table_name
+    ''').render(project=project_id, new_dataset=new_dataset)
+    pid_table_list = client.query(person_id_tables_query).to_dataframe().get(
+        'table_name').to_list()
+
+    query = JINJA_ENV.from_string('''
+        SELECT
+            \'{{table}}\' as table_name,
+            COUNT(*) AS aian_row_count
+        FROM `{{project}}.{{new_dataset}}.{{table}}`
+        WHERE person_id IN (
+            SELECT {{pid_or_rid}} FROM `{{project}}.{{aian_lookup_dataset}}.{{aian_lookup_table}}`
+            WHERE {{pid_or_rid}} IS NOT NULL
+        )
+        HAVING COUNT(*) > 0
+    ''')
+    queries = [
+        query.render(project=project_id,
+                     new_dataset=new_dataset,
+                     table=table,
+                     aian_lookup_dataset=aian_lookup_dataset,
+                     aian_lookup_table=aian_lookup_table,
+                     pid_or_rid=pid_or_rid) for table in pid_table_list
+    ]
+    union_all_query = '\nUNION ALL\n'.join(queries)
+
+    df = execute(client, union_all_query)
+
+    success_null_check = f"No AIAN participants' records are found in {new_dataset}.<br><br>"
+    failure_null_check = (
+        "There are <b>{count}</b> tables that might have "
+        "AIAN participants' records. <br>Look at these tables and investigate why AIAN "
+        "records are there: <b>{tables}</b><br><br>")
+
+    render_message(df,
+                   success_null_check,
+                   failure_null_check,
+                   failure_msg_args={
+                       'count': len(df),
+                       'tables': ', '.join(df.table_name)
+                   })
+# -
+
+# ## QC 2-1. Confirm there are no duplicate `OBSERVATION_ID`s
+# Any observation records from `incremental_dataset` got new `OBSERVATION_ID`s
+# assigned in `new_dataset` to avoid ID duplicates. <br>We must confirm all the
+# `OBSERVATION_ID`s in `new_dataset` are unique. <br>The same goes to
+# `_mapping_observation` and `obsesrvation_ext`.
+
+# +
+if is_deid_dataset(new_dataset):
+    obs_tables = [OBSERVATION, ext_table_for(OBSERVATION)]
+elif is_combined_release_dataset(new_dataset):
+    obs_tables = [
+        OBSERVATION,
+        mapping_table_for(OBSERVATION),
+        ext_table_for(OBSERVATION)
+    ]
+elif is_rdr_dataset(new_dataset):
+    obs_tables = [OBSERVATION]
+else:
+    obs_tables = [OBSERVATION, mapping_table_for(OBSERVATION)]
+
+query = JINJA_ENV.from_string('''
+    SELECT
+        \'{{table}}\' as table_name,
+        observation_id,
+        COUNT(*) AS duplicate_row_count
+    FROM `{{project}}.{{new_dataset}}.{{table}}`
+    GROUP BY table_name, observation_id
+    HAVING COUNT(*) > 1
+''')
+
+queries = [
+    query.render(project=project_id, new_dataset=new_dataset, table=table)
+    for table in obs_tables
+]
+
+union_all_query = '\nUNION ALL\n'.join(queries)
+df = execute(client, union_all_query)
+
+success_null_check = f"No OBSERVATION_ID duplicates are found in {new_dataset}.<br><br>"
+failure_null_check = (
+    "There are total <b>{count}</b> OBSERVATION_IDs that might have"
+    "duplicates. <br>Look at these tables and investigate why there are duplicates: <b>{tables}</b><br><br>"
+)
+
+render_message(df,
+               success_null_check,
+               failure_null_check,
+               failure_msg_args={
+                   'count': len(df),
+                   'tables': ', '.join(df.table_name)
+               })
+# -
+
+# ## QC 2-2. Confirm all new records in `OBSERVATION` have mapping info in `_observation_id_map`
+# Any observation records from `incremental_dataset` got new `OBSERVATION_ID`s
+# assigned in `new_dataset` to avoid ID duplicates. The mapping of the old-new
+# `OBSERVATION_ID`s is kept in `sandbox._observation_id_map`. <br>We must confirm
+# all the new `OBSERVATION_ID`s have their mapping info in `sandbox._observation_id_map`<br>.
+# NOTE: Not all records in `_observation_id_map` have corresponding records in `new_dataset`
+# because `_observation_id_map` is referenced by multiple data releases.
+
+# +
+query = JINJA_ENV.from_string('''
+    SELECT
+        'no mapping record found in sandbox._observation_id_map' AS issue,
+        COUNT(*) AS no_mapping_row_count
+    FROM `{{project}}.{{new_dataset}}.observation`
+    WHERE observation_id NOT IN (
+        SELECT observation_id FROM `{{project}}.{{sandbox_dataset}}._observation_id_map`
+        WHERE observation_id IS NOT NULL
+    )
+    HAVING COUNT(*) > 1
+''').render(project=project_id,
+            new_dataset=new_dataset,
+            sandbox_dataset=sandbox_dataset)
+
+df = execute(client, query)
+issues = df.issue
+
+success_null_check = (
+    f"All records in {new_dataset}.observation have corresponding records in "
+    f"{sandbox_dataset}._observation_id_map and vice versa.<br><br>")
+failure_null_check = (
+    f"Issue(s) found: {', '.join(issues)}. Look at the result table below. <br>"
+    "investigate why they are inconsistent.<br><br>")
+
+render_message(df, success_null_check, failure_null_check)
+# -
+
+# ## QC 2-3. Confirm all the sandboxed `OBSERVATION` records have new records populated in `new_dataset`
+# We must confirm all the sandboxed `OBSERVATION` records have new records in `new_dataset`.
+# We can do so by looking at `OBSERVATION_SOURCE_CONCEPT_ID` and `PERSON_ID`. We cannot use `OBSERVATION_ID`
+# here because old-OBSERVATION_ID:new-OBSERVATION_ID can be 1:N, N:1, and N:N. (Not always 1:1)
+
+# +
+query = JINJA_ENV.from_string('''
+    SELECT COUNT(*) AS unmatched_records
+    FROM `{{project}}.{{sandbox_dataset}}.{{sandbox_obs}}` m
+    WHERE NOT EXISTS (
+        SELECT 1 FROM `{{project}}.{{new_dataset}}.observation` o
+        WHERE m.person_id = o.person_id
+        AND m.observation_source_concept_id = o.observation_source_concept_id
+    )
+    HAVING COUNT(*) > 0
+''').render(project=project_id,
+            new_dataset=new_dataset,
+            sandbox_dataset=sandbox_dataset,
+            sandbox_obs=sandbox_obs)
+
+df = execute(client, query)
+unmatched_records = df.unmatched_records[0]
+
+success_null_check = (
+    f"All the sandboxed records in {sandbox_dataset}.{sandbox_obs} have new records "
+    f"in {new_dataset}.observation.<br><br>")
+failure_null_check = (
+    f"There are <b>{unmatched_records}</b> sandboxed observation records that did not "
+    f"get populated in {new_dataset}. <br>investigate why they are inconsistent.<br><br>"
+)
+
+render_message(df, success_null_check, failure_null_check)
+# -
+
+# ## QC 3. Confirm mapping/ext tables are consistent
+# This hotfix runs several delete and insert statements to OBSERVATION, SURVEY_CONDUCT, PERSON
+# and their mapping/ext tables. <br>We must confirm that mapping/ext tables are consistent with
+# their correspondants after the hotfix.
+
+# +
+if is_rdr_dataset(new_dataset):
+    success_msg = "Skipping this check because RDR dataset does not have mapping/ext tables.<br><br>"
+    render_message('', success_msg=success_msg)
+
+else:
+    if is_combined_release_dataset(new_dataset):
+        map_ext_tuples = [
+            (OBSERVATION, mapping_table_for(OBSERVATION)),
+            (OBSERVATION, ext_table_for(OBSERVATION)),
+            (SURVEY_CONDUCT, mapping_table_for(SURVEY_CONDUCT)),
+            (SURVEY_CONDUCT, ext_table_for(SURVEY_CONDUCT)),
+        ]
+    elif is_deid_dataset(new_dataset):
+        map_ext_tuples = [
+            (OBSERVATION, ext_table_for(OBSERVATION)),
+            (SURVEY_CONDUCT, ext_table_for(SURVEY_CONDUCT)),
+            (PERSON, ext_table_for(PERSON)),
+        ]
+    else:
+        map_ext_tuples = [
+            (OBSERVATION, mapping_table_for(OBSERVATION)),
+            (SURVEY_CONDUCT, mapping_table_for(SURVEY_CONDUCT)),
+        ]
+
+    query = JINJA_ENV.from_string('''
+        SELECT
+            \'{{mapping_table}}\' as table_name,
+            COUNT(*) AS unmatched_ids
+        FROM `{{project}}.{{new_dataset}}.{{table_name}}` d
+        FULL OUTER JOIN `{{project}}.{{new_dataset}}.{{mapping_table}}` mp
+        USING ({{table_name}}_id)
+        WHERE d.{{table_name}}_id IS NULL OR mp.{{table_name}}_id IS NULL
+        HAVING COUNT(*) > 0
+    ''')
+
+    queries = []
+    for (table, mapping_table) in map_ext_tuples:
+        queries.append(
+            query.render(project=project_id,
+                         new_dataset=new_dataset,
+                         table_name=table,
+                         mapping_table=mapping_table))
+    union_all_query = '\nUNION ALL\n'.join(queries)
+
+    df = execute(client, union_all_query)
+
+    success_null_check = (
+        "All OBSERVATION, SURVEY_CONDUCT, and PERSON records have "
+        "valid corresponding records in their mapping/ext tables. <br>"
+        "And there are no invalid records in the mapping/ext tables.")
+    failure_null_check = (
+        "These mapping/ext tables are inconsistent with their "
+        "correspondants. <br>Look at these tables and investigate why "
+        "they are inconsistent: <b>{tables}</b><br><br>")
+
+    render_message(df,
+                   success_null_check,
+                   failure_null_check,
+                   failure_msg_args={'tables': ', '.join(df.table_name)})
+
+# -
+
+# ## QC 4-1. (Only for deid base/clean) Confirm `person_ext`'s state related columns come from `source_dataset` <br>- Check against entire `new_dataset`
+# `state_of_residence_concept_id` and `state_of_residence_source_value` in `incremental_dataset.person_ext` are
+# all NULL. This is because these two columns do not originate from the basics. <br>To have a complete `new_dataset.person_ext`,
+# we must pull these columns from `source_dataset`, not from `incremental_dataset`.<br>
+# If this QC fails, see how QC 4-2 goes.
+
+# +
+if not is_deid_release_dataset(new_dataset):
+    success_msg = "Skipping this check person_ext table exists only in deid base/clean datasets.<br>"
+    render_message('', success_msg=success_msg)
+
+else:
+    query = JINJA_ENV.from_string('''
+        SELECT *
+        FROM `{{project}}.{{new_dataset}}.person_ext` n
+        JOIN `{{project}}.{{source_dataset}}.person_ext` s
+        ON n.person_id = s.person_id
+        WHERE (
+            n.state_of_residence_concept_id != s.state_of_residence_concept_id
+            OR n.state_of_residence_source_value != s.state_of_residence_source_value
+        )
+        OR (
+            (n.state_of_residence_concept_id IS NULL AND s.state_of_residence_concept_id IS NOT NULL)
+            OR (n.state_of_residence_source_value IS NULL AND s.state_of_residence_source_value IS NOT NULL)
+        )
+    ''').render(project=project_id,
+                new_dataset=new_dataset,
+                source_dataset=source_dataset)
+
+    df = execute(client, query)
+
+    success_null_check = (
+        f"All state columns in {new_dataset}.person_ext come from {source_dataset}, "
+        f"not {incremental_dataset}.<br><br>")
+    failure_null_check = (
+        f"There are <b>{len(df)}</b> records in {new_dataset}.person_ext that have "
+        f"unmatching state columns from {source_dataset}. <br>Look at the table and "
+        "investigate why they are inconsistent. <br><b>QC 4-2 will help narrow down "
+        "the potential cause of the issue.</b><br><br>")
+
+    render_message(df, success_null_check, failure_null_check)
+
+# -
+
+# ## QC 4-2. (Only for deid base/clean) Confirm `person_ext`'s state related columns come from `source_dataset` <br>- Check against records from `incremental_dataset`
+# If QC 4-1 fails, this QC will be helpful for troubleshooting. This QC checks the same thing as 4-1, but the scope is limited to only the participants from `incremental_dataset`.<br>
+# If QC 4-1 fails but 4-2 is successful, that means the issue comes from the original dataset, not from the incremental dataset. If both 4-1 and 4-2 fail, that means
+# something related to the incremental dataset did not work as expected.
+
+# +
+if not is_deid_release_dataset(new_dataset):
+    success_msg = "Skipping this check person_ext table exists only in deid base/clean datasets.<br>"
+    render_message('', success_msg=success_msg)
+
+else:
+    query = JINJA_ENV.from_string('''
+        SELECT *
+        FROM `{{project}}.{{new_dataset}}.person_ext` n
+        JOIN `{{project}}.{{source_dataset}}.person_ext` s
+        ON n.person_id = s.person_id
+        WHERE n.person_id IN (
+            SELECT person_id FROM `{{project}}.{{incremental_dataset}}.person`
+            WHERE person_id IS NOT NULL
+        )
+        AND (
+            (
+                n.state_of_residence_concept_id != s.state_of_residence_concept_id
+                OR n.state_of_residence_source_value != s.state_of_residence_source_value
+            ) OR (
+                (n.state_of_residence_concept_id IS NULL AND s.state_of_residence_concept_id IS NOT NULL)
+                OR (n.state_of_residence_source_value IS NULL AND s.state_of_residence_source_value IS NOT NULL)
+            )
+        )
+    ''').render(project=project_id,
+                new_dataset=new_dataset,
+                incremental_dataset=incremental_dataset,
+                source_dataset=source_dataset)
+
+    df = execute(client, query)
+
+    success_null_check = (
+        f"All records in {new_dataset}.person_ext affected by the hotfix have correct state columns.<br> "
+        f"If QC 4-1 failed, we can be sure the problem came from the original data in {source_dataset}, "
+        f"not by the hotfix.<br><br>")
+    failure_null_check = (
+        f"There are <b>{len(df)}</b> records in {new_dataset}.person_ext that are affected by the hotfix "
+        f"and still have unmatching state columns from {source_dataset}. <br>Look at the table and "
+        "investigate why they are inconsistent.<br><br>")
+
+    render_message(df, success_null_check, failure_null_check)
+
+# -
+
+# ## QC 5-1. Confirm `SURVEY_CONDUCT` - `OBSERVATION` relationship is still intact
+# This hotfix runs delete and insert on both `SURVEY_CONDUCT` and `OBSERVATION`. <br>
+# `survey_conduct_id` must have corresponding `questionnaire_response_id` in `OBSERVATION`
+# and vice versa. <br>
+# This QC confirms the relationship between `SURVEY_CONDUCT`and `OBSERVATION` are still complete
+# after the hotfix.
+
+# +
+query = JINJA_ENV.from_string('''
+    SELECT 'orphaned survey_conduct_id' AS issue, COUNT(*) 
+    FROM `{{project}}.{{new_dataset}}.survey_conduct`
+    WHERE survey_conduct_id NOT IN (
+        SELECT questionnaire_response_id FROM `{{project}}.{{new_dataset}}.observation`
+        WHERE questionnaire_response_id IS NOT NULL
+    )
+    HAVING COUNT(*) > 0
+    UNION ALL
+    SELECT 'orphaned questionnaire_response_id' AS issue, COUNT(*) 
+    FROM `{{project}}.{{new_dataset}}.observation`
+    WHERE questionnaire_response_id NOT IN (
+        SELECT survey_conduct_id FROM `{{project}}.{{new_dataset}}.survey_conduct`
+        WHERE survey_conduct_id IS NOT NULL
+    )
+    HAVING COUNT(*) > 0
+    ''').render(project=project_id, new_dataset=new_dataset)
+
+df = execute(client, query)
+issues = df.issue
+
+success_null_check = (
+    f"All records in {new_dataset}.survey_conduct have corresponding records in "
+    f"{new_dataset}.observation and vice versa.<br><br>")
+failure_null_check = (
+    f"Issue(s) found: {', '.join(issues)}. Look at the result table below. <br>"
+    "investigate why they are inconsistent.<br><br>")
+
+render_message(df, success_null_check, failure_null_check)
+
+# -
+
+# ## QC 5-2. How many new `questionnaire_response_id`s and `survey_conduct_id`s came from the "incremental"
+# This is a supplemental check. There is no success/failure for it. <br>
+# This QC shows how many new `questionnaire_response_id`s and `survey_conduct_id`s are introduced
+# to `new_dataset` from `incremental_dataset`.
+# <b>The new questionnaire_response_ids and survey_conduct_ids should be the same.</b>
+
+# +
+query = JINJA_ENV.from_string('''
+    WITH qrid AS (
+        SELECT 
+            COUNT(DISTINCT questionnaire_response_id) AS num_new_id
+        FROM `{{project}}.{{new_dataset}}.observation`
+        WHERE questionnaire_response_id NOT IN (
+            SELECT DISTINCT questionnaire_response_id
+            FROM `{{project}}.{{source_dataset}}.observation`
+            WHERE questionnaire_response_id IS NOT NULL
+        )
+    ), scid AS (
+        SELECT 
+            COUNT(DISTINCT survey_conduct_id) AS num_new_id
+        FROM `{{project}}.{{new_dataset}}.survey_conduct`
+        WHERE survey_conduct_id NOT IN (
+            SELECT DISTINCT survey_conduct_id
+            FROM `{{project}}.{{source_dataset}}.survey_conduct`
+            WHERE survey_conduct_id IS NOT NULL
+        )
+    )
+    SELECT
+        qrid.num_new_id AS new_questionnaire_response_ids,
+        scid.num_new_id AS new_survey_conduct_ids
+    FROM qrid CROSS JOIN scid
+    ''').render(project=project_id,
+                new_dataset=new_dataset,
+                source_dataset=source_dataset)
+
+df = execute(client, query)
+new_questionnaire_response_ids, new_survey_conduct_ids = df.new_questionnaire_response_ids[
+    0], df.new_survey_conduct_ids[0]
+
+check_status = "Cannot tell success or failure. Check the result."
+msg = (
+    f"There are <b>{new_questionnaire_response_ids}</b> questionnaire_response_ids added as a result of the hotfix. <br>"
+    f"There are <b>{new_survey_conduct_ids}</b> survey_conducts added as a result of the hotfix. <br>"
+    "<b>These numbers should be the same.</b> <br>"
+    "If these numbers look off, investigate.<br><br>")
+
+display(
+    HTML(f'''<br>
+        <h3>Check Status: <span style="color: gold">{check_status}</span></h3>
+        <p>{msg}</p>
+    '''))
+df
+
+# -
+
+# ## QC 6. Confirm most of "missing basics" issues are remediated
+# This hotfix will fix the "missing basics" problem. But not all "missing basics"
+# will be fixed. <br>This QC is to see how much of the problem is resolved.
+# (We do not have a specific number for this check to succeed/fail.)<br>
+# We must re-assess our hotfix if unresolved "missing basics" are still way too many.
+
+# +
+query = JINJA_ENV.from_string('''
+    WITH new_missing AS (
+        SELECT COUNT(DISTINCT person_id) AS count_missing_basics
+        FROM `{{project}}.{{new_dataset}}.person`
+        WHERE person_id NOT IN
+        (
+            SELECT DISTINCT person_id
+            FROM `{{project}}.{{new_dataset}}.concept` 
+            JOIN `{{project}}.{{new_dataset}}.concept_ancestor`
+                ON concept_id = ancestor_concept_id
+            JOIN `{{project}}.{{new_dataset}}.observation`
+                ON descendant_concept_id = observation_concept_id
+            WHERE observation_concept_id NOT IN (40766240, 43528428, 1585389)
+            AND concept_class_id = 'Module'
+            AND concept_name IN ('The Basics') 
+            AND questionnaire_response_id is not null
+            AND observation_source_value NOT LIKE 'Second%' 
+            AND observation_source_value NOT LIKE 'PersonOne%'
+            AND observation_source_value NOT LIKE 'SocialSecurity%'
+        )
+    ), source_missing AS (
+        SELECT COUNT(DISTINCT person_id) AS count_missing_basics
+        FROM `{{project}}.{{source_dataset}}.person`
+        WHERE person_id NOT IN
+        (
+            SELECT DISTINCT person_id
+            FROM `{{project}}.{{source_dataset}}.concept` 
+            JOIN `{{project}}.{{source_dataset}}.concept_ancestor`
+                ON concept_id = ancestor_concept_id
+            JOIN `{{project}}.{{source_dataset}}.observation`
+                ON descendant_concept_id = observation_concept_id
+            WHERE observation_concept_id NOT IN (40766240, 43528428, 1585389)
+            AND concept_class_id = 'Module'
+            AND concept_name IN ('The Basics') 
+            AND questionnaire_response_id is not null
+            AND observation_source_value NOT LIKE 'Second%' 
+            AND observation_source_value NOT LIKE 'PersonOne%'
+            AND observation_source_value NOT LIKE 'SocialSecurity%'
+        )
+    ), new_all AS (
+        SELECT COUNT(*) AS count_new_all
+        FROM `{{project}}.{{new_dataset}}.person`
+    ), source_all AS (
+        SELECT COUNT(*) AS count_source_all
+        FROM `{{project}}.{{source_dataset}}.person`        
+    )
+    SELECT 
+        new_missing.count_missing_basics AS remaining_missing_basics,
+        source_missing.count_missing_basics AS original_missing_basics,
+        new_all.count_new_all AS count_new_all,
+        source_all.count_source_all AS count_source_all,
+        ROUND(source_missing.count_missing_basics / source_all.count_source_all * 100, 1) AS original_missing_percent,
+        ROUND(new_missing.count_missing_basics / new_all.count_new_all * 100, 1) AS remaining_missing_percent,
+        source_missing.count_missing_basics - new_missing.count_missing_basics AS remediated_missing_basics
+    FROM new_missing 
+    CROSS JOIN source_missing
+    CROSS JOIN new_all
+    CROSS JOIN source_all
+''').render(project=project_id,
+            new_dataset=new_dataset,
+            source_dataset=source_dataset)
+
+df = execute(client, query)
+(remaining_missing_basics, original_missing_basics, count_new_all,
+ count_source_all, original_missing_percent, remaining_missing_percent,
+ remediated_missing_basics) = (df.remaining_missing_basics[0],
+                               df.original_missing_basics[0],
+                               df.count_new_all[0], df.count_source_all[0],
+                               df.original_missing_percent[0],
+                               df.remaining_missing_percent[0],
+                               df.remediated_missing_basics[0])
+
+check_status = "Cannot tell success or failure. Check the result."
+msg = (
+    f"Originally there were <b>{original_missing_basics}</b> participants "
+    f"(<b>{original_missing_percent}% of {count_source_all} participants</b>) who had missing basics. <br>"
+    f"We successfully remediated <b>{remediated_missing_basics}</b> participants with this hotfix. <br>"
+    f"There are still <b>{remaining_missing_basics}</b> participants "
+    f"(<b>{remaining_missing_percent}% of {count_new_all} participants</b>) who miss their basics. <br>"
+    f"If <b>{remaining_missing_basics}</b> seems too high, re-assess our hotfix and ensure "
+    "we are not missing anything.<br><br>")
+
+display(
+    HTML(f'''<br>
+        <h3>Check Status: <span style="color: gold">{check_status}</span></h3>
+        <p>{msg}</p>
+    '''))
+df
+
+# -

--- a/data_steward/analytics/cdr_ops/incremental_load_qc.py
+++ b/data_steward/analytics/cdr_ops/incremental_load_qc.py
@@ -27,6 +27,7 @@ sandbox_obs: str = ""  # sandbox table for observation used for this hotfix
 aian_lookup_dataset: str = ""  # dataset where we have aian lookup table
 aian_lookup_table: str = ""  # table that has PIDs/RIDs of AIAN participants
 incremental_dataset: str = ""  # dataset so-called "incremental"
+obs_id_lookup_dataset: str = ""  # dataset that has NEW_OBS_ID_LOOKUP table.
 includes_aian: str = ""  # True if AIAN participants' data is in the dataset, False if not
 # -
 
@@ -162,19 +163,19 @@ render_message(df,
 # ## QC 2-2. Confirm all new records in `OBSERVATION` have mapping info in `_observation_id_map`
 # Any observation records from `incremental_dataset` got new `OBSERVATION_ID`s
 # assigned in `new_dataset` to avoid ID duplicates. The mapping of the old-new
-# `OBSERVATION_ID`s is kept in `sandbox._observation_id_map`. <br>We must confirm
-# all the new `OBSERVATION_ID`s have their mapping info in `sandbox._observation_id_map`<br>.
+# `OBSERVATION_ID`s is kept in `obs_id_lookup_dataset._observation_id_map`. <br>We must confirm
+# all the new `OBSERVATION_ID`s have their mapping info in `obs_id_lookup_dataset._observation_id_map`<br>.
 # NOTE: Not all records in `_observation_id_map` have corresponding records in `new_dataset`
 # because `_observation_id_map` is referenced by multiple data releases.
 
 # +
 query = JINJA_ENV.from_string('''
     SELECT
-        'no mapping record found in sandbox._observation_id_map' AS issue,
+        'no mapping record found in obs_id_lookup_dataset._observation_id_map' AS issue,
         COUNT(*) AS no_mapping_row_count
     FROM `{{project}}.{{new_dataset}}.observation`
     WHERE observation_id NOT IN (
-        SELECT observation_id FROM `{{project}}.{{sandbox_dataset}}._observation_id_map`
+        SELECT observation_id FROM `{{project}}.{{obs_id_lookup_dataset}}._observation_id_map`
         WHERE observation_id IS NOT NULL
     )
     HAVING COUNT(*) > 1
@@ -187,7 +188,7 @@ issues = df.issue
 
 success_null_check = (
     f"All records in {new_dataset}.observation have corresponding records in "
-    f"{sandbox_dataset}._observation_id_map and vice versa.<br><br>")
+    f"{obs_id_lookup_dataset}._observation_id_map and vice versa.<br><br>")
 failure_null_check = (
     f"Issue(s) found: {', '.join(issues)}. Look at the result table below. <br>"
     "investigate why they are inconsistent.<br><br>")

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -13,6 +13,27 @@ import resources
 logger = logging.getLogger(__name__)
 
 
+def get_parser():
+
+    parser = argparse.ArgumentParser(
+        description='Parse project_id and dataset_id',
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        'dataset_id', help='Identifies the dataset to create OMOP table(s) in')
+
+    mutex = parser.add_mutually_exclusive_group(required=True)
+    mutex.add_argument(
+        '--table',
+        help='A specific CDM table to create (creates all by default)',
+        choices=list(resources.CDM_TABLES))
+    mutex.add_argument('--component',
+                         help='Subset of CDM tables to create',
+                         choices=list(common.CDM_COMPONENTS))
+
+    return parser
+
+
 def tables_to_map():
     """
     Determine which CDM tables must have ids remapped
@@ -69,28 +90,18 @@ def create_all_tables(dataset_id):
 
 if __name__ == '__main__':
     # TODO parse args, support multiple commands
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument(
-        '--table',
-        help='A specific CDM table to create (creates all by default)',
-        choices=list(resources.CDM_TABLES))
-    parser.add_argument('--component',
-                        help='Subset of CDM tables to create',
-                        choices=list(common.CDM_COMPONENTS))
-    parser.add_argument(
-        'dataset_id', help='Identifies the dataset to create OMOP table(s) in')
+    parser = get_parser()
     args = parser.parse_args()
+
     if args.table:
-        if args.component:
-            raise RuntimeError('Cannot process both table and component')
         create_table(args.table, args.dataset_id)
+    elif args.component == common.VOCABULARY:
+        create_vocabulary_tables(args.dataset_id)
+    elif args.component == common.ACHILLES:
+        # TODO implement creating achilles tables; need to fix interdependency of common, resource_files, cdm
+        raise NotImplementedError(
+            'Creating achilles tables not yet implemented')
     elif args.component:
-        if args.component == common.VOCABULARY:
-            create_vocabulary_tables(args.dataset_id)
-        elif args.component == common.ACHILLES:
-            # TODO implement creating achilles tables; need to fix interdependency of common, resource_files, cdm
-            raise NotImplementedError(
-                'Creating achilles tables not yet implemented')
+        pass
     else:
         create_all_tables(args.dataset_id)

--- a/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics.py
+++ b/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics.py
@@ -14,9 +14,10 @@ import logging
 # Project imports
 from common import (JINJA_ENV, OBSERVATION, PERSON, SURVEY_CONDUCT)
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule
-from constants.cdr_cleaner.clean_cdr import (COMBINED,
+from constants.cdr_cleaner.clean_cdr import (COMBINED, CONTROLLED_TIER_DEID,
                                              CONTROLLED_TIER_DEID_BASE,
                                              CONTROLLED_TIER_DEID_CLEAN, QUERY,
+                                             RDR, REGISTERED_TIER_DEID,
                                              REGISTERED_TIER_DEID_BASE,
                                              REGISTERED_TIER_DEID_CLEAN)
 from resources import ext_table_for, mapping_table_for
@@ -129,9 +130,17 @@ SELECT
 FROM `{{project}}.{{incremental_dataset}}.{{table}}` inc_o
 JOIN `{{project}}.{{obs_id_lookup_dataset}}.{{new_obs_id_lookup}}` new_id
 ON inc_o.observation_id = new_id.source_observation_id
-WHERE inc_o.person_id IN (
-    SELECT person_id FROM `{{project}}.{{dataset}}.{{table}}` 
+WHERE inc_o.person_id IN ( -- Include only existing participants --
+    SELECT DISTINCT person_id
+    FROM `{{project}}.{{dataset}}.person`
 )
+{% if exclude_lookup_dataset and exclude_lookup_table %}
+AND inc_o.person_id NOT IN (
+    SELECT 
+        {% if is_deid %} research_id {% else %} person_id {% endif %}
+    FROM `{{project}}.{{exclude_lookup_dataset}}.{{exclude_lookup_table}}` 
+)
+{% endif %}
 """)
 
 INSERT_OBS_MAPPING = JINJA_ENV.from_string("""
@@ -147,11 +156,22 @@ FROM `{{project}}.{{incremental_dataset}}.{{table}}` i
 JOIN `{{project}}.{{obs_id_lookup_dataset}}.{{new_obs_id_lookup}}` oim
 ON i.observation_id = oim.source_observation_id
 WHERE i.observation_id IN (
-    SELECT observation_id FROM `{{project}}.{{incremental_dataset}}.observation`
-    WHERE person_id IN (
-        SELECT person_id FROM `{{project}}.{{dataset}}.person` 
+    SELECT observation_id FROM `{{project}}.{{incremental_dataset}}.{{domain}}`
+    WHERE person_id IN ( -- Include only existing participants --
+        SELECT DISTINCT person_id
+        FROM `{{project}}.{{dataset}}.person`
     )
 )
+{% if exclude_lookup_dataset and exclude_lookup_table %}
+AND i.observation_id IN (
+    SELECT observation_id FROM `{{project}}.{{incremental_dataset}}.{{domain}}`
+    WHERE person_id NOT IN (
+        SELECT 
+            {% if is_deid %} research_id {% else %} person_id {% endif %}
+        FROM `{{project}}.{{exclude_lookup_dataset}}.{{exclude_lookup_table}}` 
+    )
+)
+{% endif %}
 """)
 
 INSERT_OBS_EXT = JINJA_ENV.from_string("""
@@ -165,11 +185,22 @@ FROM `{{project}}.{{incremental_dataset}}.{{table}}` i
 JOIN `{{project}}.{{obs_id_lookup_dataset}}.{{new_obs_id_lookup}}` oim
 ON i.observation_id = oim.source_observation_id
 WHERE i.observation_id IN (
-    SELECT observation_id FROM `{{project}}.{{incremental_dataset}}.observation`
-    WHERE person_id IN (
-        SELECT person_id FROM `{{project}}.{{dataset}}.person` 
+    SELECT observation_id FROM `{{project}}.{{incremental_dataset}}.{{domain}}`
+    WHERE person_id IN ( -- Include only existing participants --
+        SELECT DISTINCT person_id
+        FROM `{{project}}.{{dataset}}.person`
     )
 )
+{% if exclude_lookup_dataset and exclude_lookup_table %}
+AND i.observation_id IN (
+    SELECT observation_id FROM `{{project}}.{{incremental_dataset}}.{{domain}}`
+    WHERE person_id NOT IN (
+        SELECT 
+            {% if is_deid %} research_id {% else %} person_id {% endif %}
+        FROM `{{project}}.{{exclude_lookup_dataset}}.{{exclude_lookup_table}}` 
+    )
+)
+{% endif %}
 """)
 
 # NOTE Due to the incremental dataset's setup, state_of_residence_concept_id and
@@ -183,21 +214,64 @@ SELECT
     i.person_id,
     i.src_id,
     sb.state_of_residence_concept_id,
-    sb.state_of_residence_source_value,    
+    sb.state_of_residence_source_value,
     i.sex_at_birth_concept_id,
     i.sex_at_birth_source_concept_id,
     i.sex_at_birth_source_value
 FROM `{{project}}.{{incremental_dataset}}.{{table}}` i
-JOIN `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` sb
+LEFT JOIN `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` sb
 ON i.person_id = sb.person_id
+WHERE i.person_id IN ( -- Include only existing participants --
+    SELECT DISTINCT person_id
+    FROM `{{project}}.{{dataset}}.person`
+)
+{% if exclude_lookup_dataset and exclude_lookup_table %}
+AND i.person_id NOT IN (
+    SELECT 
+        {% if is_deid %} research_id {% else %} person_id {% endif %}
+    FROM `{{project}}.{{exclude_lookup_dataset}}.{{exclude_lookup_table}}` 
+)
+{% endif %}
 """)
 
 GENERIC_INSERT = JINJA_ENV.from_string("""
 INSERT INTO `{{project}}.{{dataset}}.{{table}}`
 SELECT * FROM `{{project}}.{{incremental_dataset}}.{{table}}`
-WHERE {{domain}}_id IN (
-    SELECT {{domain}}_id FROM `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}` 
+WHERE person_id IN ( -- Include only existing participants --
+    SELECT DISTINCT person_id
+    FROM 
+        {% if table=='person' %} `{{project}}.{{sandbox_dataset}}.{{sandbox_table}}`
+        {% else %} `{{project}}.{{dataset}}.person` {% endif %}
 )
+{% if exclude_lookup_dataset and exclude_lookup_table %}
+AND person_id NOT IN (
+    SELECT 
+        {% if is_deid %} research_id {% else %} person_id {% endif %}
+    FROM `{{project}}.{{exclude_lookup_dataset}}.{{exclude_lookup_table}}` 
+)
+{% endif %}
+""")
+
+GENERIC_INSERT_MAP_EXT = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.{{table}}`
+SELECT * FROM `{{project}}.{{incremental_dataset}}.{{table}}`
+WHERE {{domain}}_id IN (
+    SELECT {{domain}}_id FROM `{{project}}.{{incremental_dataset}}.{{domain}}`
+    WHERE person_id IN ( -- Include only existing participants --
+        SELECT DISTINCT person_id
+        FROM `{{project}}.{{dataset}}.person`
+    )
+)
+{% if exclude_lookup_dataset and exclude_lookup_table %}
+AND {{domain}}_id IN (
+    SELECT {{domain}}_id FROM `{{project}}.{{incremental_dataset}}.{{domain}}`
+    WHERE person_id NOT IN (
+        SELECT 
+            {% if is_deid %} research_id {% else %} person_id {% endif %}
+        FROM `{{project}}.{{exclude_lookup_dataset}}.{{exclude_lookup_table}}` 
+    )
+)
+{% endif %}
 """)
 
 OBS_MAPPING = mapping_table_for(OBSERVATION)
@@ -219,6 +293,8 @@ class RemediateBasics(BaseCleaningRule):
                  incremental_dataset_id=None,
                  obs_id_lookup_dataset=None,
                  dataset_with_largest_observation_id=None,
+                 exclude_lookup_dataset=None,
+                 exclude_lookup_table=None,
                  table_namer=None):
         """
         Initialize the class with proper information.
@@ -233,9 +309,10 @@ class RemediateBasics(BaseCleaningRule):
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
                          affected_datasets=[
-                             COMBINED, CONTROLLED_TIER_DEID_BASE,
-                             CONTROLLED_TIER_DEID_CLEAN,
-                             REGISTERED_TIER_DEID_BASE,
+                             COMBINED, CONTROLLED_TIER_DEID,
+                             CONTROLLED_TIER_DEID_BASE,
+                             CONTROLLED_TIER_DEID_CLEAN, RDR,
+                             REGISTERED_TIER_DEID, REGISTERED_TIER_DEID_BASE,
                              REGISTERED_TIER_DEID_CLEAN
                          ],
                          affected_tables=[
@@ -250,6 +327,8 @@ class RemediateBasics(BaseCleaningRule):
         self.incremental_dataset_id = incremental_dataset_id
         self.dataset_with_largest_observation_id = dataset_with_largest_observation_id
         self.obs_id_lookup_dataset = obs_id_lookup_dataset
+        self.exclude_lookup_dataset = exclude_lookup_dataset
+        self.exclude_lookup_table = exclude_lookup_table
 
     def _get_query(self, template, domain, table) -> dict:
         """
@@ -276,7 +355,10 @@ class RemediateBasics(BaseCleaningRule):
                     new_obs_id_lookup=NEW_OBS_ID_LOOKUP,
                     dataset_with_largest_observation_id=self.
                     dataset_with_largest_observation_id,
-                    obs_id_lookup_dataset=self.obs_id_lookup_dataset)
+                    obs_id_lookup_dataset=self.obs_id_lookup_dataset,
+                    exclude_lookup_dataset=self.exclude_lookup_dataset,
+                    exclude_lookup_table=self.exclude_lookup_table,
+                    is_deid=is_deid_dataset(self.dataset_id))
         }
 
     def get_query_specs(self):
@@ -288,10 +370,17 @@ class RemediateBasics(BaseCleaningRule):
             The specifications are optional but the query is required.
         """
 
+        # Operations for person table must run seperately because it is used
+        # for filtering existing participants in the JINJA teplates
+        person_queries = [
+            self._get_query(GENERIC_SANDBOX, PERSON, PERSON),
+            self._get_query(GENERIC_DELETE, PERSON, PERSON),
+            self._get_query(GENERIC_INSERT, PERSON, PERSON)
+        ]
+
         sandbox_queries = [
             self._get_query(SANDBOX_OBS, OBSERVATION, OBSERVATION),
-            self._get_query(GENERIC_SANDBOX, SURVEY_CONDUCT, SURVEY_CONDUCT),
-            self._get_query(GENERIC_SANDBOX, PERSON, PERSON)
+            self._get_query(GENERIC_SANDBOX, SURVEY_CONDUCT, SURVEY_CONDUCT)
         ]
 
         delete_queries = [
@@ -299,14 +388,12 @@ class RemediateBasics(BaseCleaningRule):
             for (domain, table) in [
                 (OBSERVATION, OBSERVATION),
                 (SURVEY_CONDUCT, SURVEY_CONDUCT),
-                (PERSON, PERSON),
             ]
         ]
 
         insert_queries = [
             self._get_query(INSERT_OBS, OBSERVATION, OBSERVATION),
             self._get_query(GENERIC_INSERT, SURVEY_CONDUCT, SURVEY_CONDUCT),
-            self._get_query(GENERIC_INSERT, PERSON, PERSON)
         ]
 
         # obs_ext and sc_ext exist in combined_release and deid datasets
@@ -322,7 +409,7 @@ class RemediateBasics(BaseCleaningRule):
             ])
             insert_queries.extend([
                 self._get_query(INSERT_OBS_EXT, OBSERVATION, OBS_EXT),
-                self._get_query(GENERIC_INSERT, SURVEY_CONDUCT, SC_EXT)
+                self._get_query(GENERIC_INSERT_MAP_EXT, SURVEY_CONDUCT, SC_EXT)
             ])
 
         # person_ext table exists only in deid base/clean datasets
@@ -348,10 +435,11 @@ class RemediateBasics(BaseCleaningRule):
             ])
             insert_queries.extend([
                 self._get_query(INSERT_OBS_MAPPING, OBSERVATION, OBS_MAPPING),
-                self._get_query(GENERIC_INSERT, SURVEY_CONDUCT, SC_MAPPING),
+                self._get_query(GENERIC_INSERT_MAP_EXT, SURVEY_CONDUCT,
+                                SC_MAPPING),
             ])
 
-        return sandbox_queries + delete_queries + insert_queries
+        return sandbox_queries + delete_queries + insert_queries + person_queries
 
     def setup_rule(self, client):
         """Create a lookup table for observation_id. New observation_ids need
@@ -405,6 +493,22 @@ if __name__ == '__main__':
                         dest='obs_id_lookup_dataset',
                         help=(f'Dataset for NEW_OBS_ID_LOOKUP table.'),
                         required=True)
+    parser.add_argument(
+        '--exclude_lookup_dataset',
+        action='store',
+        dest='exclude_lookup_dataset',
+        help=
+        (f'Dataset that has the PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
+        ),
+        required=False)
+    parser.add_argument(
+        '--exclude_lookup_table',
+        action='store',
+        dest='exclude_lookup_table',
+        help=
+        (f'PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
+        ),
+        required=False)
 
     ARGS = parser.parse_args()
 
@@ -419,7 +523,9 @@ if __name__ == '__main__':
             incremental_dataset_id=ARGS.incremental_dataset_id,
             dataset_with_largest_observation_id=ARGS.
             dataset_with_largest_observation_id,
-            obs_id_lookup_dataset=ARGS.obs_id_lookup_dataset)
+            obs_id_lookup_dataset=ARGS.obs_id_lookup_dataset,
+            exclude_lookup_dataset=ARGS.exclude_lookup_dataset,
+            exclude_lookup_table=ARGS.exclude_lookup_table)
         for query_dict in query_list:
             LOGGER.info(query_dict.get(QUERY))
     else:
@@ -430,4 +536,6 @@ if __name__ == '__main__':
             incremental_dataset_id=ARGS.incremental_dataset_id,
             dataset_with_largest_observation_id=ARGS.
             dataset_with_largest_observation_id,
-            obs_id_lookup_dataset=ARGS.obs_id_lookup_dataset)
+            obs_id_lookup_dataset=ARGS.obs_id_lookup_dataset,
+            exclude_lookup_dataset=ARGS.exclude_lookup_dataset,
+            exclude_lookup_table=ARGS.exclude_lookup_table)

--- a/data_steward/resources.py
+++ b/data_steward/resources.py
@@ -615,4 +615,4 @@ def get_new_dataset_name(src_dataset_name: str, release_tag: str) -> str:
         release_tag: Release tag for the new datasets.
     Returns: Name of the new dataset.
     """
-    return re.sub(r'\d{4}q\dr\d', release_tag, src_dataset_name)
+    return re.sub(r'\d{4}q[1-4]r\d{1,3}', release_tag, src_dataset_name)

--- a/data_steward/retraction/retract_utils.py
+++ b/data_steward/retraction/retract_utils.py
@@ -171,6 +171,17 @@ def is_deid_dataset(dataset_id):
     return DEID in dataset_id or is_deid_fitbit_dataset(dataset_id)
 
 
+def is_deid_release_dataset(dataset_id):
+    """
+    Returns boolean indicating if a dataset is a deid base/clean dataset using the dataset_id
+    :param dataset_id: Identifies the dataset
+    :return: Boolean indicating if the dataset is a deid base dataset
+    NOTE It returns True for deid_base/clean_xyz datasets too (e.g. deid_base_sandbox)
+    """
+    return DEID in dataset_id and ('base' in dataset_id or
+                                   'clean' in dataset_id)
+
+
 def is_combined_dataset(dataset_id):
     """
     Returns boolean indicating if a dataset is a combined dataset using the dataset_id
@@ -179,6 +190,15 @@ def is_combined_dataset(dataset_id):
     NOTE It returns True for combined_xyz datasets too (e.g. combined_staging)
     """
     return COMBINED in dataset_id
+
+
+def is_combined_release_dataset(dataset_id):
+    """
+    Returns boolean indicating if a dataset is a combined release dataset using the dataset_id
+    :param dataset_id: Identifies the dataset
+    :return: Boolean indicating if the dataset is a combined release dataset or not
+    """
+    return COMBINED in dataset_id and 'release' in dataset_id
 
 
 def is_deid_fitbit_dataset(dataset_id: str):

--- a/data_steward/tools/deid_runner.sh
+++ b/data_steward/tools/deid_runner.sh
@@ -12,8 +12,6 @@ Usage: deid_runner.sh
   --deid_questionnaire_response_map_dataset <deid questionnaire response map dataset name>
   --vocab_dataset <vocabulary dataset name>
   --dataset_release_tag <release tag for the CDR>
-  --cope_lookup_dataset_id <dataset where RDR provided cope survey mapping table is loaded>
-  --cope_table_name <name of the cope survey mapping table>
   --deid_max_age <integer maximum age for de-identified participants>
 "
 
@@ -47,14 +45,6 @@ while true; do
     dataset_release_tag=$2
     shift 2
     ;;
-  --cope_lookup_dataset_id)
-    cope_lookup_dataset_id=$2
-    shift 2
-    ;;
-  --cope_table_name)
-    cope_table_name=$2
-    shift 2
-    ;;
   --deid_max_age)
     deid_max_age=$2
     shift 2
@@ -69,8 +59,7 @@ done
 
 if [[ -z "${key_file}" ]] || [[ -z "${cdr_id}" ]] || [[ -z "${run_as}" ]] || [[ -z "${pmi_email}" ]] || \
    [[ -z "${deid_questionnaire_response_map_dataset}" ]] || [[ -z "${vocab_dataset}" ]] || \
-   [[ -z "${dataset_release_tag}" ]] || [[ -z "${cope_lookup_dataset_id}" ]] || \
-   [[ -z "${cope_table_name}" ]] || [[ -z "${deid_max_age}" ]]; then
+   [[ -z "${dataset_release_tag}" ]] || [[ -z "${deid_max_age}" ]]; then
   echo "${USAGE}"
   exit 1
 fi
@@ -123,8 +112,8 @@ bq mk --dataset --force --description "${version} sandbox dataset to apply clean
 unset GOOGLE_APPLICATION_CREDENTIALS
 gcloud config set account "${pmi_email}"
 
-# apply de-identification rules on registered tier dataset 
-python "${CLEANER_DIR}/clean_cdr.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --run_as "${run_as}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --data_stage ${data_stage} --mapping_dataset_id "${cdr_id}"  --cope_lookup_dataset_id "${cope_lookup_dataset_id}" --cope_table_name "${cope_table_name}" --deid_questionnaire_response_map_dataset "${deid_questionnaire_response_map_dataset}" -s 2>&1 | tee registered_tier_cleaning_log.txt
+# apply de-identification rules on registered tier dataset
+python "${CLEANER_DIR}/clean_cdr.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --run_as "${run_as}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --data_stage ${data_stage} --mapping_dataset_id "${cdr_id}" --deid_questionnaire_response_map_dataset "${deid_questionnaire_response_map_dataset}" -s 2>&1 | tee registered_tier_cleaning_log.txt
 
 # Add GOOGLE_APPLICATION_CREDENTIALS environment variable
 export GOOGLE_APPLICATION_CREDENTIALS="${key_file}"

--- a/data_steward/tools/run_basics_remediation.py
+++ b/data_steward/tools/run_basics_remediation.py
@@ -156,6 +156,22 @@ def parse_args(raw_args=None):
                         help=(f'Dataset for NEW_OBS_ID_LOOKUP table.'),
                         required=True)
     parser.add_argument(
+        '--exclude_lookup_dataset',
+        action='store',
+        dest='exclude_lookup_dataset',
+        help=
+        (f'Dataset that has the PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
+        ),
+        required=False)
+    parser.add_argument(
+        '--exclude_lookup_table',
+        action='store',
+        dest='exclude_lookup_table',
+        help=
+        (f'PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
+        ),
+        required=False)
+    parser.add_argument(
         '--new_release_tag',
         action='store',
         dest='new_release_tag',
@@ -243,7 +259,9 @@ def main():
                   incremental_dataset_id=args.incremental_dataset_id,
                   dataset_with_largest_observation_id=args.
                   dataset_with_largest_observation_id,
-                  obs_id_lookup_dataset=args.obs_id_lookup_dataset)
+                  obs_id_lookup_dataset=args.obs_id_lookup_dataset,
+                  exclude_lookup_dataset=args.exclude_lookup_dataset,
+                  exclude_lookup_table=args.exclude_lookup_table)
 
     LOGGER.info(f"Completed running remediation for {new_dataset}...")
 

--- a/data_steward/tools/run_basics_remediation.py
+++ b/data_steward/tools/run_basics_remediation.py
@@ -239,6 +239,7 @@ def main():
     clean_dataset(project_id,
                   new_dataset,
                   f"{tag}_sandbox", [(RemediateBasics,)],
+                  table_namer=f"dc3016_{new_dataset}",
                   incremental_dataset_id=args.incremental_dataset_id,
                   dataset_with_largest_observation_id=args.
                   dataset_with_largest_observation_id,

--- a/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
@@ -17,6 +17,34 @@ from common import OBSERVATION, PERSON, SURVEY_CONDUCT
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
 
+def mock_patch_decorator_bundle(*decorators):
+    """Since the test env's dataset names are different from the prod env's,
+    is_xyz_dataset() do not work as designed. So, they need to be patched for
+    the tests. This function bundles all the patches into one so we only need
+    to write one mock patch decorator for each test.
+    """
+
+    def _chain(patch):
+        for dec in reversed(decorators):
+            patch = dec(patch)
+        return patch
+
+    return _chain
+
+
+mock_patch_bundle = mock_patch_decorator_bundle(
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
+    ),
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset'),
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
+    ),
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset'))
+
+
 class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
 
     @classmethod
@@ -33,6 +61,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         cls.incremental_dataset_id = os.environ.get('BIGQUERY_DATASET_ID')
         cls.dataset_with_largest_observation_id = cls.dataset_id
         cls.obs_id_lookup_dataset = cls.sandbox_id
+        cls.exclude_lookup_dataset = cls.sandbox_id
+        cls.exclude_lookup_table = 'aian_participant'
 
         cls.kwargs.update(
             {'incremental_dataset_id': cls.incremental_dataset_id})
@@ -41,14 +71,12 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 cls.dataset_with_largest_observation_id
         })
         cls.kwargs.update({'obs_id_lookup_dataset': cls.obs_id_lookup_dataset})
+        cls.kwargs.update(
+            {'exclude_lookup_dataset': cls.exclude_lookup_dataset})
+        cls.kwargs.update({'exclude_lookup_table': cls.exclude_lookup_table})
 
-        cls.rule_instance = RemediateBasics(
-            cls.project_id,
-            cls.dataset_id,
-            cls.sandbox_id,
-            incremental_dataset_id=cls.incremental_dataset_id,
-            dataset_with_largest_observation_id=cls.
-            dataset_with_largest_observation_id)
+        cls.rule_instance = RemediateBasics(cls.project_id, cls.dataset_id,
+                                            cls.sandbox_id)
 
         for dataset in [cls.dataset_id, cls.incremental_dataset_id]:
             cls.fq_table_names.extend([
@@ -83,11 +111,19 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             f'{cls.project_id}.{cls.sandbox_id}.{NEW_OBS_ID_LOOKUP}'
         ]
 
+        cls.fq_exclusion_table = f'{cls.project_id}.{cls.exclude_lookup_dataset}.{cls.exclude_lookup_table}'
+
         super().setUpClass()
 
     def setUp(self):
         """
-        Create test table for the rule to run on
+        Create test tables for the rule to run on.
+
+        Test cases:
+        person_id==1: Exists in the original dataset but not in the incremental dataset. No change to this participant's records.
+        person_id==2: Exists both in the original dataset but in the incremental dataset. Records will be updated.
+        person_id==3: Does not exist in the original dataset but exists in the incremental dataset. Records will be ignored.
+        person_id==9: Same as 3, but listed in the exlude_lookup_table. Must be ignored when exlude_lookup_table is specified.
         """
 
         super().setUp()
@@ -123,7 +159,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (904, 2, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586147, 'WhatRaceEthnicity_Hispanic', 1002),  -- new ID: 209 --
                 (905, 2, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586146, 'WhatRaceEthnicity_White', 1002), -- new ID: 210 --
                 (906, 2, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586142, 'WhatRaceEthnicity_Asian', 1002), -- new ID: 211 --
-                (999, 9, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586142, 'WhatRaceEthnicity_Asian', 9999) -- new ID: 212 --
+                (907, 3, 1585845, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1585845, 1585846, 'SexAtBirth_Male', 1003), -- new ID: 212 (This new id will not be used anywhere but it is assigned anyway in the new_obs_id_lookup table) --
+                (999, 9, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586142, 'WhatRaceEthnicity_Asian', 9999) -- new ID: 213 --
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
                         obs=OBSERVATION)
@@ -155,6 +192,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (904, 'dummy_rdr_2', 94, 'rdr', 'observation'),
                 (905, 'dummy_rdr_2', 95, 'rdr', 'observation'),
                 (906, 'dummy_rdr_2', 96, 'rdr', 'observation'),
+                (907, 'dummy_rdr_2', 97, 'rdr', 'observation'),
                 (999, 'dummy_rdr_2', 99, 'rdr', 'observation')
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -187,6 +225,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (904, 'PPI/PM', NULL),
                 (905, 'PPI/PM', NULL),
                 (906, 'PPI/PM', NULL),
+                (907, 'PPI/PM', NULL),
                 (999, 'PPI/PM', NULL)
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -213,6 +252,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                  validated_survey_concept_id)
             VALUES
                 (1002, 2, 1586134, timestamp('2022-01-01 12:34:56'), 0, 0, 0, 42531021, 1586134, 1),
+                (1020, 2, 1586134, timestamp('2022-01-02 12:34:56'), 0, 0, 0, 42531021, 1586134, 1),
+                (1003, 3, 1586134, timestamp('2022-01-01 12:34:56'), 0, 0, 0, 42531021, 1586134, 1),
                 (9999, 9, 1586134, timestamp('2022-01-01 12:34:56'), 0, 0, 0, 42531021, 1586134, 0)
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -233,6 +274,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (survey_conduct_id, src_dataset_id, src_survey_conduct_id, src_hpo_id, src_table_id)
             VALUES
                 (1002, 'dummy_rdr_2', 1002, 'rdr', 'survey_conduct'),
+                (1020, 'dummy_rdr_2', 1020, 'rdr', 'survey_conduct'),
+                (1003, 'dummy_rdr_2', 1003, 'rdr', 'survey_conduct'),
                 (9999, 'dummy_rdr_2', 9999, 'rdr', 'survey_conduct')
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -253,6 +296,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (survey_conduct_id, src_id, language)
             VALUES
                 (1002, 'PPI/PM', 'es'),
+                (1020, 'PPI/PM', 'es'),
+                (1003, 'PPI/PM', 'es'),
                 (9999, 'PPI/PM', 'es')
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -275,8 +320,9 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             INSERT INTO `{{project}}.{{incremental_dataset}}.{{pers}}`
                 (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
             VALUES
-                (2, 1585839, 1995, 1585841, 38003563),
-                (9, 1585839, 1995, 1585841, 38003563)
+                (2, 1585839, 1995, 1585841, 38003563), -- existing in original --
+                (3, 1585839, 1995, 1585841, 38003563), -- new from incremental --
+                (9, 1585839, 1995, 1585841, 38003563)  -- new from incremental, must be excluded when exclude_lookup_table is present --
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
                         pers=PERSON)
@@ -295,11 +341,22 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             INSERT INTO `{{project}}.{{incremental_dataset}}.{{pers_ext}}`
                 (person_id, state_of_residence_concept_id, state_of_residence_source_value, sex_at_birth_source_concept_id)
             VALUES
-                (2, NULL, NULL, 1585846),
-                (9, NULL, NULL, 1585846)
+                (2, NULL, NULL, 1585846), -- existing in original --
+                (3, NULL, NULL, 1585846), -- new from incremental --
+                (9, NULL, NULL, 1585846)  -- new from incremental, must be excluded when exclude_lookup_table is present --
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
                         pers_ext=PERS_EXT)
+
+        create_exclusion_table = self.jinja_env.from_string("""
+        CREATE TABLE `{{fq_exclusion_table}}` (person_id INT64, research_id INT64)
+        """).render(fq_exclusion_table=self.fq_exclusion_table)
+
+        insert_exclusion_table = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_exclusion_table}}` (person_id, research_id)
+        VALUES
+        (9, 9)
+        """).render(fq_exclusion_table=self.fq_exclusion_table)
 
         self.load_test_data([
             insert_obs, insert_incremental_obs, insert_obs_mapping,
@@ -307,19 +364,11 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             insert_incremental_obs_ext, insert_sc, insert_incremental_sc,
             insert_sc_mapping, insert_incremental_sc_mapping, insert_sc_ext,
             insert_incremental_sc_ext, insert_pers, insert_incremental_pers,
-            insert_pers_ext, insert_incremental_pers_ext
+            insert_pers_ext, insert_incremental_pers_ext,
+            create_exclusion_table, insert_exclusion_table
         ])
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_combined_release(self, mock_is_rdr,
                                                mock_is_combined_release,
                                                mock_is_deid,
@@ -335,7 +384,9 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 203 ... Similar to 202, the same behavior even when the source value is 'PMI_Skip'.
                 204, 205 ... Those have multiple corresponding records (=904,905,906).
                              204 and 205 get dropped and 904, 905, and 906 get inserted.
-                * 901 - 999 become 206 - 212 respectively after re-mapping using NEW_OBS_ID_LOOKUP.
+                * 901 - 999 become 206 - 213 respectively after re-mapping using NEW_OBS_ID_LOOKUP.
+            person_id == 3:
+                This person is new. The records are ignored.
             person_id == 9 (observation_id 901 and 999):
                 This person only exists in the incremental dataset. Such data MUST NOT be included
                 in the final output. (e.g. AIAN participants are included in incremental_dataset while
@@ -344,11 +395,14 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         [2] SURVEY_CONDUCT and its ext/mapping tables
             survey_conduct_id = 1001 does not change.
             survey_conduct_id = 1002 gets sandboxed and updated since it exists in the incremental dataset.
+            survey_conduct_id = 1020 is a brand-new ID and inserted into final output.
+            survey_conduct_id = 1003 gets ignored because it belongs to person_id = 3
             survey_conduct_id = 9999 gets ignored because it belongs to person_id = 9
 
         [3] PERSON table
             person_id = 1 does not change.
             person_id = 2 gets sandboxed and updated since it exists in the incremental dataset.
+            person_id = 3 is a new person from the incremental dataset. Will be ignored.
             person_id = 9 gets ignored because it only exists in the incremental dataset.
 
         [4] PERSON_EXT table
@@ -397,7 +451,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1020, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_MAPPING}',
@@ -406,7 +460,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'src_dataset_id'],
-            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2')]
+            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2'),
+                               (1020, 'dummy_rdr_2')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
@@ -415,7 +470,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1020, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -433,16 +488,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_pers_ext}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_combined(self, mock_is_rdr,
                                        mock_is_combined_release, mock_is_deid,
                                        mock_is_deid_release):
@@ -492,7 +538,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1020, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_MAPPING}',
@@ -501,7 +547,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'src_dataset_id'],
-            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2')]
+            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2'),
+                               (1020, 'dummy_rdr_2')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -523,16 +570,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_ext}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_deid(self, mock_is_rdr, mock_is_combined_release,
                                    mock_is_deid, mock_is_deid_release):
         """Test to ensure RemediateBasics works as expected for DEID (= CT and RT) NOT BASE/CLEAN dataset.
@@ -542,15 +580,9 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         [2] SURVEY_CONDUCT and its ext table
             Same result as test_remediate_basics_combined_release
 
-        [3] PERSON and its ext table
-            person_id = 1 does not change.
-            person_id = 2 gets sandboxed and updated since it exists in the incremental dataset.
-                * state_of_residence_concept_id and state_of_residence_source_value will NOT change.
-            person_id = 9 gets ignored because it only exists in the incremental dataset.
-                Such data MUST NOT be included in the final output. (e.g. AIAN participants are 
-                included in incremental_dataset while the final output must not include AIAN 
-                participants for releases W/O AIAN)
-        
+        [3] PERSON table
+            Same result as test_remediate_basics_combined_release
+
         [4] PERSON_EXT table
             This table does not exist in deid dataset. No sandboxing/deleting/inserting will run on it.
 
@@ -587,7 +619,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1020, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
@@ -596,7 +628,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1020, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -618,16 +650,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_mapping}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_deid_release(self, mock_is_rdr,
                                            mock_is_combined_release,
                                            mock_is_deid, mock_is_deid_release):
@@ -638,16 +661,15 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         [2] SURVEY_CONDUCT and its ext table
             Same result as test_remediate_basics_combined_release
 
-        [3] PERSON and its ext table
-            person_id = 1 does not change.
-            person_id = 2 gets sandboxed and updated since it exists in the incremental dataset.
-                * state_of_residence_concept_id and state_of_residence_source_value will NOT change.
-            person_id = 9 gets ignored because it only exists in the incremental dataset.
-                Such data MUST NOT be included in the final output. (e.g. AIAN participants are 
-                included in incremental_dataset while the final output must not include AIAN 
-                participants for releases W/O AIAN)
+        [3] PERSON table
+            Same result as test_remediate_basics_combined_release
 
-        [4] OBSERVATION_MAPPING and SURVEY_CONDUCT_MAPPING tables
+        [4] PERSON_EXT table
+            Just like PERSON table...
+            1 stays the same, 2 is updated, 3 is inserted, and 9 is ignored.
+            3's state columns are NULL because it does not exist in the source dataset.
+
+        [5] OBSERVATION_MAPPING and SURVEY_CONDUCT_MAPPING tables
             These tables do not exist in deid dataset. No sandboxing/deleting/inserting will run on it.
         """
         mock_is_rdr.return_value, mock_is_combined_release.return_value, mock_is_deid.return_value, mock_is_deid_release.return_value = False, False, True, True
@@ -680,7 +702,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1020, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
@@ -689,7 +711,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1020, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -723,22 +745,13 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_mapping}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_rdr(self, mock_is_rdr, mock_is_combined_release,
                                   mock_is_deid, mock_is_deid_release):
         """Test to ensure RemediateBasics works as expected for RDR dataset.
         [1] OBSERVATION, SURVEY_CONDUCT, PERSON tables
             Same result as test_remediate_basics_combined_release
-        
+
         [2] mapping and ext tables
             These tables do not exist in rdr dataset. No sandboxing/deleting/inserting will run on it.
         """
@@ -762,7 +775,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1020, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -787,3 +800,156 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_ext}')
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_pers_ext}')
+
+    @mock_patch_bundle
+    def test_no_exclusion(self, mock_is_rdr, mock_is_combined_release,
+                          mock_is_deid, mock_is_deid_release):
+        """Test to ensure RemediateBasics works as expected when exclude_lookup_table and exclude_lookup_dataset
+        are not specified. Testing against COMBINED_RELEASE dataset.
+
+        Mostly same result as test_remediate_basics_combined_release.
+        Only the difference is this one includes person_id == 9 (observation_id 901 and 999) (survey_conduct_id 9999).
+        person_id==9 is in exclude_lookup_table but this table is not referenced in this test case.
+        """
+        # Unsetting exclude_lookup_xyz arguments.
+        self.kwargs.update({'exclude_lookup_dataset': None})
+        self.kwargs.update({'exclude_lookup_table': None})
+
+        # Adding records for person_id==9
+        insert_obs = self.jinja_env.from_string("""
+            INSERT INTO `{{project}}.{{dataset}}.{{obs}}`
+                (observation_id, person_id, observation_concept_id, observation_date,
+                 observation_datetime, observation_type_concept_id, observation_source_concept_id,
+                 value_source_concept_id, value_source_value, questionnaire_response_id)
+            VALUES
+                (200, 9, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586144, 'WhatRaceEthnicity_MENA', 9999)
+            """).render(project=self.project_id,
+                        dataset=self.dataset_id,
+                        obs=OBSERVATION)
+
+        insert_obs_mapping = self.jinja_env.from_string("""
+            INSERT INTO `{{project}}.{{dataset}}.{{obs_mapping}}`
+                (observation_id, src_dataset_id, src_observation_id, src_hpo_id, src_table_id)
+            VALUES
+                (200, 'dummy_rdr_1', 20, 'rdr', 'observation')
+            """).render(project=self.project_id,
+                        dataset=self.dataset_id,
+                        obs_mapping=OBS_MAPPING)
+
+        insert_obs_ext = self.jinja_env.from_string("""
+            INSERT INTO `{{project}}.{{dataset}}.{{obs_ext}}`
+                (observation_id, src_id, survey_version_concept_id)
+            VALUES
+                (200, 'PPI/PM', NULL)
+            """).render(project=self.project_id,
+                        dataset=self.dataset_id,
+                        obs_ext=OBS_EXT)
+
+        insert_pers = self.jinja_env.from_string("""
+            INSERT INTO `{{project}}.{{dataset}}.{{pers}}`
+                (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
+            VALUES
+                (9, 1585839, 1995, 1585841, 38003563)
+            """).render(project=self.project_id,
+                        dataset=self.dataset_id,
+                        pers=PERSON)
+
+        insert_pers_ext = self.jinja_env.from_string("""
+            INSERT INTO `{{project}}.{{dataset}}.{{pers_ext}}`
+                (person_id, state_of_residence_concept_id, state_of_residence_source_value, sex_at_birth_source_concept_id)
+            VALUES
+                (9, 1585266, 'PII State: CA', 1585847)
+            """).render(project=self.project_id,
+                        dataset=self.dataset_id,
+                        pers_ext=PERS_EXT)
+
+        self.load_test_data([
+            insert_obs, insert_obs_mapping, insert_obs_ext, insert_pers,
+            insert_pers_ext
+        ])
+
+        mock_is_rdr.return_value, mock_is_combined_release.return_value, mock_is_deid.return_value, mock_is_deid_release.return_value = False, True, False, False
+
+        tables_and_counts = [{
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBSERVATION}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_obs}',
+            'loaded_ids': [101, 102, 103, 104, 200, 201, 202, 203, 204, 205],
+            'sandboxed_ids': [200, 202, 203, 204, 205],
+            'fields': ['observation_id'],
+            'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (206,),
+                               (207,), (208,), (209,), (210,), (211,), (213,)]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBS_MAPPING}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_obs_mapping}',
+            'loaded_ids': [101, 102, 103, 104, 200, 201, 202, 203, 204, 205],
+            'sandboxed_ids': [200, 202, 203, 204, 205],
+            'fields': ['observation_id', 'src_dataset_id'],
+            'cleaned_values': [(101, 'dummy_rdr_1'), (102, 'dummy_rdr_1'),
+                               (103, 'dummy_rdr_1'), (104, 'dummy_rdr_1'),
+                               (201, 'dummy_rdr_1'), (206, 'dummy_rdr_2'),
+                               (207, 'dummy_rdr_2'), (208, 'dummy_rdr_2'),
+                               (209, 'dummy_rdr_2'), (210, 'dummy_rdr_2'),
+                               (211, 'dummy_rdr_2'), (213, 'dummy_rdr_2')]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBS_EXT}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_obs_ext}',
+            'loaded_ids': [101, 102, 103, 104, 200, 201, 202, 203, 204, 205],
+            'sandboxed_ids': [200, 202, 203, 204, 205],
+            'fields': ['observation_id'],
+            'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (206,),
+                               (207,), (208,), (209,), (210,), (211,), (213,)]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_sc}',
+            'loaded_ids': [1001, 1002],
+            'sandboxed_ids': [1002],
+            'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
+            'cleaned_values': [(1001, 0), (1002, 1), (1020, 1), (9999, 0)]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SC_MAPPING}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_mapping}',
+            'loaded_ids': [1001, 1002],
+            'sandboxed_ids': [1002],
+            'fields': ['survey_conduct_id', 'src_dataset_id'],
+            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2'),
+                               (1020, 'dummy_rdr_2'), (9999, 'dummy_rdr_2')]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_ext}',
+            'loaded_ids': [1001, 1002],
+            'sandboxed_ids': [1002],
+            'fields': ['survey_conduct_id', 'language'],
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1020, 'es'),
+                               (9999, 'es')]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{PERSON}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_pers}',
+            'loaded_ids': [1, 2, 9],
+            'sandboxed_ids': [2, 9],
+            'fields': ['person_id', 'gender_concept_id'],
+            'cleaned_values': [(1, 1585839), (2, 1585839), (9, 1585839)]
+        }]
+
+        self.default_test(tables_and_counts)
+
+        # Sandbox for PERSON_EXT does not exist because it's combined release dataset.
+        self.assertTableDoesNotExist(
+            f'{self.project_id}.{self.sandbox_id}.{self.sb_pers_ext}')
+
+    def tearDown(self):
+        self.client.delete_table(self.fq_exclusion_table, not_found_ok=True)
+        super().tearDown()


### PR DESCRIPTION
Extension table creation and population rules have moved from the RT and CT deid stages to the COMBINED_CLEANING_CLASSES data stage during the Registered Tier CDR generation.  Therefore, these parameters are required, but no longer needed.

```
--cope_lookup_dataset_id THIS_IS_NOT_NEEDED \
--cope_table_name THIS_IS_NOT_NEEDED  \
--additional_info_dataset THIS_IS_NOT_NEEDED
```

This PR removes those variables.