### PR TITLE
[DC-3060] Remove unused variables required by `deid_runner.sh`

### DIFF
--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -158,6 +158,8 @@ def get_table_id(hpo_id, table_name):
     return hpo_id + '_' + table_name
 
 
+@deprecated(reason='Use gcloud.bq.BigQueryClient.get_table(self, table) instead'
+           )
 def get_table_info(table_id, dataset_id=None, project_id=None):
     """
     Get metadata describing a table

--- a/data_steward/bq_utils.py
+++ b/data_steward/bq_utils.py
@@ -293,6 +293,10 @@ def load_from_csv(hpo_id, table_name, source_folder_prefix=""):
     return load_cdm_csv(hpo_id, table_name, source_folder_prefix)
 
 
+@deprecated(
+    reason=
+    'see: https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.client.Client#google_cloud_bigquery_client_Client_delete_table'
+)
 def delete_table(table_id, dataset_id=None):
     """
     Delete bigquery table by id

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -88,7 +88,7 @@ def create_all_tables(dataset_id):
         create_table(table, dataset_id)
 
 
-if __name__ == '__main__':
+def main():
     # TODO parse args, support multiple commands
     parser = get_parser()
     args = parser.parse_args()
@@ -105,3 +105,7 @@ if __name__ == '__main__':
         pass
     else:
         create_all_tables(args.dataset_id)
+
+
+if __name__ == '__main__':
+    main()

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -26,10 +26,10 @@ def get_parser():
     mutex.add_argument(
         '--table',
         help='A specific CDM table to create (creates all by default)',
-        choices=list(resources.CDM_TABLES))
+        choices=resources.CDM_TABLES)
     mutex.add_argument('--component',
                        help='Subset of CDM tables to create',
-                       choices=list(common.CDM_COMPONENTS))
+                       choices=common.CDM_COMPONENTS)
 
     return parser
 

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -13,7 +13,7 @@ import resources
 logger = logging.getLogger(__name__)
 
 
-def get_parser():
+def create_parser():
 
     parser = argparse.ArgumentParser(
         description='Parse project_id and dataset_id',
@@ -90,7 +90,7 @@ def create_all_tables(dataset_id):
 
 def main():
     # TODO parse args, support multiple commands
-    parser = get_parser()
+    parser = create_parser()
     args = parser.parse_args()
 
     if args.table:

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -20,7 +20,9 @@ def get_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument(
-        'dataset_id', help='Identifies the dataset to create OMOP table(s) in')
+        'dataset_id',
+        help='Identifies the dataset to create OMOP table(s) in',
+        required=False)
 
     mutex = parser.add_mutually_exclusive_group(required=True)
     mutex.add_argument(

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -13,6 +13,27 @@ import resources
 logger = logging.getLogger(__name__)
 
 
+def get_parser():
+
+    parser = argparse.ArgumentParser(
+        description='Parse project_id and dataset_id',
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        'dataset_id', help='Identifies the dataset to create OMOP table(s) in')
+
+    mutex = parser.add_mutually_exclusive_group(required=True)
+    mutex.add_argument(
+        '--table',
+        help='A specific CDM table to create (creates all by default)',
+        choices=list(resources.CDM_TABLES))
+    mutex.add_argument('--component',
+                       help='Subset of CDM tables to create',
+                       choices=list(common.CDM_COMPONENTS))
+
+    return parser
+
+
 def tables_to_map():
     """
     Determine which CDM tables must have ids remapped
@@ -69,28 +90,18 @@ def create_all_tables(dataset_id):
 
 if __name__ == '__main__':
     # TODO parse args, support multiple commands
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument(
-        '--table',
-        help='A specific CDM table to create (creates all by default)',
-        choices=list(resources.CDM_TABLES))
-    parser.add_argument('--component',
-                        help='Subset of CDM tables to create',
-                        choices=list(common.CDM_COMPONENTS))
-    parser.add_argument(
-        'dataset_id', help='Identifies the dataset to create OMOP table(s) in')
+    parser = get_parser()
     args = parser.parse_args()
+
     if args.table:
-        if args.component:
-            raise RuntimeError('Cannot process both table and component')
         create_table(args.table, args.dataset_id)
+    elif args.component == common.VOCABULARY:
+        create_vocabulary_tables(args.dataset_id)
+    elif args.component == common.ACHILLES:
+        # TODO implement creating achilles tables; need to fix interdependency of common, resource_files, cdm
+        raise NotImplementedError(
+            'Creating achilles tables not yet implemented')
     elif args.component:
-        if args.component == common.VOCABULARY:
-            create_vocabulary_tables(args.dataset_id)
-        elif args.component == common.ACHILLES:
-            # TODO implement creating achilles tables; need to fix interdependency of common, resource_files, cdm
-            raise NotImplementedError(
-                'Creating achilles tables not yet implemented')
+        pass
     else:
         create_all_tables(args.dataset_id)

--- a/data_steward/cdm.py
+++ b/data_steward/cdm.py
@@ -20,11 +20,9 @@ def get_parser():
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument(
-        'dataset_id',
-        help='Identifies the dataset to create OMOP table(s) in',
-        required=False)
+        'dataset_id', help='Identifies the dataset to create OMOP table(s) in')
 
-    mutex = parser.add_mutually_exclusive_group(required=True)
+    mutex = parser.add_mutually_exclusive_group(required=False)
     mutex.add_argument(
         '--table',
         help='A specific CDM table to create (creates all by default)',

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -221,6 +221,10 @@ COMBINED_CLEANING_CLASSES = [
     (RemoveNonMatchingParticipant,),
     (DropOrphanedSurveyConductIds,),
     (DropOrphanedPIDS,),
+    (GenerateExtTables,),
+    (COPESurveyVersionTask,
+    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
+    (PopulateSurveyConductExt,),
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
@@ -235,15 +239,10 @@ FITBIT_CLEANING_CLASSES = [
 REGISTERED_TIER_DEID_CLEANING_CLASSES = [
     # Data mappings/re-mappings
     ####################################
-    (
-        GenerateExtTables,),
-    (COPESurveyVersionTask,
-    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
     # TODO: Uncomment rule after date-shift removed from deid module
     # (SurveyConductDateShiftRule,),
     (
-        PopulateSurveyConductExt,),
-    (QRIDtoRID,),  # Should run before any row suppression rules
+        QRIDtoRID,),  # Should run before any row suppression rules
 
     # Data generalizations
     ####################################
@@ -298,10 +297,6 @@ REGISTERED_TIER_FITBIT_CLEANING_CLASSES = [
 
 CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (RtCtPIDtoRID,),
-    (GenerateExtTables,),
-    (COPESurveyVersionTask,
-    ),  # Should run after GenerateExtTables and before CleanMappingExtTables
-    (PopulateSurveyConductExt,),
     (QRIDtoRID,),  # Should run before any row suppression rules
     (TruncateEraTables,),
     (NullPersonBirthdate,),

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters.py
@@ -2,7 +2,7 @@
 Apply value ranges to ensure that values are reasonable and to minimize the likelihood
 of sensitive information (like phone numbers) within the free text fields.
 
-Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475
+Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475 , DC-2649
 
 The intent is to ensure that numeric free-text fields that are not manipulated by de-id
 have value range restrictions applied to the value_as_number field across the entire dataset.
@@ -27,29 +27,29 @@ SELECT *
 FROM
     `{{project}}.{{dataset}}.observation`
 WHERE
-    (observation_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1585795 AND (value_as_number < 0 OR value_as_number > 99))
 OR
-    (observation_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1585802 AND (value_as_number < 0 OR value_as_number > 99))
 OR
-    (observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255))
+    (observation_source_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255))
 OR
-    (observation_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1585864 AND (value_as_number < 0 OR value_as_number > 99))
 OR
-    (observation_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1585870 AND (value_as_number < 0 OR value_as_number > 99))
 OR 
-    (observation_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1585873 AND (value_as_number < 0 OR value_as_number > 99))
 OR
-    (observation_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1586159 AND (value_as_number < 0 OR value_as_number > 99))
 OR
-    (observation_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99))
+    (observation_source_concept_id = 1586162 AND (value_as_number < 0 OR value_as_number > 99))
 OR
     -- from dc1061: sandbox any participant data who have a household size greater than 11 --
-    (observation_concept_id IN (1333015, 1585889) AND (value_as_number < 0 OR value_as_number > 10))
+    (observation_source_concept_id IN (1333015, 1585889) AND (value_as_number < 0 OR value_as_number > 10))
 OR
     -- from dc1058: sandbox any participant data who have 6 or more members under 18 in their household --
-    (observation_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5))
+    (observation_source_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5))
 OR
-    (observation_concept_id = 1333023 AND value_as_number IS NULL AND value_as_string IS NOT NULL))
+    (observation_source_concept_id = 1333023 AND value_as_number IS NULL AND value_as_string IS NOT NULL))
 """)
 
 CLEAN_INVALID_VALUES_QUERY = JINJA_ENV.from_string("""
@@ -61,38 +61,38 @@ SELECT
     observation_datetime,
     observation_type_concept_id,
 CASE
-    WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN NULL
-    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN NULL
+    WHEN observation_source_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN NULL
+    WHEN observation_source_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN NULL
     
     -- from dc1058: will null invalid values for value_as_number if participant household size is greater than 11 --
-    WHEN observation_concept_id IN (1333015, 1585889) AND (value_as_number < 0 OR value_as_number > 10) THEN NULL
+    WHEN observation_source_concept_id IN (1333015, 1585889) AND (value_as_number < 0 OR value_as_number > 10) THEN NULL
     
     -- from dc1061: will null invalid values for value_as_number if participant household has 6 or more members under the age of 18 --
-    WHEN observation_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5) THEN NULL
+    WHEN observation_source_concept_id IN (1333023, 1585890) AND (value_as_number < 0 OR value_as_number > 5) THEN NULL
   ELSE value_as_number
 END AS
     value_as_number,
-    CASE WHEN observation_concept_id = 1333023 AND value_as_number IS NULL AND value_as_string IS NOT NULL THEN NULL
+    CASE WHEN observation_source_concept_id = 1333023 AND value_as_number IS NULL AND value_as_string IS NOT NULL THEN NULL
     ELSE value_as_string
     END AS value_as_string,
 CASE
-    WHEN observation_concept_id IN (1585890, 1333023, 1333015, 1585889) 
+    WHEN observation_source_concept_id IN (1585890, 1333023, 1333015, 1585889) 
         AND (
             value_as_number < 0 
             OR value_as_number >= 20 
             OR (value_as_number IS NULL AND value_as_string IS NOT NULL)
         )
         THEN 2000000010
-    WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
-    WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
+    WHEN observation_source_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
+    WHEN observation_source_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
     
-    -- from dc1058: if the observation_concept_id is 1585889 or 1333015 and has between less than 11 members in the household --
+    -- from dc1058: if the observation_source_concept_id is 1585889 or 1333015 and has between less than 11 members in the household --
     -- will set value_as_concept_id to the new custom concept --
-    WHEN observation_concept_id IN (1585889, 1333015) AND (value_as_number < 20 AND value_as_number > 10) THEN 2000000013
+    WHEN observation_source_concept_id IN (1585889, 1333015) AND (value_as_number < 20 AND value_as_number > 10) THEN 2000000013
     
-    -- from dc1061: if the observation_concept_id is 1333023 or 1585890 and less than 6 members in the household --
+    -- from dc1061: if the observation_source_concept_id is 1333023 or 1585890 and less than 6 members in the household --
     -- is under the age of 18, will set value_as_concept_id to the new custom concept --
-    WHEN observation_concept_id IN (1333023, 1585890) AND (value_as_number < 20 AND value_as_number > 5) THEN 2000000012
+    WHEN observation_source_concept_id IN (1333023, 1585890) AND (value_as_number < 20 AND value_as_number > 5) THEN 2000000012
   ELSE value_as_concept_id
 END AS
     value_as_concept_id,
@@ -106,23 +106,23 @@ END AS
     unit_source_value,
     qualifier_source_value,
     CASE
-        WHEN observation_concept_id IN (1585890, 1333023, 1333015, 1585889) 
+        WHEN observation_source_concept_id IN (1585890, 1333023, 1333015, 1585889) 
             AND (
                 value_as_number < 0 
                 OR value_as_number >= 20 
                 OR (value_as_number IS NULL AND value_as_string IS NOT NULL)
             )
             THEN 2000000010
-        WHEN observation_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
-        WHEN observation_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
+        WHEN observation_source_concept_id IN (1585795, 1585802, 1585864, 1585870, 1585873, 1586159, 1586162) AND (value_as_number < 0 OR value_as_number > 99) THEN 2000000010
+        WHEN observation_source_concept_id = 1585820 AND (value_as_number < 0 OR value_as_number > 255) THEN 2000000010
     
-        -- from dc1058: if the observation_concept_id is 1585889 or 1333015 and has between less than 11 members in the household --
+        -- from dc1058: if the observation_source_concept_id is 1585889 or 1333015 and has between less than 11 members in the household --
         -- will set value_as_concept_id to the new custom concept --
-        WHEN observation_concept_id IN (1585889, 1333015) AND (value_as_number < 20 AND value_as_number > 10) THEN 2000000013
+        WHEN observation_source_concept_id IN (1585889, 1333015) AND (value_as_number < 20 AND value_as_number > 10) THEN 2000000013
     
-        -- from dc1061: if the observation_concept_id is 1333023 or 1585890 and less than 6 members in the household --
+        -- from dc1061: if the observation_source_concept_id is 1333023 or 1585890 and less than 6 members in the household --
         -- is under the age of 18, will set value_as_concept_id to the new custom concept --
-        WHEN observation_concept_id IN (1333023, 1585890) AND (value_as_number < 20 AND value_as_number > 5) THEN 2000000012
+        WHEN observation_source_concept_id IN (1333023, 1585890) AND (value_as_number < 20 AND value_as_number > 5) THEN 2000000012
     ELSE value_source_concept_id
     END AS
     value_source_concept_id,
@@ -155,7 +155,7 @@ class CleanPPINumericFieldsUsingParameters(BaseCleaningRule):
             'to new AOU custom concept 2000000012 for households with 6 or more individuals '
             'under the age of 18')
         super().__init__(issue_numbers=[
-            'DC1058', 'DC1061', 'DC827', 'DC502', 'DC487', 'DC2475'
+            'DC1058', 'DC1061', 'DC827', 'DC502', 'DC487', 'DC2475', 'DC2649'
         ],
                          description=desc,
                          affected_datasets=[cdr_consts.RDR],

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info.py
@@ -68,7 +68,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 cope_lookup_dataset_id=None,
+                 clean_survey_dataset_id=None,
                  table_namer=None):
         """
         Initialize the class with proper info.
@@ -95,10 +95,10 @@ class COPESurveyVersionTask(BaseCleaningRule):
             depends_on=[GenerateExtTables],
             table_namer=table_namer)
 
