### PR TITLE
[DC-3063] Update insert statements/ Update QC notebook

### DIFF
--- a/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics.py
+++ b/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics.py
@@ -458,7 +458,7 @@ if __name__ == '__main__':
         action='store',
         dest='exclude_lookup_dataset',
         help=
-        (f'Dataset that has the PID/RID table for exlusion (e.g. AIAN participants for W/O AIAN dataset).'
+        (f'Dataset that has the PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
         ),
         required=False)
     parser.add_argument(
@@ -466,7 +466,7 @@ if __name__ == '__main__':
         action='store',
         dest='exclude_lookup_table',
         help=
-        (f'PID/RID table for exlusion (e.g. AIAN participants for W/O AIAN dataset).'
+        (f'PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
         ),
         required=False)
 

--- a/data_steward/tools/run_basics_remediation.py
+++ b/data_steward/tools/run_basics_remediation.py
@@ -156,6 +156,22 @@ def parse_args(raw_args=None):
                         help=(f'Dataset for NEW_OBS_ID_LOOKUP table.'),
                         required=True)
     parser.add_argument(
+        '--exclude_lookup_dataset',
+        action='store',
+        dest='exclude_lookup_dataset',
+        help=
+        (f'Dataset that has the PID/RID table for exlusion (e.g. AIAN participants for W/O AIAN dataset).'
+        ),
+        required=False)
+    parser.add_argument(
+        '--exclude_lookup_table',
+        action='store',
+        dest='exclude_lookup_table',
+        help=
+        (f'PID/RID table for exlusion (e.g. AIAN participants for W/O AIAN dataset).'
+        ),
+        required=False)
+    parser.add_argument(
         '--new_release_tag',
         action='store',
         dest='new_release_tag',
@@ -243,7 +259,9 @@ def main():
                   incremental_dataset_id=args.incremental_dataset_id,
                   dataset_with_largest_observation_id=args.
                   dataset_with_largest_observation_id,
-                  obs_id_lookup_dataset=args.obs_id_lookup_dataset)
+                  obs_id_lookup_dataset=args.obs_id_lookup_dataset,
+                  exclude_lookup_dataset=args.exclude_lookup_dataset,
+                  exclude_lookup_table=args.exclude_lookup_table)
 
     LOGGER.info(f"Completed running remediation for {new_dataset}...")
 

--- a/data_steward/tools/run_basics_remediation.py
+++ b/data_steward/tools/run_basics_remediation.py
@@ -160,7 +160,7 @@ def parse_args(raw_args=None):
         action='store',
         dest='exclude_lookup_dataset',
         help=
