### PR TITLE
[DC-3014] Use `bq.copy_dataset` in `create_rdr_snapshot` instead of `copy_raw_rdr_dataset`

### DIFF
--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -241,13 +241,14 @@ class BigQueryClient(Client):
         :param job_config: An optional google.cloud.bigquery.job.CopyJobConfig
         :return: incomplete jobs
         """
-        job_config = job_config if job_config else CopyJobConfig(write_disposition=WriteDisposition.WRITE_EMPTY)
+        job_config = job_config if job_config else CopyJobConfig(
+            write_disposition=WriteDisposition.WRITE_EMPTY)
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         job_list = []
         for table in tables:
             staging_table = f'{output_dataset}.{table.table_id}'
-            job_config.labels.update( {
+            job_config.labels.update({
                 'table_name': table.table_id,
                 'copy_from': input_dataset,
                 'copy_to': output_dataset

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -242,6 +242,9 @@ class BigQueryClient(Client):
         :return: incomplete jobs
         """
 
+        if not job_config:
+            job_config = CopyJobConfig()  # create an empty default
+
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         job_list = []

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -249,9 +249,9 @@ class BigQueryClient(Client):
         for table in tables:
             staging_table = f'{output_dataset}.{table.table_id}'
             job_config.labels.update({
-                'table_name': table.table_id,
-                'copy_from': input_dataset,
-                'copy_to': output_dataset
+                'table_name': table.table_id.lower(),
+                'copy_from': input_dataset.lower(),
+                'copy_to': output_dataset.lower()
             })
             job = self.copy_table(table, staging_table, job_config=job_config)
             job_list.append(job.job_id)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -250,11 +250,11 @@ class BigQueryClient(Client):
         job_list = []
         for table in tables:
             staging_table = f'{output_dataset}.{table.table_id}'
-            job_config.labels = {
+            job_config.labels.update( {
                 'table_name': table.table_id,
                 'copy_from': input_dataset,
                 'copy_to': output_dataset
-            }
+            })
             job = self.copy_table(table, staging_table, job_config=job_config)
             job_list.append(job.job_id)
         self.wait_on_jobs(job_list)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -12,6 +12,8 @@ from time import sleep
 from google.api_core import retry
 from google.cloud import bigquery
 from google.cloud.bigquery import Client
+from google.cloud.bigquery.job import CopyJobConfig, WriteDisposition
+
 from google.auth import default
 from google.api_core.exceptions import GoogleAPIError, BadRequest
 from google.cloud.exceptions import NotFound
@@ -227,7 +229,10 @@ class BigQueryClient(Client):
 
         return dataset
 
-    def copy_dataset(self, input_dataset: str, output_dataset: str) -> list:
+    def copy_dataset(self,
+                     input_dataset: str,
+                     output_dataset: str,
+                     job_config: CopyJobConfig = None) -> list:
         """
         Copies tables from source dataset to a destination datasets
 
@@ -240,7 +245,7 @@ class BigQueryClient(Client):
         job_list = []
         for table in tables:
             staging_table = f'{output_dataset}.{table.table_id}'
-            job = self.copy_table(table, staging_table)
+            job = self.copy_table(table, staging_table, job_config=job_config)
             job_list.append(job.job_id)
         self.wait_on_jobs(job_list)
         return job_list

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -232,7 +232,8 @@ class BigQueryClient(Client):
     def copy_dataset(self,
                      input_dataset: str,
                      output_dataset: str,
-                     job_config: CopyJobConfig = None) -> list:
+                     job_config: CopyJobConfig = None,
+                     include_metadata: bool = False) -> list:
         """
         Copies tables from source dataset to a destination datasets
 
@@ -240,11 +241,20 @@ class BigQueryClient(Client):
         :param output_dataset: fully qualified name of the output(destination) dataset
         :return: incomplete jobs
         """
+        if include_metadata and not job_config:
+            job_config = CopyJobConfig()
+            
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         job_list = []
         for table in tables:
             staging_table = f'{output_dataset}.{table.table_id}'
+            if include_metadata:
+                job_config.labels = {
+                    'table_name': table.table_id,
+                    'copy_from': input_dataset,
+                    'copy_to': output_dataset
+                }
             job = self.copy_table(table, staging_table, job_config=job_config)
             job_list.append(job.job_id)
         self.wait_on_jobs(job_list)

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -229,20 +229,22 @@ class BigQueryClient(Client):
 
         return dataset
 
-    def copy_dataset(self, input_dataset: str, output_dataset: str) -> list:
+    def copy_dataset(self,
+                     input_dataset: str,
+                     output_dataset: str,
+                     job_config: CopyJobConfig = None) -> list:
         """
         Copies tables from source dataset to a destination datasets
 
         :param input_dataset: fully qualified name of the input(source) dataset
         :param output_dataset: fully qualified name of the output(destination) dataset