-        if not cope_lookup_dataset_id:
-            raise RuntimeError("'cope_lookup_dataset_id' must be set")
+        if not clean_survey_dataset_id:
+            raise RuntimeError("'clean_survey_dataset_id' must be set")
 
-        self.cope_lookup_dataset_id = cope_lookup_dataset_id
+        self.clean_survey_dataset_id = clean_survey_dataset_id
 
     def get_query_specs(self):
         """
@@ -113,7 +113,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
                 VERSION_COPE_SURVEYS_QUERY.render(
                     project_id=self.project_id,
                     dataset_id=self.dataset_id,
-                    cope_table_dataset_id=self.cope_lookup_dataset_id,
+                    cope_table_dataset_id=self.clean_survey_dataset_id,
                     cope_survey_mapping_table=COPE_SURVEY_MAP)
         }
 
@@ -128,7 +128,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
         to use it in a cleaning query.
         """
         msg = ''
-        tables = client.list_tables(self.cope_lookup_dataset_id)
+        tables = client.list_tables(self.clean_survey_dataset_id)
         try:
             table_ids = [table.table_id for table in tables]
         except (BadRequest):
@@ -137,7 +137,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
             LOGGER.exception(msg)
         except (NotFound):
             msg = (f"{self.__class__.__name__} cannot execute because dataset: "
-                   f"'{self.cope_lookup_dataset_id}' "
+                   f"'{self.clean_survey_dataset_id}' "
                    f"does not exist in project: '{self.project_id}'")
             LOGGER.exception(msg)
         else:
@@ -145,7 +145,7 @@ class COPESurveyVersionTask(BaseCleaningRule):
                 msg = (f"{self.__class__.__name__} cannot execute because the "
                        f"cope survey mapping table: '{COPE_SURVEY_MAP}' "
                        f"does not exist in "
-                       f"'{self.project_id}.{self.cope_lookup_dataset_id}'")
+                       f"'{self.project_id}.{self.clean_survey_dataset_id}'")
                 LOGGER.error(msg)
         finally:
             # raise the message to error out of a running shell script
@@ -187,9 +187,9 @@ if __name__ == '__main__':
 
     parser = ap.get_argument_parser()
     parser.add_argument(
-        '--cope_survey_dataset',
+        '--clean_survey_dataset',
         action='store',
-        dest='cope_survey_dataset_id',
+        dest='clean_survey_dataset_id',
         help=('Dataset containing the mapping table provided by RDR team.  '
               'These maps questionnaire_response_ids to cope_months.'),
         required=True)
@@ -204,7 +204,7 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(COPESurveyVersionTask,)],
-            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)
         for query_dict in query_list:
             LOGGER.info(query_dict.get(cdr_consts.QUERY))
     else:
@@ -212,4 +212,4 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(COPESurveyVersionTask,)],
-            cope_lookup_dataset_id=ARGS.cope_survey_dataset_id)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)

--- a/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 UPDATE_SURVEY_CONDUCT_EXT_QUERY = JINJA_ENV.from_string("""
 UPDATE `{{project_id}}.{{dataset_id}}.survey_conduct_ext` AS sce
 SET language = qrai.value
-FROM `{{project_id}}.{{additional_info_dataset}}.questionnaire_response_additional_info` AS qrai
+FROM `{{project_id}}.{{clean_survey_dataset_id}}.questionnaire_response_additional_info` AS qrai
 WHERE sce.survey_conduct_id = qrai.questionnaire_response_id
 AND UPPER(qrai.type) = 'LANGUAGE'
 """)
@@ -34,7 +34,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                  project_id,
                  dataset_id,
                  sandbox_dataset_id,
-                 additional_info_dataset=None,
+                 clean_survey_dataset_id=None,
                  table_namer=None):
         """
         Initialize the class with proper information.
@@ -57,7 +57,10 @@ class PopulateSurveyConductExt(BaseCleaningRule):
                          depends_on=[GenerateExtTables, COPESurveyVersionTask],
                          table_namer=table_namer)
 
-        self.additional_info_dataset = additional_info_dataset
+        if not clean_survey_dataset_id:
+            raise RuntimeError("'clean_survey_dataset_id' must be set")
+
+        self.clean_survey_dataset_id = clean_survey_dataset_id
 
     def get_query_specs(self):
         """