-        (f'Dataset that has the PID/RID table for exlusion (e.g. AIAN participants for W/O AIAN dataset).'
+        (f'Dataset that has the PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
         ),
         required=False)
     parser.add_argument(
@@ -168,7 +168,7 @@ def parse_args(raw_args=None):
         action='store',
         dest='exclude_lookup_table',
         help=
-        (f'PID/RID table for exlusion (e.g. AIAN participants for W/O AIAN dataset).'
+        (f'PID/RID table for exclusion (e.g. AIAN participants for W/O AIAN dataset).'
         ),
         required=False)
     parser.add_argument(

--- a/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
@@ -382,7 +382,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 204, 205 ... Those have multiple corresponding records (=904,905,906).
                              204 and 205 get dropped and 904, 905, and 906 get inserted.
                 * 901 - 999 become 206 - 213 respectively after re-mapping using NEW_OBS_ID_LOOKUP.
-            person_id == 2:
+            person_id == 3:
                 This person is new. The records are simply inserted to the observation table.
             person_id == 9 (observation_id 901 and 999):
                 This person only exists in the incremental dataset. Such data MUST NOT be included
@@ -578,7 +578,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         [2] SURVEY_CONDUCT and its ext table
             Same result as test_remediate_basics_combined_release
 
-        [3] PERSON and its ext table
+        [3] PERSON table
             Same result as test_remediate_basics_combined_release
 
         [4] PERSON_EXT table

--- a/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
@@ -17,6 +17,34 @@ from common import OBSERVATION, PERSON, SURVEY_CONDUCT
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
 
+def mock_patch_decorator_bundle(*decorators):
+    """Since the test env's dataset names are different from the prod env's,
+    is_xyz_dataset() do not work as designed. So, they need to be patched for
+    the tests. This function bundles all the patches into one so we only need
+    to write one mock patch decorator for each test.
+    """
+
+    def _chain(patch):
+        for dec in reversed(decorators):
+            patch = dec(patch)
+        return patch
+
+    return _chain
+
+
+mock_patch_bundle = mock_patch_decorator_bundle(
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
+    ),
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset'),
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
+    ),
+    mock.patch(
+        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset'))
+
+
 class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
 
     @classmethod
@@ -33,6 +61,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         cls.incremental_dataset_id = os.environ.get('BIGQUERY_DATASET_ID')
         cls.dataset_with_largest_observation_id = cls.dataset_id
         cls.obs_id_lookup_dataset = cls.sandbox_id
+        cls.exclude_lookup_dataset = cls.sandbox_id
+        cls.exclude_lookup_table = 'aian_participant'
 
         cls.kwargs.update(
             {'incremental_dataset_id': cls.incremental_dataset_id})
@@ -41,14 +71,12 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 cls.dataset_with_largest_observation_id
         })
         cls.kwargs.update({'obs_id_lookup_dataset': cls.obs_id_lookup_dataset})
+        cls.kwargs.update(
+            {'exclude_lookup_dataset': cls.exclude_lookup_dataset})
+        cls.kwargs.update({'exclude_lookup_table': cls.exclude_lookup_table})
 
-        cls.rule_instance = RemediateBasics(
-            cls.project_id,
-            cls.dataset_id,
-            cls.sandbox_id,
-            incremental_dataset_id=cls.incremental_dataset_id,
-            dataset_with_largest_observation_id=cls.
-            dataset_with_largest_observation_id)
+        cls.rule_instance = RemediateBasics(cls.project_id, cls.dataset_id,
+                                            cls.sandbox_id)
 
         for dataset in [cls.dataset_id, cls.incremental_dataset_id]:
             cls.fq_table_names.extend([
@@ -83,11 +111,19 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             f'{cls.project_id}.{cls.sandbox_id}.{NEW_OBS_ID_LOOKUP}'
         ]
 
+        cls.fq_exclusion_table = f'{cls.project_id}.{cls.exclude_lookup_dataset}.{cls.exclude_lookup_table}'
+
         super().setUpClass()
 
     def setUp(self):
         """
-        Create test table for the rule to run on
+        Create test tables for the rule to run on.
+
+        Test cases:
+        person_id==1: Exists in the original dataset but not in the incremental dataset. No change to this participant's records.
+        person_id==2: Exists both in the original dataset but in the incremental dataset. Records will be updated.
+        person_id==3: Does not exist in the original dataset but exists in the incremental dataset. Records will be inserted.
+        person_id==9: Same as 3, but listed in the exlude_lookup_table. Must be ignored when exlude_lookup_table is specified.
         """
 
         super().setUp()
@@ -123,7 +159,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (904, 2, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586147, 'WhatRaceEthnicity_Hispanic', 1002),  -- new ID: 209 --
                 (905, 2, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586146, 'WhatRaceEthnicity_White', 1002), -- new ID: 210 --
                 (906, 2, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586142, 'WhatRaceEthnicity_Asian', 1002), -- new ID: 211 --
-                (999, 9, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586142, 'WhatRaceEthnicity_Asian', 9999) -- new ID: 212 --
+                (907, 3, 1585845, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1585845, 1585846, 'SexAtBirth_Male', 1003), -- new ID: 212 --
+                (999, 9, 1586140, date('2022-01-01'), timestamp('2022-01-01 12:34:56'), 45905771, 1586140, 1586142, 'WhatRaceEthnicity_Asian', 9999) -- new ID: 213 --
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
                         obs=OBSERVATION)