+        :param job_config: An optional google.cloud.bigquery.job.CopyJobConfig
         :return: incomplete jobs
         """
 
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         job_list = []
-        job_config = CopyJobConfig(
-            write_disposition=bigquery.job.WriteDisposition.WRITE_EMPTY)
         for table in tables:
             staging_table = f'{output_dataset}.{table.table_id}'
             job_config.labels = {

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -241,10 +241,7 @@ class BigQueryClient(Client):
         :param job_config: An optional google.cloud.bigquery.job.CopyJobConfig
         :return: incomplete jobs
         """
-
-        if not job_config:
-            job_config = CopyJobConfig()  # create an empty default
-
+        job_config = job_config if job_config else CopyJobConfig(write_disposition=WriteDisposition.WRITE_EMPTY)
         # Copy input dataset tables to backup and staging datasets
         tables = super(BigQueryClient, self).list_tables(input_dataset)
         job_list = []

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -5,12 +5,10 @@ from argparse import ArgumentParser
 from datetime import datetime
 import logging
 
-from google.cloud import bigquery
-
 from cdr_cleaner import clean_cdr
 from cdr_cleaner.args_parser import add_kwargs_to_args
 from utils import auth
-from gcloud.bq import BigQueryClient
+from gcloud.bq import BigQueryClient, CopyJobConfig, WriteDisposition
 from utils import pipeline_logging
 from common import CDR_SCOPES
 
@@ -100,8 +98,10 @@ def main(raw_args=None):
     # create staging, sandbox, and clean datasets with descriptions and labels
     datasets = create_datasets(bq_client, args.rdr_dataset, args.release_tag)
 
+    job_config = CopyJobConfig(write_disposition=WriteDisposition.WRITE_EMPTY)
     bq_client.copy_dataset(input_dataset=args.rdr_dataset,
-                           output_dataset=datasets.get('staging'))
+                           output_dataset=datasets.get('staging'),
+                           job_config=job_config)
     LOGGER.info(
         f'RDR dataset COPY from `{args.rdr_dataset}` to `{datasets.get("staging")}` has completed'
     )

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -7,7 +7,6 @@ from argparse import ArgumentParser
 
 # Third-party imports
 from gcloud.bq import BigQueryClient
-from google.cloud.bigquery.job import CopyJobConfig, WriteDisposition
 
 # Project level imports
 from utils import auth

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -6,12 +6,13 @@ import logging
 from argparse import ArgumentParser
 
 # Third-party imports
-from gcloud.bq import BigQueryClient
+from google.cloud.bigquery.job import CopyJobConfig, WriteDisposition
 
 # Project level imports
-from utils import auth
 from cdr_cleaner import clean_cdr
 from cdr_cleaner.args_parser import add_kwargs_to_args
+from gcloud.bq import BigQueryClient
+from utils import auth
 from utils import pipeline_logging
 from common import CDR_SCOPES
 

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -99,18 +99,14 @@ def main(raw_args=None):
 
     # create staging, sandbox, and clean datasets with descriptions and labels
     datasets = create_datasets(bq_client, args.rdr_dataset, args.release_tag)
-
-
-    # copy raw data into staging dataset
-    # To replace with copy_dataset
-    #copy_raw_rdr_tables(bq_client, args.rdr_dataset, datasets.get('staging'))
-
+    
     job_config = CopyJobConfig(
         write_disposition=bigquery.job.WriteDisposition.WRITE_EMPTY)
 
     bq_client.copy_dataset(input_dataset=args.rdr_dataset,
                            output_dataset=datasets.get('staging'),
-                           job_config=job_config)
+                           job_config=job_config,
+                           include_metadata=True)
     LOGGER.info(
         f'RDR dataset COPY from `{args.rdr_dataset}` to `{datasets.get("staging")}` has completed'
     )
@@ -147,39 +143,6 @@ def main(raw_args=None):
 
     LOGGER.info(f'RDR snapshot and cleaning, '
                 f'`{bq_client.project}.{datasets.get("clean")}`, is complete.')
-
-
-def copy_raw_rdr_tables(client: BigQueryClient, rdr_dataset, rdr_staging):
-    LOGGER.info(
-        f'Beginning COPY of raw rdr tables from `{rdr_dataset}` to `{rdr_staging}`'
-    )
-    # get list of tables
-    src_tables = client.list_tables(rdr_dataset)
-
-    # create a copy job config
-    job_config = bigquery.job.CopyJobConfig(
-        write_disposition=bigquery.job.WriteDisposition.WRITE_EMPTY)
-
-    for table_item in src_tables:
-        job_config.labels = {
-            'table_name': table_item.table_id,
-            'copy_from': rdr_dataset,
-            'copy_to': rdr_staging
-        }
-
-        destination_table = f'{client.project}.{rdr_staging}.{table_item.table_id}'
-        # job_id defined to the second precision
-        job_id = (f'rdr_staging_copy_{table_item.table_id.lower()}_'
-                  f'{datetime.now().strftime("%Y%m%d_%H%M%S")}')
-        # copy each table to rdr dataset
-        client.copy_table(table_item.reference,
-                          destination_table,
-                          job_id=job_id,
-                          job_config=job_config)
-
-    LOGGER.info(
-        f'RDR raw table COPY from `{rdr_dataset}` to `{rdr_staging}` is complete'
-    )
 
 
 def create_datasets(client, rdr_dataset, release_tag):

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -10,7 +10,7 @@ from google.cloud import bigquery
 from cdr_cleaner import clean_cdr
 from cdr_cleaner.args_parser import add_kwargs_to_args
 from utils import auth