@@ -66,7 +69,7 @@ class PopulateSurveyConductExt(BaseCleaningRule):
         update_query = UPDATE_SURVEY_CONDUCT_EXT_QUERY.render(
             project_id=self.project_id,
             dataset_id=self.dataset_id,
-            additional_info_dataset=self.additional_info_dataset)
+            clean_survey_dataset_id=self.clean_survey_dataset_id)
 
         update_query_dict = {cdr_consts.QUERY: update_query}
 
@@ -100,9 +103,9 @@ if __name__ == '__main__':
 
     ap = parser.get_argument_parser()
     ap.add_argument(
-        '--additional_info_dataset',
+        '--clean_survey_dataset',
         action='store',
-        dest='additional_info_dataset',
+        dest='clean_survey_dataset_id',
         help=
         ('Dataset containing the mapping table provided by RDR team.  '
          'These have additional info like language to questionnaire_response_id.'
@@ -119,7 +122,7 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(PopulateSurveyConductExt,)],
-            additional_info_dataset=ARGS.additional_info_dataset)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)
         for query in query_list:
             LOGGER.info(query)
     else:
@@ -128,4 +131,4 @@ if __name__ == '__main__':
             ARGS.project_id,
             ARGS.dataset_id,
             ARGS.sandbox_dataset_id, [(PopulateSurveyConductExt,)],
-            additional_info_dataset=ARGS.additional_info_dataset)
+            clean_survey_dataset_id=ARGS.clean_survey_dataset_id)

--- a/data_steward/retraction/run_retraction.py
+++ b/data_steward/retraction/run_retraction.py
@@ -37,6 +37,7 @@ from retraction.retract_data_bq import run_bq_retraction, RETRACTION_ONLY_EHR, R
 from retraction.retract_utils import is_fitbit_dataset
 from utils import pipeline_logging
 from utils.auth import get_impersonation_credentials
+from utils.parameter_validators import validate_release_tag_param
 
 LOGGER = logging.getLogger(__name__)
 
@@ -189,6 +190,7 @@ def parse_args(raw_args=None):
         action='store',
         dest='new_release_tag',
         required=True,
+        type=validate_release_tag_param,
         help='Release tag for the new datasets after retraction.')
     parser.add_argument(
         '--lookup_creation_sql_file_path',

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -191,15 +191,14 @@ def generate_output_prod(tier,
             f'Copying fitbit tables from dataset {src_project_id}.{fitbit_dataset_id} to {src_project_id}.{src_dataset_id}...'
         )
 
-        copy_fitbit_jobs = bq_client.copy_dataset(
-            f'{src_project_id}.{fitbit_dataset_id}',
-            f'{src_project_id}.{src_dataset_id}')
+        _ = bq_client.copy_dataset(f'{src_project_id}.{fitbit_dataset_id}',
+                                   f'{src_project_id}.{src_dataset_id}')
 
     #Copy tables from source to output-prod
     LOGGER.info(
         f'Copying tables from dataset {src_project_id}.{src_dataset_id} to {output_prod_project_id}.{output_dataset_name}...'
     )
-    copy_src_jobs = bq_client.copy_dataset(
+    _ = bq_client.copy_dataset(
         f'{src_project_id}.{src_dataset_id}',
         f'{output_prod_project_id}.{output_dataset_name}')
 

--- a/data_steward/tools/deid_runner.sh
+++ b/data_steward/tools/deid_runner.sh
@@ -12,8 +12,6 @@ Usage: deid_runner.sh
   --deid_questionnaire_response_map_dataset <deid questionnaire response map dataset name>
   --vocab_dataset <vocabulary dataset name>
   --dataset_release_tag <release tag for the CDR>
-  --cope_lookup_dataset_id <dataset where RDR provided cope survey mapping table is loaded>
-  --cope_table_name <name of the cope survey mapping table>
   --deid_max_age <integer maximum age for de-identified participants>
 "
 
@@ -47,14 +45,6 @@ while true; do
     dataset_release_tag=$2
     shift 2
     ;;
-  --cope_lookup_dataset_id)
-    cope_lookup_dataset_id=$2
-    shift 2
-    ;;
-  --cope_table_name)
-    cope_table_name=$2
-    shift 2
-    ;;
   --deid_max_age)
     deid_max_age=$2
     shift 2
@@ -69,8 +59,7 @@ done
 
 if [[ -z "${key_file}" ]] || [[ -z "${cdr_id}" ]] || [[ -z "${run_as}" ]] || [[ -z "${pmi_email}" ]] || \
    [[ -z "${deid_questionnaire_response_map_dataset}" ]] || [[ -z "${vocab_dataset}" ]] || \
-   [[ -z "${dataset_release_tag}" ]] || [[ -z "${cope_lookup_dataset_id}" ]] || \
-   [[ -z "${cope_table_name}" ]] || [[ -z "${deid_max_age}" ]]; then
+   [[ -z "${dataset_release_tag}" ]] || [[ -z "${deid_max_age}" ]]; then
   echo "${USAGE}"
   exit 1
 fi
@@ -123,8 +112,8 @@ bq mk --dataset --force --description "${version} sandbox dataset to apply clean
 unset GOOGLE_APPLICATION_CREDENTIALS
 gcloud config set account "${pmi_email}"
 
-# apply de-identification rules on registered tier dataset 
-python "${CLEANER_DIR}/clean_cdr.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --run_as "${run_as}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --data_stage ${data_stage} --mapping_dataset_id "${cdr_id}"  --cope_lookup_dataset_id "${cope_lookup_dataset_id}" --cope_table_name "${cope_table_name}" --deid_questionnaire_response_map_dataset "${deid_questionnaire_response_map_dataset}" -s 2>&1 | tee registered_tier_cleaning_log.txt
+# apply de-identification rules on registered tier dataset
+python "${CLEANER_DIR}/clean_cdr.py" --project_id "${APP_ID}" --dataset_id "${registered_cdr_deid}" --run_as "${run_as}" --sandbox_dataset_id "${registered_cdr_deid_sandbox}" --data_stage ${data_stage} --mapping_dataset_id "${cdr_id}" --deid_questionnaire_response_map_dataset "${deid_questionnaire_response_map_dataset}" -s 2>&1 | tee registered_tier_cleaning_log.txt
 
 # Add GOOGLE_APPLICATION_CREDENTIALS environment variable
 export GOOGLE_APPLICATION_CREDENTIALS="${key_file}"

--- a/data_steward/tools/run_basics_remediation.py
+++ b/data_steward/tools/run_basics_remediation.py
@@ -27,6 +27,7 @@ from gcloud.bq import BigQueryClient
 from resources import ask_if_continue, get_new_dataset_name
 from utils import pipeline_logging
 from utils.auth import get_impersonation_credentials
+from utils.parameter_validators import validate_release_tag_param
 
 LOGGER = logging.getLogger(__name__)
 
@@ -176,6 +177,7 @@ def parse_args(raw_args=None):
         action='store',
         dest='new_release_tag',
         required=True,
+        type=validate_release_tag_param,
         help='Release tag for the new datasets after remediation.')
     parser.add_argument('-l',
                         '--console_log',

--- a/data_steward/validation/achilles.py
+++ b/data_steward/validation/achilles.py
@@ -6,6 +6,7 @@ import os
 import app_identity
 import bq_utils
 import resources
+import common
 from validation import sql_wrangle
 
 ACHILLES_ANALYSIS = 'achilles_analysis'
@@ -14,7 +15,6 @@ ACHILLES_RESULTS_DIST = 'achilles_results_dist'
 ACHILLES_TABLES = [ACHILLES_ANALYSIS, ACHILLES_RESULTS, ACHILLES_RESULTS_DIST]
 ACHILLES_DML_SQL_PATH = os.path.join(resources.resource_files_path,
                                      'achilles_dml.sql')
-INSERT_INTO = 'insert into'
 
 
 def _get_run_analysis_commands(hpo_id):
@@ -26,6 +26,7 @@ def _get_run_analysis_commands(hpo_id):
 def load_analyses(hpo_id):
     """
     Populate achilles lookup table
+    
     :param hpo_id: hpo_id of the site to run achilles on
     :return: None
     """
@@ -44,6 +45,7 @@ def drop_or_truncate_table(client, command):
     """
     Deletes or truncates table
     Previously, deletion was used for both truncate and drop, and this function retains the behavior
+
     :param client: a BigQueryClient
     :param command: query to run
     :return: None
@@ -53,12 +55,15 @@ def drop_or_truncate_table(client, command):
     else:
         table_id = sql_wrangle.get_drop_table_name(command)
     if client.table_exists(table_id):
-        bq_utils.delete_table(table_id)
+        assert (table_id not in common.VOCABULARY_TABLES)
+        client.delete_table(
+            f'{os.environ.get("BIGQUERY_DATASET_ID")}.{table_id}')
 
 
 def run_analysis_job(command):
     """
     Runs command query and waits for job completion
+    
     :param command: query to run
     :return: None
     :raises RuntimeError: Raised if job takes too long to complete
@@ -81,6 +86,7 @@ def run_analysis_job(command):
 def run_analyses(client, hpo_id):
     """
     Run the achilles analyses
+    
     :param client: a BigQueryClient
     :param hpo_id: hpo_id of the site to run on
     :return: None
@@ -96,6 +102,7 @@ def run_analyses(client, hpo_id):
 def create_tables(hpo_id, drop_existing=False):
     """
     Create the achilles related tables
+    
     :param hpo_id: associated hpo id
     :param drop_existing: if True, drop existing tables
     :return: None

--- a/data_steward/validation/main.py
+++ b/data_steward/validation/main.py
@@ -151,7 +151,7 @@ def run_achilles(client, hpo_id=None):
     if hpo_id is not None:
         logging.info(f"Running achilles_heel for hpo_id '{hpo_id}'")
     achilles_heel.create_tables(hpo_id, True)
-    achilles_heel.run_heel(hpo_id=hpo_id)
+    achilles_heel.run_heel(client, hpo_id=hpo_id)
 
 
 @api_util.auth_required_cron
@@ -970,6 +970,7 @@ def _is_string_excluded_file(gcs_file_name):
 def process_hpo_copy(hpo_id):
     """
     copies over files from hpo bucket to drc bucket
+    
     :hpo_id: hpo from which to copy
     """
 
@@ -1006,7 +1007,8 @@ def process_hpo_copy(hpo_id):
 @api_util.auth_required_cron
 @log_traceback
 def copy_files(hpo_id):
-    """endpoint to copy files for hpo_id
+    """
+    endpoint to copy files for hpo_id
 
     :hpo_id: hpo from which to copy
     :return: json string indicating the job has finished

--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -88,13 +88,6 @@ class BqUtilsTest(unittest.TestCase):
             FAKE_HPO_ID)
         self.storage_client.empty_bucket(self.hpo_bucket)
 