@@ -155,6 +192,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (904, 'dummy_rdr_2', 94, 'rdr', 'observation'),
                 (905, 'dummy_rdr_2', 95, 'rdr', 'observation'),
                 (906, 'dummy_rdr_2', 96, 'rdr', 'observation'),
+                (907, 'dummy_rdr_2', 97, 'rdr', 'observation'),
                 (999, 'dummy_rdr_2', 99, 'rdr', 'observation')
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -187,6 +225,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (904, 'PPI/PM', NULL),
                 (905, 'PPI/PM', NULL),
                 (906, 'PPI/PM', NULL),
+                (907, 'PPI/PM', NULL),
                 (999, 'PPI/PM', NULL)
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -213,6 +252,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                  validated_survey_concept_id)
             VALUES
                 (1002, 2, 1586134, timestamp('2022-01-01 12:34:56'), 0, 0, 0, 42531021, 1586134, 1),
+                (1003, 3, 1586134, timestamp('2022-01-01 12:34:56'), 0, 0, 0, 42531021, 1586134, 1),
                 (9999, 9, 1586134, timestamp('2022-01-01 12:34:56'), 0, 0, 0, 42531021, 1586134, 0)
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -233,6 +273,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (survey_conduct_id, src_dataset_id, src_survey_conduct_id, src_hpo_id, src_table_id)
             VALUES
                 (1002, 'dummy_rdr_2', 1002, 'rdr', 'survey_conduct'),
+                (1003, 'dummy_rdr_2', 1003, 'rdr', 'survey_conduct'),
                 (9999, 'dummy_rdr_2', 9999, 'rdr', 'survey_conduct')
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -253,6 +294,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 (survey_conduct_id, src_id, language)
             VALUES
                 (1002, 'PPI/PM', 'es'),
+                (1003, 'PPI/PM', 'es'),
                 (9999, 'PPI/PM', 'es')
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
@@ -275,8 +317,9 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             INSERT INTO `{{project}}.{{incremental_dataset}}.{{pers}}`
                 (person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
             VALUES
-                (2, 1585839, 1995, 1585841, 38003563),
-                (9, 1585839, 1995, 1585841, 38003563)
+                (2, 1585839, 1995, 1585841, 38003563), -- existing in original --
+                (3, 1585839, 1995, 1585841, 38003563), -- new from incremental --
+                (9, 1585839, 1995, 1585841, 38003563)  -- new from incremental, must be excluded when exclude_lookup_table is present --
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
                         pers=PERSON)
@@ -295,11 +338,22 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             INSERT INTO `{{project}}.{{incremental_dataset}}.{{pers_ext}}`
                 (person_id, state_of_residence_concept_id, state_of_residence_source_value, sex_at_birth_source_concept_id)
             VALUES