-from gcloud.bq import BigQueryClient, CopyJobConfig, WriteDisposition
+from gcloud.bq import BigQueryClient
 from utils import pipeline_logging
 from common import CDR_SCOPES
 
@@ -99,14 +99,9 @@ def main(raw_args=None):
 
     # create staging, sandbox, and clean datasets with descriptions and labels
     datasets = create_datasets(bq_client, args.rdr_dataset, args.release_tag)
-    
-    job_config = CopyJobConfig(
-        write_disposition=bigquery.job.WriteDisposition.WRITE_EMPTY)
 
     bq_client.copy_dataset(input_dataset=args.rdr_dataset,
-                           output_dataset=datasets.get('staging'),
-                           job_config=job_config,
-                           include_metadata=True)
+                           output_dataset=datasets.get('staging'))
     LOGGER.info(
         f'RDR dataset COPY from `{args.rdr_dataset}` to `{datasets.get("staging")}` has completed'
     )

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -2,7 +2,6 @@
 # This Script automates the process of generating the rdr_snapshot and apply rdr cleaning rules
 
 from argparse import ArgumentParser
-from datetime import datetime
 import logging
 
 from cdr_cleaner import clean_cdr

--- a/data_steward/tools/create_rdr_snapshot.py
+++ b/data_steward/tools/create_rdr_snapshot.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # This Script automates the process of generating the rdr_snapshot and apply rdr cleaning rules
 
-from argparse import ArgumentParser
+# Python standard imports
 import logging
+from argparse import ArgumentParser
 
+# Third-party imports
+from gcloud.bq import BigQueryClient
+from google.cloud.bigquery.job import CopyJobConfig, WriteDisposition
+
+# Project level imports
+from utils import auth
 from cdr_cleaner import clean_cdr
 from cdr_cleaner.args_parser import add_kwargs_to_args
-from utils import auth
-from gcloud.bq import BigQueryClient, CopyJobConfig, WriteDisposition
 from utils import pipeline_logging
 from common import CDR_SCOPES
 

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -254,6 +254,8 @@ class BQCTest(TestCase):
             jobs.append(fake_job)
         mock_copy_table.side_effect = jobs
         mock_list_jobs.return_value = jobs
+        mock_job_config = MagicMock()
+        mock_job_config.labels = {'foo_key': 'bar_value'}
 
         full_table_ids = [
             f'{self.client.project}.{self.dataset_id}.{table_id}'
@@ -267,15 +269,17 @@ class BQCTest(TestCase):
 
         self.client.copy_dataset(
             f'{self.client.project}.{self.dataset_id}',
-            f'{self.client.project}.{self.dataset_id}_snapshot')
+            f'{self.client.project}.{self.dataset_id}_snapshot',
+            job_config=mock_job_config)
         mock_list_tables.assert_called_once_with(
             f'{self.client.project}.{self.dataset_id}')
         self.assertEqual(mock_copy_table.call_count, len(list_tables_results))
         expected_calls = [
             call(
                 table_object,
-                f'{self.client.project}.{self.dataset_id}_snapshot.{table_object.table_id}'
-            ) for table_object in list_tables_results
+                f'{self.client.project}.{self.dataset_id}_snapshot.{table_object.table_id}',
+                job_config=mock_job_config)
+            for table_object in list_tables_results
         ]
         mock_copy_table.assert_has_calls(expected_calls)
 

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 # Third party imports
 from unittest.mock import ANY
 
-from google.api_core import retry
+
 from google.cloud import bigquery
 from google.cloud.bigquery import TableReference, DatasetReference
 from google.cloud.bigquery.table import TableListItem

--- a/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
+++ b/tests/unit_tests/data_steward/gcloud/bq/bq_test.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 # Third party imports
 from unittest.mock import ANY
 
-
 from google.cloud import bigquery
 from google.cloud.bigquery import TableReference, DatasetReference
 from google.cloud.bigquery.table import TableListItem


### PR DESCRIPTION
`data_steward/tools/create_rdr_snapshot.py` is not taking full advantage of the tools at its disposal via the `gcloud/bq/__init__.py` functionality.  Instead, this script defines `copy_raw_rdr_tables` to copy the contents of one dataset to another.   This PR deletes the `copy_raw_rdr_tables(...)` function and replaces the call with our implementation in the BigQueryClient, removing code duplication.

However, when `copy_raw_rdr_tables` created each table, it used a job_config (`CopyJobConfig`) to make each table with a specified write disposition which was later passed to the core copy_table method.  An optional parameter now facilitates this functionality.  If none is provided, a default is created.

This PR adds a feature to add labels `table_id`, `copy_from`, and `copy_to` to the copied tables using this new job_config.