-    def _drop_tables(self):
-        tables = bq_utils.list_tables()
-        for table in tables:
-            table_id = table['tableReference']['tableId']
-            if table_id not in common.VOCABULARY_TABLES:
-                bq_utils.delete_table(table_id)
-
     def _table_has_clustering(self, table_info):
         clustering = table_info.get('clustering')
         self.assertIsNotNone(clustering)

--- a/tests/integration_tests/data_steward/bq_utils_test.py
+++ b/tests/integration_tests/data_steward/bq_utils_test.py
@@ -88,15 +88,11 @@ class BqUtilsTest(unittest.TestCase):
             FAKE_HPO_ID)
         self.storage_client.empty_bucket(self.hpo_bucket)
 
-    def _table_has_clustering(self, table_info):
-        clustering = table_info.get('clustering')
-        self.assertIsNotNone(clustering)
-        fields = clustering.get('fields')
-        self.assertSetEqual(set(fields), {'person_id'})
-        time_partitioning = table_info.get('timePartitioning')
-        self.assertIsNotNone(time_partitioning)
-        tpe = time_partitioning.get('type')
-        self.assertEqual(tpe, 'DAY')
+    def _table_has_clustering(self, table):
+        self.assertIsNotNone(table.clustering_fields)
+        self.assertSetEqual(set(table.clustering_fields), {'person_id'})
+        self.assertIsNotNone(table.time_partitioning)
+        self.assertEqual(table.time_partitioning.type_, 'DAY')
 
     def test_load_csv(self):
         table_name = 'achilles_analysis'
@@ -131,9 +127,9 @@ class BqUtilsTest(unittest.TestCase):
         incomplete_jobs = bq_utils.wait_on_jobs([load_job_id])
         self.assertEqual(len(incomplete_jobs), 0,
                          'loading table {} timed out'.format(table_id))
-        table_info = bq_utils.get_table_info(table_id)
-        num_rows = table_info.get('numRows')
-        self.assertEqual(num_rows, '5')
+        table = self.bq_client.get_table(
+            f'{os.environ.get("BIGQUERY_DATASET_ID")}.{table_id}')
+        self.assertEqual(table.num_rows, 5)
 
     @mock.patch("gcloud.gcs.LOOKUP_TABLES_DATASET_ID", dataset_id)
     def test_query_result(self):
@@ -159,8 +155,9 @@ class BqUtilsTest(unittest.TestCase):
         result = bq_utils.create_table(table_id, fields)
         self.assertTrue('kind' in result)
         self.assertEqual(result['kind'], 'bigquery#table')
-        table_info = bq_utils.get_table_info(table_id)
-        self._table_has_clustering(table_info)
+        table = self.bq_client.get_table(
+            f'{os.environ.get("BIGQUERY_DATASET_ID")}.{table_id}')
+        self._table_has_clustering(table)
 
     def test_create_existing_table_without_drop_raises_error(self):
         table_id = 'some_random_table_id'

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/bigquery_tests_base.py
@@ -349,6 +349,7 @@ class BaseTest:
                     destination, schema=schema),
                                                      exists_ok=True)
                 self.client.copy_table(src_table, dst_table)
+                self.fq_table_names.append(destination)
 
     class DeidRulesTestBase(CleaningRulesTestBase):
         """

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_ppi_numeric_fields_using_parameters_test.py
@@ -4,7 +4,7 @@ Integration test for clean_ppi_numeric_fields_using_parameters module
 Apply value ranges to ensure that values are reasonable and to minimize the likelihood
 of sensitive information (like phone numbers) within the free text fields.
 
-Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475
+Original Issues: DC-1058, DC-1061, DC-827, DC-502, DC-487, DC-2475, DC-2649
 
 The intent is to ensure that numeric free-text fields that are not manipulated by de-id
 have value range restrictions applied to the value_as_number field across the entire dataset.
@@ -84,50 +84,50 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
         invalid_values_tmpl = self.jinja_env.from_string(
             """
             INSERT INTO `{{fq_dataset_name}}.observation`