-                (2, NULL, NULL, 1585846),
-                (9, NULL, NULL, 1585846)
+                (2, NULL, NULL, 1585846), -- existing in original --
+                (3, NULL, NULL, 1585846), -- new from incremental --
+                (9, NULL, NULL, 1585846)  -- new from incremental, must be excluded when exclude_lookup_table is present --
             """).render(project=self.project_id,
                         incremental_dataset=self.incremental_dataset_id,
                         pers_ext=PERS_EXT)
+
+        create_exclusion_table = self.jinja_env.from_string("""
+        CREATE TABLE `{{fq_exclusion_table}}` (person_id INT64, research_id INT64)
+        """).render(fq_exclusion_table=self.fq_exclusion_table)
+
+        insert_exclusion_table = self.jinja_env.from_string("""
+        INSERT INTO `{{fq_exclusion_table}}` (person_id, research_id)
+        VALUES
+        (9, 9)
+        """).render(fq_exclusion_table=self.fq_exclusion_table)
 
         self.load_test_data([
             insert_obs, insert_incremental_obs, insert_obs_mapping,
@@ -307,19 +361,11 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             insert_incremental_obs_ext, insert_sc, insert_incremental_sc,
             insert_sc_mapping, insert_incremental_sc_mapping, insert_sc_ext,
             insert_incremental_sc_ext, insert_pers, insert_incremental_pers,
-            insert_pers_ext, insert_incremental_pers_ext
+            insert_pers_ext, insert_incremental_pers_ext,
+            create_exclusion_table, insert_exclusion_table
         ])
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_combined_release(self, mock_is_rdr,
                                                mock_is_combined_release,
                                                mock_is_deid,
@@ -335,7 +381,9 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 203 ... Similar to 202, the same behavior even when the source value is 'PMI_Skip'.
                 204, 205 ... Those have multiple corresponding records (=904,905,906).
                              204 and 205 get dropped and 904, 905, and 906 get inserted.
-                * 901 - 999 become 206 - 212 respectively after re-mapping using NEW_OBS_ID_LOOKUP.
+                * 901 - 999 become 206 - 213 respectively after re-mapping using NEW_OBS_ID_LOOKUP.
+            person_id == 2:
+                This person is new. The records are simply inserted to the observation table.
             person_id == 9 (observation_id 901 and 999):
                 This person only exists in the incremental dataset. Such data MUST NOT be included
                 in the final output. (e.g. AIAN participants are included in incremental_dataset while
@@ -344,11 +392,13 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         [2] SURVEY_CONDUCT and its ext/mapping tables
             survey_conduct_id = 1001 does not change.
             survey_conduct_id = 1002 gets sandboxed and updated since it exists in the incremental dataset.
+            survey_conduct_id = 1003 is a brand-new ID and inserted into final output.
             survey_conduct_id = 9999 gets ignored because it belongs to person_id = 9
 
         [3] PERSON table
             person_id = 1 does not change.
             person_id = 2 gets sandboxed and updated since it exists in the incremental dataset.
+            person_id = 3 is a new person from the incremental dataset. Will be inserted.
             person_id = 9 gets ignored because it only exists in the incremental dataset.
 
         [4] PERSON_EXT table
@@ -365,7 +415,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBS_MAPPING}',
@@ -378,7 +428,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                                (103, 'dummy_rdr_1'), (104, 'dummy_rdr_1'),
                                (201, 'dummy_rdr_1'), (207, 'dummy_rdr_2'),
                                (208, 'dummy_rdr_2'), (209, 'dummy_rdr_2'),
-                               (210, 'dummy_rdr_2'), (211, 'dummy_rdr_2')]
+                               (210, 'dummy_rdr_2'), (211, 'dummy_rdr_2'),
+                               (212, 'dummy_rdr_2')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBS_EXT}',
@@ -388,7 +439,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
@@ -397,7 +448,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1003, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_MAPPING}',
@@ -406,7 +457,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'src_dataset_id'],
-            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2')]
+            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2'),
+                               (1003, 'dummy_rdr_2')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
@@ -415,7 +467,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1003, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -424,7 +476,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2],
             'sandboxed_ids': [2],
             'fields': ['person_id', 'gender_concept_id'],
-            'cleaned_values': [(1, 1585839), (2, 1585839)]
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839)]
         }]
 
         self.default_test(tables_and_counts)
@@ -433,16 +485,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_pers_ext}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_combined(self, mock_is_rdr,
                                        mock_is_combined_release, mock_is_deid,
                                        mock_is_deid_release):
@@ -470,7 +513,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBS_MAPPING}',
@@ -483,7 +526,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                                (103, 'dummy_rdr_1'), (104, 'dummy_rdr_1'),
                                (201, 'dummy_rdr_1'), (207, 'dummy_rdr_2'),
                                (208, 'dummy_rdr_2'), (209, 'dummy_rdr_2'),
-                               (210, 'dummy_rdr_2'), (211, 'dummy_rdr_2')]
+                               (210, 'dummy_rdr_2'), (211, 'dummy_rdr_2'),
+                               (212, 'dummy_rdr_2')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
@@ -492,7 +536,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1003, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_MAPPING}',
@@ -501,7 +545,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'src_dataset_id'],
-            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2')]
+            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2'),
+                               (1003, 'dummy_rdr_2')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -510,7 +555,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2],
             'sandboxed_ids': [2],
             'fields': ['person_id', 'gender_concept_id'],
-            'cleaned_values': [(1, 1585839), (2, 1585839)]
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839)]
         }]
 
         self.default_test(tables_and_counts)
@@ -523,16 +568,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_ext}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_deid(self, mock_is_rdr, mock_is_combined_release,
                                    mock_is_deid, mock_is_deid_release):
         """Test to ensure RemediateBasics works as expected for DEID (= CT and RT) NOT BASE/CLEAN dataset.
@@ -543,14 +579,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             Same result as test_remediate_basics_combined_release
 
         [3] PERSON and its ext table
-            person_id = 1 does not change.
-            person_id = 2 gets sandboxed and updated since it exists in the incremental dataset.
-                * state_of_residence_concept_id and state_of_residence_source_value will NOT change.
-            person_id = 9 gets ignored because it only exists in the incremental dataset.
-                Such data MUST NOT be included in the final output. (e.g. AIAN participants are 
-                included in incremental_dataset while the final output must not include AIAN 
-                participants for releases W/O AIAN)
-        
+            Same result as test_remediate_basics_combined_release
+
         [4] PERSON_EXT table
             This table does not exist in deid dataset. No sandboxing/deleting/inserting will run on it.
 
@@ -568,7 +598,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBS_EXT}',
@@ -578,7 +608,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
@@ -587,7 +617,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1003, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
@@ -596,7 +626,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1003, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -605,7 +635,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2],
             'sandboxed_ids': [2],
             'fields': ['person_id', 'gender_concept_id'],
-            'cleaned_values': [(1, 1585839), (2, 1585839)]
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839)]
         }]
 
         self.default_test(tables_and_counts)
@@ -618,16 +648,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_mapping}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_deid_release(self, mock_is_rdr,
                                            mock_is_combined_release,
                                            mock_is_deid, mock_is_deid_release):
@@ -638,16 +659,15 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         [2] SURVEY_CONDUCT and its ext table
             Same result as test_remediate_basics_combined_release
 
-        [3] PERSON and its ext table
-            person_id = 1 does not change.
-            person_id = 2 gets sandboxed and updated since it exists in the incremental dataset.
-                * state_of_residence_concept_id and state_of_residence_source_value will NOT change.
-            person_id = 9 gets ignored because it only exists in the incremental dataset.
-                Such data MUST NOT be included in the final output. (e.g. AIAN participants are 
-                included in incremental_dataset while the final output must not include AIAN 
-                participants for releases W/O AIAN)
+        [3] PERSON table
+            Same result as test_remediate_basics_combined_release
 
-        [4] OBSERVATION_MAPPING and SURVEY_CONDUCT_MAPPING tables
+        [4] PERSON_EXT table
+            Just like PERSON table...
+            1 stays the same, 2 is updated, 3 is inserted, and 9 is ignored.
+            3's state columns are NULL because it does not exist in the source dataset.
+
+        [5] OBSERVATION_MAPPING and SURVEY_CONDUCT_MAPPING tables
             These tables do not exist in deid dataset. No sandboxing/deleting/inserting will run on it.
         """
         mock_is_rdr.return_value, mock_is_combined_release.return_value, mock_is_deid.return_value, mock_is_deid_release.return_value = False, False, True, True
@@ -661,7 +681,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBS_EXT}',
@@ -671,7 +691,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
@@ -680,7 +700,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1003, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
@@ -689,7 +709,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1003, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -698,7 +718,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2],
             'sandboxed_ids': [2],
             'fields': ['person_id', 'gender_concept_id'],
-            'cleaned_values': [(1, 1585839), (2, 1585839)]
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERS_EXT}',
@@ -712,7 +732,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
                 'sex_at_birth_source_concept_id'
             ],
             'cleaned_values': [(1, 1585266, 'PII State: CA', 1585847),
-                               (2, 1585266, 'PII State: CA', 1585846)]
+                               (2, 1585266, 'PII State: CA', 1585846),
+                               (3, None, None, 1585846)]
         }]
 
         self.default_test(tables_and_counts)
@@ -723,22 +744,13 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_mapping}')
 
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_deid_dataset')
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_combined_release_dataset'
-    )
-    @mock.patch(
-        'cdr_cleaner.manual_cleaning_rules.remediate_basics.is_rdr_dataset')
+    @mock_patch_bundle
     def test_remediate_basics_rdr(self, mock_is_rdr, mock_is_combined_release,
                                   mock_is_deid, mock_is_deid_release):
         """Test to ensure RemediateBasics works as expected for RDR dataset.
         [1] OBSERVATION, SURVEY_CONDUCT, PERSON tables
             Same result as test_remediate_basics_combined_release