-            (observation_id, person_id, observation_concept_id, observation_date,
+            (observation_id, person_id, observation_concept_id, observation_source_concept_id, observation_date,
              observation_type_concept_id, value_as_number, value_as_string, value_as_concept_id, value_source_concept_id)
             VALUES
                 -- invalid values test setup --
-                (103, 3, 1585795, date('2015-07-15'), 0, 100, NULL, 1234567, 1234567),
-                (104, 4, 1585802, date('2015-07-15'), 0, -100, NULL, 1234567, 1234567),
-                (105, 5, 1585820, date('2015-07-15'), 0, 256, NULL, 1234567, 1234567),
-                (106, 6, 1585820, date('2015-07-15'), 0, -256, NULL, 1234567, 1234567),
-                (107, 7, 1585864, date('2015-07-15'), 0, 100, NULL, 1234567, 1234567),
-                (108, 8, 1585870, date('2015-07-15'), 0, -100, NULL, 1234567, 1234567),
-                (109, 9, 1585873, date('2015-07-15'), 0, 15, NULL, 7654321, 7654321),
-                (110, 10, 1586159, date('2015-07-15'), 0, 16, NULL, 7654321, 7654321),
-                (111, 11, 1586162, date('2015-07-15'), 0, 17, NULL, 7654321, 7654321),
-                (122, 22, 1333023, date('2015-07-15'), 0, NULL, 'test', 7654321, 7654321)"""
+                (103, 3, 1585795,1585795, date('2015-07-15'), 0, 100, NULL, 1234567, 1234567),
+                (104, 4, 1585802,1585802, date('2015-07-15'), 0, -100, NULL, 1234567, 1234567),
+                (105, 5, 1585820,1585820, date('2015-07-15'), 0, 256, NULL, 1234567, 1234567),
+                (106, 6, 1585820,1585820, date('2015-07-15'), 0, -256, NULL, 1234567, 1234567),
+                (107, 7, 40766333,1585864, date('2015-07-15'), 0, 100, NULL, 1234567, 1234567),
+                (108, 8, 1585870,1585870, date('2015-07-15'), 0, -100, NULL, 1234567, 1234567),
+                (109, 9, 40770349,1585873, date('2015-07-15'), 0, 15, NULL, 7654321, 7654321),
+                (110, 10, 40766929,1586159, date('2015-07-15'), 0, 16, NULL, 7654321, 7654321),
+                (111, 11, 40766930,1586162, date('2015-07-15'), 0, 17, NULL, 7654321, 7654321),
+                (122, 22, 1333023,1333023, date('2015-07-15'), 0, NULL, 'test', 7654321, 7654321)"""
         ).render(fq_dataset_name=self.fq_dataset_name)
         queries.append(invalid_values_tmpl)
 
         eleven_plus_tmpl = self.jinja_env.from_string(
             """
             INSERT INTO `{{fq_dataset_name}}.observation`
-            (observation_id, person_id, observation_concept_id, observation_date,
+            (observation_id, person_id, observation_concept_id, observation_source_concept_id, observation_date,
              observation_type_concept_id, value_as_number, value_as_concept_id, value_source_concept_id)
             VALUES
                 -- 11+ generalization test setup --
-                (112, 12, 1333015, date('2020-09-06'), 0, -12, 1234567, 1234567),
-                (113, 13, 1585889, date('2020-09-06'), 0, 12, 1234567, 1234567),
-                (114, 14, 1333015, date('2020-09-06'), 0, 10, 7654321, 7654321),
-                (118, 18, 1585889, date('2020-09-06'), 0, 20, 7654321, 1234567),
-                (121, 21, 1333015, date('2020-09-06'), 0, 15, 1234567, 1234567)"""
+                (112, 12, 1333015,1333015, date('2020-09-06'), 0, -12, 1234567, 1234567),
+                (113, 13, 1585889,1585889, date('2020-09-06'), 0, 12, 1234567, 1234567),
+                (114, 14, 1333015,1333015, date('2020-09-06'), 0, 10, 7654321, 7654321),
+                (118, 18, 1585889,1585889, date('2020-09-06'), 0, 20, 7654321, 1234567),
+                (121, 21, 1333015,1333015, date('2020-09-06'), 0, 15, 1234567, 1234567)"""
         ).render(fq_dataset_name=self.fq_dataset_name)
         queries.append(eleven_plus_tmpl)
 
         six_plus_tmpl = self.jinja_env.from_string(
             """
             INSERT INTO `{{fq_dataset_name}}.observation`
-            (observation_id, person_id, observation_concept_id, observation_date,
+            (observation_id, person_id, observation_concept_id, observation_source_concept_id, observation_date,
              observation_type_concept_id, value_as_number, value_as_concept_id, value_source_concept_id)
             VALUES
                 -- 6+ generalization test setup --
-                (115, 15, 1333023, date('2020-09-11'), 0, -7, 1234567, 1234567),
-                (116, 16, 1585890, date('2020-09-11'), 0, 7, 1234567, 1234567),
-                (117, 17, 1333023, date('2020-09-11'), 0, 5, 7654321, 7654321),
-                (119, 19, 1585890, date('2020-09-11'), 0, 20, 7654321, 7654321),
-                (120, 20, 1333023, date('2020-09-11'), 0, 6, 1234567, 1234567)"""
+                (115, 15, 1333023,1333023, date('2020-09-11'), 0, -7, 1234567, 1234567),
+                (116, 16, 1585890,1585890, date('2020-09-11'), 0, 7, 1234567, 1234567),
+                (117, 17, 1333023,1333023, date('2020-09-11'), 0, 5, 7654321, 7654321),
+                (119, 19, 1585890,1585890, date('2020-09-11'), 0, 20, 7654321, 7654321),
+                (120, 20, 1333023,1333023, date('2020-09-11'), 0, 6, 1234567, 1234567)"""
         ).render(fq_dataset_name=self.fq_dataset_name)
         queries.append(six_plus_tmpl)
 
@@ -148,59 +148,64 @@ class CleanPPINumericFieldsUsingParameterTest(BaseTest.CleaningRulesTestBase):
                 121, 122
             ],
             'fields': [
-                'observation_id', 'observation_concept_id', 'value_as_number',
+                'observation_id', 'observation_concept_id',
+                'observation_source_concept_id', 'value_as_number',
                 'value_as_string', 'value_as_concept_id',
                 'value_source_concept_id'
             ],
             'cleaned_values': [
                 # invalid values tests
-                (103, 1585795, None, None,
+                (103, 1585795, 1585795, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (104, 1585802, None, None,
+                (104, 1585802, 1585802, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (105, 1585820, None, None,
+                (105, 1585820, 1585820, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (106, 1585820, None, None,
+                (106, 1585820, 1585820, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (107, 1585864, None, None,
+                (107, 40766333, 1585864, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (108, 1585870, None, None,
+                (108, 1585870, 1585870, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (109, 1585873, 15, None, 7654321, 7654321),
-                (110, 1586159, 16, None, 7654321, 7654321),
-                (111, 1586162, 17, None, 7654321, 7654321),
-                (122, 1333023, None, None,
+                (109, 40770349, 1585873, 15, None, 7654321, 7654321),
+                (110, 40766929, 1586159, 16, None, 7654321, 7654321),
+                (111, 40766930, 1586162, 17, None, 7654321, 7654321),
+                (122, 1333023, 1333023, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
                 # 11+ values tests
-                (112, 1333015, None, None,
+                (112, 1333015, 1333015, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (113, 1585889, None, None, self.eleven_plus_value_as_concept_id,
+                (113, 1585889, 1585889, None, None,
+                 self.eleven_plus_value_as_concept_id,
                  self.eleven_plus_value_as_concept_id),
-                (114, 1333015, 10, None, 7654321, 7654321),
-                (118, 1585889, None, None,
+                (114, 1333015, 1333015, 10, None, 7654321, 7654321),
+                (118, 1585889, 1585889, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (121, 1333015, None, None, self.eleven_plus_value_as_concept_id,
+                (121, 1333015, 1333015, None, None,
+                 self.eleven_plus_value_as_concept_id,
                  self.eleven_plus_value_as_concept_id),
                 # 6+ values tests
-                (115, 1333023, None, None,
+                (115, 1333023, 1333023, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (116, 1585890, None, None, self.six_plus_value_as_concept_id,
+                (116, 1585890, 1585890, None, None,
+                 self.six_plus_value_as_concept_id,
                  self.six_plus_value_as_concept_id),
-                (117, 1333023, 5, None, 7654321, 7654321),
-                (119, 1585890, None, None,
+                (117, 1333023, 1333023, 5, None, 7654321, 7654321),
+                (119, 1585890, 1585890, None, None,
                  self.invalid_values_value_as_concept_id,
                  self.invalid_values_value_as_concept_id),
-                (120, 1333023, None, None, self.six_plus_value_as_concept_id,
+                (120, 1333023, 1333023, None, None,
+                 self.six_plus_value_as_concept_id,
                  self.six_plus_value_as_concept_id)
             ]
         }]

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/survey_version_info_test.py
@@ -43,13 +43,13 @@ class COPESurveyVersionTaskTest(BaseTest.DeidRulesTestBase):
 
         dataset_id = os.environ.get('COMBINED_DATASET_ID')
         sandbox_id = f'{dataset_id}_sandbox'
-        cls.kwargs.update({'cope_lookup_dataset_id': cls.cope_dataset_id})
+        cls.kwargs.update({'clean_survey_dataset_id': cls.cope_dataset_id})
 
         cls.rule_instance = COPESurveyVersionTask(
             cls.project_id,
             dataset_id,
             sandbox_id,
-            cope_lookup_dataset_id=cls.cope_dataset_id)
+            clean_survey_dataset_id=cls.cope_dataset_id)
 
         cls.fq_table_names = [
             f"{cls.project_id}.{dataset_id}.observation",

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_route_ids_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_route_ids_test.py
@@ -39,6 +39,10 @@ class PopulateRouteIdsTest(BaseTest.CleaningRulesTestBase):
             f'{cls.project_id}.{cls.dataset_id}.{table}' for table in tables
         ]
 
+        for table in VOCABULARY_TABLES:
+            cls.fq_table_names.append(
+                f'{cls.project_id}.{cls.dataset_id}.{table}')
+
         cls.fq_sandbox_table_names = []
         for table in cls.rule_instance.get_sandbox_tablenames():
             cls.fq_sandbox_table_names.append(

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/populate_survey_conduct_ext_test.py
@@ -24,7 +24,7 @@ INSERT_SURVEY_CONDUCT_EXT = JINJA_ENV.from_string("""
 """)
 
 INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO = JINJA_ENV.from_string("""
-    INSERT INTO `{{project}}.{{additional_info_dataset}}.questionnaire_response_additional_info`
+    INSERT INTO `{{project}}.{{clean_survey_dataset_id}}.questionnaire_response_additional_info`
         (questionnaire_response_id, type, value)
     VALUES
         (11, 'LANGUAGE', 'en'),
@@ -48,9 +48,9 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
 
         cls.project_id = os.environ.get(PROJECT_ID)
         cls.dataset_id = os.environ.get('RDR_DATASET_ID')
-        cls.additional_info_dataset = os.environ.get('RDR_DATASET_ID')
+        cls.clean_survey_dataset_id = os.environ.get('RDR_DATASET_ID')
         cls.kwargs.update(
-            {'additional_info_dataset': cls.additional_info_dataset})
+            {'clean_survey_dataset_id': cls.clean_survey_dataset_id})
         sandbox_id = f"{cls.dataset_id}_sandbox"
         cls.sandbox_id = sandbox_id
 
@@ -58,13 +58,13 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             cls.project_id,
             cls.dataset_id,
             sandbox_id,
-            additional_info_dataset=cls.additional_info_dataset)
+            clean_survey_dataset_id=cls.clean_survey_dataset_id)
 
         cls.fq_sandbox_table_names = []
 
         cls.fq_table_names = [
             f'{cls.project_id}.{cls.dataset_id}.{SURVEY_CONDUCT}{EXT_SUFFIX}',
-            f'{cls.project_id}.{cls.additional_info_dataset}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
+            f'{cls.project_id}.{cls.clean_survey_dataset_id}.{QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO}',
         ]
 
         super().setUpClass()
@@ -76,7 +76,7 @@ class PopulateSurveyConductExtTest(BaseTest.CleaningRulesTestBase):
             project=self.project_id, dataset=self.dataset_id)
         insert_questionnaire_response_additional_info = INSERT_QUESTIONNAIRE_RESPONSE_ADDITIONAL_INFO.render(
             project=self.project_id,
-            additional_info_dataset=self.additional_info_dataset)
+            clean_survey_dataset_id=self.clean_survey_dataset_id)
 
         queries = [
             insert_survey_conduct_ext,

--- a/tests/integration_tests/data_steward/tools/create_combined_backup_dataset_test.py
+++ b/tests/integration_tests/data_steward/tools/create_combined_backup_dataset_test.py
@@ -138,8 +138,6 @@ class CreateCombinedBackupDatasetTest(unittest.TestCase):
             self.assertFalse(
                 self.bq_client.table_exists(
                     table, self.combined_dataset_id))  # sanity check
-            # self.bq_client.create_table(f'{self.combined_dataset_id}.{table}',
-            #                             exists_ok=True)
             self.bq_client.copy_table(f'{self.rdr_dataset_id}.{table}',
                                       f'{self.combined_dataset_id}.{table}')
             actual = self.bq_client.table_exists(f'{table}')
@@ -212,10 +210,12 @@ class CreateCombinedBackupDatasetTest(unittest.TestCase):
             expected_mapping_table = mapping_table_for(table)
             self.assertIn(expected_mapping_table, output_tables)
             expected_fields = resources.fields_for(expected_mapping_table)
-            actual_table_info = bq_utils.get_table_info(
-                expected_mapping_table, self.combined_dataset_id)
-            actual_fields = actual_table_info.get('schema',
-                                                  dict()).get('fields', [])
+            mapping_table_obj = self.bq_client.get_table(
+                f'{self.combined_dataset_id}.{expected_mapping_table}')
+            actual_fields = [
+                schema_field.__dict__['_properties']
+                for schema_field in mapping_table_obj.schema
+            ]
             actual_fields_norm = map(test_util.normalize_field_payload,
                                      actual_fields)
             self.assertCountEqual(expected_fields, actual_fields_norm)

--- a/tests/integration_tests/data_steward/validation/achilles_heel_test.py
+++ b/tests/integration_tests/data_steward/validation/achilles_heel_test.py
@@ -108,7 +108,7 @@ class AchillesHeelTest(unittest.TestCase):
 
         # run achilles heel
         achilles_heel.create_tables(randomized_hpo_id, True)
-        achilles_heel.run_heel(hpo_id=randomized_hpo_id)
+        achilles_heel.run_heel(self.bq_client, hpo_id=randomized_hpo_id)
 
         # validate
         query = sql_wrangle.qualify_tables(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,5 @@
 # Python imports
 import inspect
-from io import open
 import os
 from typing import Optional
 
@@ -34,13 +33,6 @@ COPY_HPO_FILES_URL = f'{main.PREFIX}CopyFiles/{FAKE_HPO_ID}'
 BASE_TESTS_PATH = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
 TEST_DATA_PATH = os.path.join(BASE_TESTS_PATH, 'test_data')
-EMPTY_VALIDATION_RESULT = os.path.join(TEST_DATA_PATH,
-                                       'empty_validation_result.csv')
-ALL_FILES_UNPARSEABLE_VALIDATION_RESULT = os.path.join(
-    TEST_DATA_PATH, 'all_files_unparseable_validation_result.csv')
-ALL_FILES_UNPARSEABLE_VALIDATION_RESULT_NO_HPO_JSON = os.path.join(
-    TEST_DATA_PATH, 'all_files_unparseable_validation_result_no_hpo.json')
-EMPTY_ERROR_CSV = os.path.join(TEST_DATA_PATH, 'empty_error.csv')
 
 # Test files for five person sample
 FIVE_PERSONS_PATH = os.path.join(TEST_DATA_PATH, 'five_persons')
@@ -55,8 +47,6 @@ FIVE_PERSONS_DRUG_EXPOSURE_CSV = os.path.join(FIVE_PERSONS_PATH,
                                               'drug_exposure.csv')
 FIVE_PERSONS_MEASUREMENT_CSV = os.path.join(FIVE_PERSONS_PATH,
                                             'measurement.csv')
-FIVE_PERSON_FACT_RELATIONSHIP_CSV = os.path.join(FIVE_PERSONS_PATH,
-                                                 'fact_relationship.csv')
 FIVE_PERSONS_PII_NAME_CSV = os.path.join(FIVE_PERSONS_PATH, 'pii_name.csv')
 FIVE_PERSONS_PARTICIPANT_MATCH_CSV = os.path.join(FIVE_PERSONS_PATH,
                                                   'participant_match.csv')
@@ -71,55 +61,13 @@ FIVE_PERSONS_FILES = [
 
 FIVE_PERSONS_SUCCESS_RESULT_CSV = os.path.join(
     TEST_DATA_PATH, 'five_persons_success_result.csv')
-FIVE_PERSONS_SUCCESS_RESULT_NO_HPO_JSON = os.path.join(
-    TEST_DATA_PATH, 'five_persons_success_result_no_hpo.json')
 
 # OMOP NYC and PITT test data from synpuf
 NYC_FIVE_PERSONS_PATH = os.path.join(TEST_DATA_PATH, 'nyc_five_person')
 PITT_FIVE_PERSONS_PATH = os.path.join(TEST_DATA_PATH, 'pitt_five_person')
 
-NYC_FIVE_PERSONS_PERSON_CSV = os.path.join(NYC_FIVE_PERSONS_PATH, 'person.csv')
-NYC_FIVE_PERSONS_VISIT_OCCURRENCE_CSV = os.path.join(NYC_FIVE_PERSONS_PATH,
-                                                     'visit_occurrence.csv')
-NYC_FIVE_PERSONS_CONDITION_OCCURRENCE_CSV = os.path.join(
-    NYC_FIVE_PERSONS_PATH, 'condition_occurrence.csv')
-NYC_FIVE_PERSONS_PROCEDURE_OCCURRENCE_CSV = os.path.join(
-    NYC_FIVE_PERSONS_PATH, 'procedure_occurrence.csv')
-NYC_FIVE_PERSONS_DRUG_EXPOSURE_CSV = os.path.join(NYC_FIVE_PERSONS_PATH,
-                                                  'drug_exposure.csv')
-NYC_FIVE_PERSONS_MEASUREMENT_CSV = os.path.join(NYC_FIVE_PERSONS_PATH,
-                                                'measurement.csv')
-NYC_FIVE_PERSONS_OBSERVATION_CSV = os.path.join(NYC_FIVE_PERSONS_PATH,
-                                                'observation.csv')
-NYC_FIVE_PERSONS_FILES = [
-    NYC_FIVE_PERSONS_PERSON_CSV, NYC_FIVE_PERSONS_VISIT_OCCURRENCE_CSV,
-    NYC_FIVE_PERSONS_CONDITION_OCCURRENCE_CSV,
-    NYC_FIVE_PERSONS_PROCEDURE_OCCURRENCE_CSV,
-    NYC_FIVE_PERSONS_DRUG_EXPOSURE_CSV, NYC_FIVE_PERSONS_MEASUREMENT_CSV,
-    NYC_FIVE_PERSONS_OBSERVATION_CSV
-]
-
-PITT_FIVE_PERSONS_PERSON_CSV = os.path.join(PITT_FIVE_PERSONS_PATH,
-                                            'person.csv')
-PITT_FIVE_PERSONS_VISIT_OCCURRENCE_CSV = os.path.join(PITT_FIVE_PERSONS_PATH,
-                                                      'visit_occurrence.csv')
-PITT_FIVE_PERSONS_CONDITION_OCCURRENCE_CSV = os.path.join(
-    PITT_FIVE_PERSONS_PATH, 'condition_occurrence.csv')
-PITT_FIVE_PERSONS_PROCEDURE_OCCURRENCE_CSV = os.path.join(
-    PITT_FIVE_PERSONS_PATH, 'procedure_occurrence.csv')
-PITT_FIVE_PERSONS_DRUG_EXPOSURE_CSV = os.path.join(PITT_FIVE_PERSONS_PATH,
-                                                   'drug_exposure.csv')
-PITT_FIVE_PERSONS_MEASUREMENT_CSV = os.path.join(PITT_FIVE_PERSONS_PATH,
-                                                 'measurement.csv')
 PITT_FIVE_PERSONS_OBSERVATION_CSV = os.path.join(PITT_FIVE_PERSONS_PATH,
                                                  'observation.csv')
-PITT_FIVE_PERSONS_FILES = [
-    PITT_FIVE_PERSONS_PERSON_CSV, PITT_FIVE_PERSONS_VISIT_OCCURRENCE_CSV,
-    PITT_FIVE_PERSONS_CONDITION_OCCURRENCE_CSV,
-    PITT_FIVE_PERSONS_PROCEDURE_OCCURRENCE_CSV,
-    PITT_FIVE_PERSONS_DRUG_EXPOSURE_CSV, PITT_FIVE_PERSONS_MEASUREMENT_CSV,
-    PITT_FIVE_PERSONS_OBSERVATION_CSV
-]
 
 RDR_PATH = os.path.join(TEST_DATA_PATH, 'rdr')
 RDR_PERSON_PATH = os.path.join(RDR_PATH, 'person.csv')
@@ -138,76 +86,10 @@ PII_FILE_LOAD_RESULT_CSV = os.path.join(TEST_DATA_PATH,
 # TODO update html file with results.html generated from synthetic data if needed
 FIVE_PERSON_RESULTS_FILE = os.path.join(TEST_DATA_PATH,
                                         'five_person_results.html')
-FIVE_PERSON_RESULTS_ACHILLES_ERROR_FILE = os.path.join(
-    TEST_DATA_PATH, 'five_person_results_achilles_error.html')
-
 TEST_VOCABULARY_PATH = os.path.join(TEST_DATA_PATH, 'vocabulary')
-TEST_VOCABULARY_CONCEPT_CSV = os.path.join(TEST_VOCABULARY_PATH, 'CONCEPT.csv')
-TEST_VOCABULARY_VOCABULARY_CSV = os.path.join(TEST_VOCABULARY_PATH,
-                                              'VOCABULARY.csv')
 
 TEST_DATA_METRICS_PATH = os.path.join(TEST_DATA_PATH, 'metrics')
 TEST_NYC_CU_COLS_CSV = os.path.join(TEST_DATA_METRICS_PATH, 'nyc_cu_cols.csv')
-TEST_MEASUREMENT_CSV = os.path.join(TEST_DATA_METRICS_PATH, 'measurement.csv')
-
-
-def _create_five_persons_success_result():
-    """
-    Generate the expected result payload for five_persons data set. For internal testing only.
-    """
-    import csv
-
-    field_names = ['file_name', 'found', 'parsed', 'loaded']
-
-    expected_result_items = []
-    for cdm_file in resources.CDM_CSV_FILES:
-        expected_item = dict(file_name=cdm_file,
-                             found="1",
-                             parsed="1",
-                             loaded="1")
-        expected_result_items.append(expected_item)
-    with open(FIVE_PERSONS_SUCCESS_RESULT_CSV, 'w') as f:
-        writer = csv.DictWriter(f, field_names, quoting=csv.QUOTE_ALL)
-        writer.writeheader()
-        writer.writerows(expected_result_items)
-
-
-def _export_query_response_by_path(p, hpo_id):
-    """Utility to create response test payloads"""
-
-    from validation import export
-
-    for f in export.list_files_only(p):
-        abs_path = os.path.join(p, f)
-        with open(abs_path, 'r') as fp:
-            sql = fp.read()
-            sql = export.render(sql,
-                                hpo_id,
-                                results_schema=bq_utils.get_dataset_id(),
-                                vocab_schema='synpuf_100')
-            query_result = bq_utils.query(sql)
-            out_file = os.path.join(TEST_DATA_EXPORT_PATH,
-                                    f.replace('.sql', '_response.json'))
-            with open(out_file, 'w') as fp:
-                data = dict()
-                if 'rows' in query_result:
-                    data['rows'] = query_result['rows']
-                if 'schema' in query_result:
-                    data['schema'] = query_result['schema']
-                import json
-                json.dump(data,
-                          fp,
-                          sort_keys=True,
-                          indent=4,
-                          separators=(',', ': '))
-
-
-def _export_query_responses():
-    from validation import export
-
-    for d in ['datadensity', 'achillesheel', 'person']:
-        p = os.path.join(export.EXPORT_PATH, d)
-        _export_query_response_by_path(p, FAKE_HPO_ID)
 
 
 def delete_all_tables(client, dataset_id):
@@ -224,7 +106,7 @@ def delete_all_tables(client, dataset_id):
     table_ids = [table.table_id for table in table_infos]
     for table_id in table_ids:
         if table_id not in common.VOCABULARY_TABLES + LOOKUP_TABLES:
-            bq_utils.delete_table(table_id, dataset_id)
+            client.delete_table(f'{dataset_id}.{table_id}')
             deleted.append(table_id)
     return deleted
 
@@ -253,20 +135,6 @@ def populate_achilles(hpo_id=FAKE_HPO_ID, include_heel=True):
     bq_utils.wait_on_jobs(running_jobs)
 
 
-def generate_rdr_files():
-    """
-    Generate test csv files based on a sample of synthetic RDR data
-
-    :return:
-    """
-    d = 'rdr_dataset_2018_4_17'
-    for table in resources.CDM_TABLES:
-        q = 'SELECT * FROM fake_%s WHERE person_id IN (SELECT person_id FROM sample_person_id)' % table
-        cmd = 'bq query --dataset_id={d} --format=csv "{q}" > %(table)s.csv'.format(
-            d=d, q=q)
-        os.system(cmd)
-
-
 def bash(cmd):
     """
     Run a bash-specific command
@@ -289,24 +157,6 @@ def bash(cmd):
     return subprocess.check_call([bash_cmd, '-c', cmd],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
-
-
-def command(cmd):
-    return os.system(cmd)
-
-
-def list_files_in(path):
-    """
-    List the abs paths to files (not dirs) in the supplied path
-
-    :param path:
-    :return:
-    """
-    return [
-        os.path.join(path, f)
-        for f in os.listdir(path)
-        if os.path.isfile(os.path.join(path, f))
-    ]
 
 
 def get_table_summary(dataset_id):

--- a/tests/unit_tests/data_steward/cdm_test.py
+++ b/tests/unit_tests/data_steward/cdm_test.py
@@ -1,7 +1,7 @@
 import unittest
 from mock import patch
 
-import cdm, common
+import cdm
 
 
 class CDMTest(unittest.TestCase):
@@ -18,12 +18,12 @@ class CDMTest(unittest.TestCase):
         self.mock_table = 'mock_table'
         self.mock_component = 'mock_component'
 
-        self.mock_achilles = common.ACHILLES
+        self.mock_achilles = 'mock_achilles'
         self.mock_vocabulary = 'mock_vocabulary'
 
-    @patch('common.CDM_COMPONENTS')
-    @patch('resources.CDM_TABLES')
-    def test_parser_with_bad_args(self, mock_cdm_tables, mock_cdm_components):
+    @patch('cdm.common')  # components
+    @patch('cdm.resources')  # tables
+    def test_parser_with_bad_args(self, mock_resources, mock_common):
         """
         Case 1: No dataset
         Case 2: Bad table
@@ -32,8 +32,9 @@ class CDMTest(unittest.TestCase):
         Case 5: table/component mutual exclusion violation with good args
         """
 
-        mock_cdm_tables.return_value = [self.mock_table]
-        mock_cdm_components.return_value = [self.mock_component]
+        mock_common.CDM_COMPONENTS = [self.mock_component, self.mock_achilles]
+        mock_common.ACHILLES = [self.mock_achilles]
+        mock_resources.CDM_TABLES = [self.mock_table]
 
         parser = cdm.get_parser()
 
@@ -49,9 +50,11 @@ class CDMTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             _ = parser.parse_args(test_args)
 
-        test_args = [self.mock_dataset, '--component', self.mock_achilles]
-        with self.assertRaises(SystemExit):
-            _ = parser.parse_args(test_args)
+        # Incorrect, targets parser, not main()
+        # test_args = [self.mock_dataset, '--component', self.mock_achilles]
+        # with self.assertRaises(NotImplementedError):
+        #     _ = parser.parse_args(test_args)
+        #     cdm.main()
 
         test_args = [
             self.mock_dataset, '--component', self.mock_component, '--table',
@@ -60,27 +63,30 @@ class CDMTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             _ = parser.parse_args(test_args)
 
-    @patch('common.VOCABULARY')
-    def test_parser_with_good_args(self, mock_vocabulary):
+    @patch('cdm.common')  # components
+    @patch('cdm.resources')  # tables
+    def test_parser_with_good_args(self, mock_resources, mock_common):
         """
-        Case 1: Only a dataset specified
-        Case 2: Dataset with table
-        Case 3: Dataset with common.vocabulary component
+        Case 1: Only a dataset specified -> create_all()
+        Case 2: Dataset with table -> create_table()
+        Case 3: Dataset with component -> create_vocabulary()
         Case 4: Dataset with no matching component
         """
 
-        mock_vocabulary.return_value = self.mock_vocabulary
+        mock_common.CDM_COMPONENTS = [self.mock_component, self.mock_achilles]
+        mock_common.ACHILLES = [self.mock_achilles]
+        mock_resources.CDM_TABLES = [self.mock_table]
 
         parser = cdm.get_parser()
 
         test_args = [self.mock_dataset]
-        result_args = parser.parse_args(test_args)
+        result = parser.parse_args(test_args)
+        self.assertIn(self.mock_dataset, list(vars(result).values()))
 
-        test_args = [self.mock_dataset, '--component', 'test_vocabulary']
-        result_args = parser.parse_args(test_args)
+        test_args = [self.mock_dataset, '--table', self.mock_table]
+        result = parser.parse_args(test_args)
+        self.assertIn(self.mock_table, list(vars(result).values()))
 
-        test_args = [
-            self.mock_dataset,
-            '--table',
-        ]
-        result_args = parser.parse_args(test_args)
+        test_args = [self.mock_dataset, '--component', self.mock_component]
+        result = parser.parse_args(test_args)
+        self.assertIn(self.mock_component, list(vars(result).values()))

--- a/tests/unit_tests/data_steward/cdm_test.py
+++ b/tests/unit_tests/data_steward/cdm_test.py
@@ -37,7 +37,7 @@ class CDMTest(unittest.TestCase):
         mock_common.ACHILLES = self.mock_achilles
         mock_resources.CDM_TABLES = [self.mock_table]
 
-        parser = cdm.get_parser()
+        parser = cdm.create_parser()
 
         # Case 1
         test_args = ['--table', self.mock_table]

--- a/tests/unit_tests/data_steward/cdm_test.py
+++ b/tests/unit_tests/data_steward/cdm_test.py
@@ -1,5 +1,6 @@
 import unittest
 from mock import patch
+from types import SimpleNamespace
 
 import cdm
 
@@ -13,7 +14,7 @@ class CDMTest(unittest.TestCase):
         print('**************************************************************')
 
     def setUp(self):
-        self.mock_dataset = 'mock_dataset'
+        self.mock_dataset_id = 'mock_dataset'
 
         self.mock_table = 'mock_table'
         self.mock_component = 'mock_component'
@@ -25,39 +26,48 @@ class CDMTest(unittest.TestCase):
     @patch('cdm.resources')  # tables
     def test_parser_with_bad_args(self, mock_resources, mock_common):
         """
-        Case 1: No dataset
-        Case 2: Bad table
-        Case 3: Bad component
-        Case 4: Using Achilles (NYI)
-        Case 5: table/component mutual exclusion violation with good args
+        Case 1: No dataset, good table
+        Case 2: Bad table, good dataset
+        Case 3: Bad component, good dataset
+        Case 4: Create a NotYetImplemented case, good dataset
+        Case 5: table/component mutual exclusion violation, good args
         """
 
         mock_common.CDM_COMPONENTS = [self.mock_component, self.mock_achilles]
-        mock_common.ACHILLES = [self.mock_achilles]
+        mock_common.ACHILLES = self.mock_achilles
         mock_resources.CDM_TABLES = [self.mock_table]
 
         parser = cdm.get_parser()
 
-        test_args = []
+        # Case 1
+        test_args = ['--table', self.mock_table]
         with self.assertRaises(SystemExit):
             _ = parser.parse_args(test_args)
 
-        test_args = [self.mock_dataset, '--table', 'bad_table']
+        # Case 2
+        test_args = [self.mock_dataset_id, '--table', 'bad_table']
         with self.assertRaises(SystemExit):
             _ = parser.parse_args(test_args)
 
-        test_args = [self.mock_dataset, '--component', 'bad_component']
+        # Case 3
+        test_args = [self.mock_dataset_id, '--component', 'bad_component']
         with self.assertRaises(SystemExit):
             _ = parser.parse_args(test_args)
 
-        # Incorrect, targets parser, not main()
-        # test_args = [self.mock_dataset, '--component', self.mock_achilles]
-        # with self.assertRaises(NotImplementedError):
-        #     _ = parser.parse_args(test_args)
-        #     cdm.main()
+        # Case 4
+        sn = SimpleNamespace()
+        sn.table = None
+        sn.component = self.mock_achilles
+        sn.dataset_id = self.mock_dataset_id
+        with self.assertRaises(NotImplementedError), patch(
+                'argparse.ArgumentParser.parse_args') as mock_args:
 
+            mock_args.return_value = sn
+            cdm.main()
+
+        # Case 5
         test_args = [
-            self.mock_dataset, '--component', self.mock_component, '--table',
+            self.mock_dataset_id, '--component', self.mock_component, '--table',
             self.mock_table
         ]
         with self.assertRaises(SystemExit):
@@ -67,26 +77,53 @@ class CDMTest(unittest.TestCase):
     @patch('cdm.resources')  # tables
     def test_parser_with_good_args(self, mock_resources, mock_common):
         """
-        Case 1: Only a dataset specified -> create_all()
-        Case 2: Dataset with table -> create_table()
+        Case 1: Only a dataset specified -> create_all_tables(dataset_id)
+        Case 2: Dataset with no matching component -> pass
         Case 3: Dataset with component -> create_vocabulary()
-        Case 4: Dataset with no matching component
+        Case 4: Dataset with table -> create_table()
         """
 
-        mock_common.CDM_COMPONENTS = [self.mock_component, self.mock_achilles]
-        mock_common.ACHILLES = [self.mock_achilles]
+        mock_common.VOCABULARY = self.mock_vocabulary
+        mock_common.CDM_COMPONENTS = [self.mock_component]
         mock_resources.CDM_TABLES = [self.mock_table]
 
-        parser = cdm.get_parser()
+        sn = SimpleNamespace()
+        sn.table = None
+        sn.component = None
+        sn.dataset_id = self.mock_dataset_id
 
-        test_args = [self.mock_dataset]
-        result = parser.parse_args(test_args)
-        self.assertIn(self.mock_dataset, list(vars(result).values()))
+        # Case 1
+        with patch('cdm.create_all_tables') as mock_create_all, patch(
+                'argparse.ArgumentParser.parse_args') as mock_args:
 
-        test_args = [self.mock_dataset, '--table', self.mock_table]
-        result = parser.parse_args(test_args)
-        self.assertIn(self.mock_table, list(vars(result).values()))
+            mock_args.return_value = sn  # Pre
+            cdm.main()  # Test
+            mock_create_all.assert_called_once_with(
+                self.mock_dataset_id)  # Post
 
-        test_args = [self.mock_dataset, '--component', self.mock_component]
-        result = parser.parse_args(test_args)
-        self.assertIn(self.mock_component, list(vars(result).values()))
+        # Case 2
+        sn.component = 'no_matching_table'
+        with patch('argparse.ArgumentParser.parse_args') as mock_args:
+
+            mock_args.return_value = sn  # Pre
+            cdm.main()  # Test
+            pass  # Post
+
+        # Case 3
+        sn.component = self.mock_vocabulary
+        with patch('cdm.create_vocabulary_tables') as mock_create_vocab, patch(
+                'argparse.ArgumentParser.parse_args') as mock_args:
+
+            mock_args.return_value = sn  # Pre
+            cdm.main()  # Test
+            mock_create_vocab.assert_called_once_with(self.mock_dataset_id)
+
+        # Case 4
+        sn.table = self.mock_table
+        with patch('cdm.create_table') as mock_create_table, patch(
+                'argparse.ArgumentParser.parse_args') as mock_args:
+
+            mock_args.return_value = sn  # Pre
+            cdm.main()  # Test
+            mock_create_table.assert_called_once_with(self.mock_table,
+                                                      self.mock_dataset_id)

--- a/tests/unit_tests/data_steward/cdm_test.py
+++ b/tests/unit_tests/data_steward/cdm_test.py
@@ -1,0 +1,70 @@
+import unittest
+
+from mock import patch
+import cdm
+
+
+class CDMTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.test_dataset = 'test_dataset'
+        self.test_component = 'test_component'
+        self.test_table = 'test_table'
+
+    @patch('common.VOCABULARY', ['mock_vocabulary'])
+    @patch('common.ACHILLES', ['mock_achilles'])
+    def test_parser_with_bad_ags(self, mock_achilles, mock_vocabulary):
+        """
+        Case 1: No dataset / arg specified
+        Case 2: bad table argument
+        Case 3: bad component argument
+        Case 4: bad table-component mutual exclusion violation
+        """
+
+        parser = cdm.get_parser()
+
+        test_args = []
+        with self.assertRaises(SystemExit):
+            _ = parser.parse_args(test_args)
+
+        test_args = [self.test_dataset, '--table', 'bad_table']
+        with self.assertRaises(SystemExit):
+            _ = parser.parse_args(test_args)
+
+        test_args = [self.test_dataset, '--component', 'bad_component']
+        with self.assertRaises(SystemExit):
+            _ = parser.parse_args(test_args)
+
+        test_args = [
+            self.test_dataset, '--component', self.test_component, '--table',
+            self.test_table
+        ]
+        with self.assertRaises(SystemExit):
+            _ = parser.parse_args(test_args)
+
+    @patch('common.VOCABULARY', ['mock_vocabulary'])
+    @patch('common.ACHILLES', ['mock_achilles'])
+    def test_parser_with_good_args(self, mock_achilles, mock_vocabulary):
+        """
+        Case 1: Only a dataset specified
+        Case 2: Dataset with table
+        Case 3: Dataset with common.vocabulary component
+        Case 4: Dataset with non-matching component
+        """
+
+        parser = cdm.get_parser()
+
+        test_args = [self.test_dataset]
+        result_args = parser.parse_args(test_args)
+
+        test_args = [self.test_dataset, '--table', mock_achilles]
+        result_args = parser.parse_args(test_args)
+
+        test_args = [self.test_dataset, '--component', mock_vocabulary]
+        result_args = parser.parse_args(test_args)

--- a/tests/unit_tests/data_steward/deid/press_test.py
+++ b/tests/unit_tests/data_steward/deid/press_test.py
@@ -30,6 +30,10 @@ class PressTest(unittest.TestCase):
 
     def setUp(self):
         # set up mocks for initialization
+        self.mock_bq_client_patcher = patch('deid.press.BigQueryClient')
+        self.mock_bq_client = self.mock_bq_client_patcher.start()
+        self.addCleanup(self.mock_bq_client_patcher.stop)
+
         mock_logs = patch('deid.press.set_up_logging')
         mock_logs.start()
         self.addCleanup(mock_logs.stop)


### PR DESCRIPTION
This PR removed two unused variables in the deid_runner.sh shell script.  It involved three fundamental changes:

1) The removal of three command line parameters in both deid_runner.sh and cdm.py scripts
2) Refactoring `data_steward/cdm.py`
- Create a [factory function](https://github.com/all-of-us/curation/blob/79c5160495046aa7e117a752c29f11ee3c7a5d53/data_steward/cdm.py#L16) to return an argument parser.  This parser now takes advantage of a [mutual exclusion clause](https://github.com/all-of-us/curation/blob/79c5160495046aa7e117a752c29f11ee3c7a5d53/data_steward/cdm.py#L25).
- Create a [main()](https://github.com/all-of-us/curation/blob/79c5160495046aa7e117a752c29f11ee3c7a5d53/data_steward/cdm.py#L91) function with simplified branching logic.
3) Create a unit test where one didn't exist before.
- Four test cases for [valid argument](https://github.com/all-of-us/curation/blob/79c5160495046aa7e117a752c29f11ee3c7a5d53/tests/unit_tests/data_steward/cdm_test.py#L68) and function calls.
- Five test cases with [bad arguments](https://github.com/all-of-us/curation/blob/79c5160495046aa7e117a752c29f11ee3c7a5d53/tests/unit_tests/data_steward/cdm_test.py#L26), including a NotYetImpleted ([here](https://github.com/all-of-us/curation/blob/883df1bf9f6dc5377dd5948c72af015d089f131f/data_steward/cdm.py#L102)) error ([here](https://github.com/all-of-us/curation/blob/883df1bf9f6dc5377dd5948c72af015d089f131f/tests/unit_tests/data_steward/cdm_test.py#L62)).

One critical piece to review is the branching logic near [line 96](https://github.com/all-of-us/curation/blob/883df1bf9f6dc5377dd5948c72af015d089f131f/data_steward/cdm.py#L96) and the mutex clause on [line 25](https://github.com/all-of-us/curation/blob/883df1bf9f6dc5377dd5948c72af015d089f131f/data_steward/cdm.py#L25), as the original logic had a dead end/do nothing branch. Was this the original intention? There is a pass statement on [line 105](https://github.com/all-of-us/curation/blob/883df1bf9f6dc5377dd5948c72af015d089f131f/data_steward/cdm.py#L105) to retain the original logic.