-        
+
         [2] mapping and ext tables
             These tables do not exist in rdr dataset. No sandboxing/deleting/inserting will run on it.
         """
@@ -753,7 +765,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'sandboxed_ids': [202, 203, 204, 205],
             'fields': ['observation_id'],
             'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (207,),
-                               (208,), (209,), (210,), (211,)]
+                               (208,), (209,), (210,), (211,), (212,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
@@ -762,7 +774,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
-            'cleaned_values': [(1001, 0), (1002, 1)]
+            'cleaned_values': [(1001, 0), (1002, 1), (1003, 1)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -771,7 +783,7 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2],
             'sandboxed_ids': [2],
             'fields': ['person_id', 'gender_concept_id'],
-            'cleaned_values': [(1, 1585839), (2, 1585839)]
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839)]
         }]
 
         self.default_test(tables_and_counts)
@@ -787,3 +799,104 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_ext}')
         self.assertTableDoesNotExist(
             f'{self.project_id}.{self.sandbox_id}.{self.sb_pers_ext}')
+
+    @mock_patch_bundle
+    def test_no_exclusion(self, mock_is_rdr, mock_is_combined_release,
+                          mock_is_deid, mock_is_deid_release):
+        """Test to ensure RemediateBasics works as expected when exclude_lookup_table and exclude_lookup_dataset
+        are not specified. Everything in the incremental dataset will be inserted in such cases.
+        Testing against COMBINED_RELEASE dataset.
+
+        Mostly same result as test_remediate_basics_combined_release.
+        Only the difference is this one includes person_id == 9 (observation_id 901 and 999) (survey_conduct_id 9999).
+        """
+        # Unsetting exclude_lookup_xyz arguments.
+        self.kwargs.update({'exclude_lookup_dataset': None})
+        self.kwargs.update({'exclude_lookup_table': None})
+
+        mock_is_rdr.return_value, mock_is_combined_release.return_value, mock_is_deid.return_value, mock_is_deid_release.return_value = False, True, False, False
+
+        tables_and_counts = [{
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBSERVATION}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_obs}',
+            'loaded_ids': [101, 102, 103, 104, 201, 202, 203, 204, 205],
+            'sandboxed_ids': [202, 203, 204, 205],
+            'fields': ['observation_id'],
+            'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (206,),
+                               (207,), (208,), (209,), (210,), (211,), (212,),
+                               (213,)]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBS_MAPPING}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_obs_mapping}',
+            'loaded_ids': [101, 102, 103, 104, 201, 202, 203, 204, 205],
+            'sandboxed_ids': [202, 203, 204, 205],
+            'fields': ['observation_id', 'src_dataset_id'],
+            'cleaned_values': [(101, 'dummy_rdr_1'), (102, 'dummy_rdr_1'),
+                               (103, 'dummy_rdr_1'), (104, 'dummy_rdr_1'),
+                               (201, 'dummy_rdr_1'), (206, 'dummy_rdr_2'),
+                               (207, 'dummy_rdr_2'), (208, 'dummy_rdr_2'),
+                               (209, 'dummy_rdr_2'), (210, 'dummy_rdr_2'),
+                               (211, 'dummy_rdr_2'), (212, 'dummy_rdr_2'),
+                               (213, 'dummy_rdr_2')]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBS_EXT}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_obs_ext}',
+            'loaded_ids': [101, 102, 103, 104, 201, 202, 203, 204, 205],
+            'sandboxed_ids': [202, 203, 204, 205],
+            'fields': ['observation_id'],
+            'cleaned_values': [(101,), (102,), (103,), (104,), (201,), (206,),
+                               (207,), (208,), (209,), (210,), (211,), (212,),
+                               (213,)]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SURVEY_CONDUCT}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_sc}',
+            'loaded_ids': [1001, 1002],
+            'sandboxed_ids': [1002],
+            'fields': ['survey_conduct_id', 'validated_survey_concept_id'],
+            'cleaned_values': [(1001, 0), (1002, 1), (1003, 1), (9999, 0)]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SC_MAPPING}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_mapping}',
+            'loaded_ids': [1001, 1002],
+            'sandboxed_ids': [1002],
+            'fields': ['survey_conduct_id', 'src_dataset_id'],
+            'cleaned_values': [(1001, 'dummy_rdr_1'), (1002, 'dummy_rdr_2'),
+                               (1003, 'dummy_rdr_2'), (9999, 'dummy_rdr_2')]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{SC_EXT}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_sc_ext}',
+            'loaded_ids': [1001, 1002],
+            'sandboxed_ids': [1002],
+            'fields': ['survey_conduct_id', 'language'],
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1003, 'es'), (9999, 'es')]
+        }, {
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{PERSON}',
+            'fq_sandbox_table_name':
+                f'{self.project_id}.{self.sandbox_id}.{self.sb_pers}',
+            'loaded_ids': [1, 2],
+            'sandboxed_ids': [2],
+            'fields': ['person_id', 'gender_concept_id'],
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839), (9, 1585839)]
+        }]
+
+        self.default_test(tables_and_counts)
+
+        # Sandbox for PERSON_EXT does not exist because it's combined release dataset.
+        self.assertTableDoesNotExist(
+            f'{self.project_id}.{self.sandbox_id}.{self.sb_pers_ext}')
+
+    def tearDown(self):
+        self.client.delete_table(self.fq_exclusion_table, not_found_ok=True)

--- a/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/manual_cleaning_rules/remediate_basics_test.py
@@ -880,7 +880,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1001, 1002],
             'sandboxed_ids': [1002],
             'fields': ['survey_conduct_id', 'language'],
-            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1003, 'es'), (9999, 'es')]
+            'cleaned_values': [(1001, 'en'), (1002, 'es'), (1003, 'es'),
+                               (9999, 'es')]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
@@ -889,7 +890,8 @@ class RemediateBasicsTest(BaseTest.CleaningRulesTestBase):
             'loaded_ids': [1, 2],
             'sandboxed_ids': [2],
             'fields': ['person_id', 'gender_concept_id'],
-            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839), (9, 1585839)]
+            'cleaned_values': [(1, 1585839), (2, 1585839), (3, 1585839),
+                               (9, 1585839)]
         }]
 
         self.default_test(tables_and_counts)


### PR DESCRIPTION
I am fixing the scripts based on the execution from 2/14.
- Updated `insert` statements in the main hotfix script so it will also insert new records. (It was inserting only records that had corresponding records in the source dataset.) 
- Introduced `exclude_lookup_table` and `exclude_lookup_dataset` to achieve the above.
- Added a new test case, `test_no_exclusion,` to test whether the above is working as expected.
- Added a new test case (`person_id==3`) to test whether new participants are correctly inserted into the output.
- Deleted `QC 2-2` from the QC notebook as we saw yesterday the check was meaningless.

NOTE: `person_ext` tables' state-related columns can be `NULL` if the participants are new since the incremental dataset.
https://github.com/all-of-us/curation/pull/1497/files#diff-638190b97f9a117d7f9c2a0fc16996cb1608d05f353b383919366a8b7aec007fR198