### PR TITLE
[DC-3042] ` _get_kwargs` needs to be refactored to accept `=` key/value pairs in `clean_cdr.py`

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -6,6 +6,7 @@ to the query engine.
 """
 # Python imports
 import logging
+import typing
 
 # Project imports
 import cdr_cleaner.clean_cdr_engine as clean_engine
@@ -434,7 +435,7 @@ def _to_kwarg_val(val: str):
     return val
 
 
-def _get_kwargs(optional_args: str):
+def _get_kwargs(optional_args: typing.List[str]):
     # TODO: Move this function to as project level arg_parser so it can be reused.
     if len(optional_args) % 2:
         raise RuntimeError(

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -416,7 +416,7 @@ PARSING_ERROR_MESSAGE_FORMAT = (
     'Custom arguments need an associated keyword to store their value.')
 
 
-def _to_kwarg_key(arg):
+def _to_kwarg_key(arg: str):
     # TODO: Move this function to as project level arg_parser so it can be reused.
     if not arg.startswith('--'):
         raise RuntimeError(PARSING_ERROR_MESSAGE_FORMAT.format(arg=arg))
@@ -426,7 +426,7 @@ def _to_kwarg_key(arg):
     return key
 
 
-def _to_kwarg_val(val):
+def _to_kwarg_val(val: str):
     # TODO: Move this function to as project level arg_parser so it can be reused.
     # likely invalid use of args- allowing single dash e.g. negative values
     if val.startswith('--'):
@@ -434,7 +434,7 @@ def _to_kwarg_val(val):
     return val
 
 
-def _get_kwargs(optional_args):
+def _get_kwargs(optional_args: str):
     # TODO: Move this function to as project level arg_parser so it can be reused.
     # TODO: Move this function to as project level arg_parser so it can be reused.
     if len(optional_args) % 2:

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -436,7 +436,6 @@ def _to_kwarg_val(val: str):
 
 def _get_kwargs(optional_args: str):
     # TODO: Move this function to as project level arg_parser so it can be reused.
-    # TODO: Move this function to as project level arg_parser so it can be reused.
     if len(optional_args) % 2:
         raise RuntimeError(
             f'All provided arguments need key-value pairs in {optional_args}')

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -443,7 +443,7 @@ def _parsed_args_to_dict(parsed_args: typing.List[str], kind: str = 'count'):
     This creates and ensures a {key: value} pair from _get_kwargs(...).
     """
 
-    if not len(parsed_args) % 2:
+    if len(parsed_args) % 2:
         raise RuntimeError(
             PARSING_ERROR_MESSAGE_FORMAT.format(kind='count', arg=parsed_args))
 

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -413,19 +413,19 @@ def get_parser():
 
 
 PARSING_ERROR_MESSAGE_FORMAT = (
-    'An unexpected `%(kind)` was found parsing arguments near `%(arg)`.'
+    'An unexpected `{kind}` was found parsing arguments near `{arg}`.'
     'Please check your arguments.')
 
 
-def _to_kwarg_key(arg: str, kind: str = '--key') -> str:
+def _to_kwarg_key(key: str, kind: str = 'key') -> str:
     # TODO: Move this function to as project level arg_parser so it can be reused.
-    if not arg.startswith('--'):
+    if not key.startswith('--'):
         raise RuntimeError(
-            PARSING_ERROR_MESSAGE_FORMAT.format(kind=kind, arg=arg))
-    elif len(arg) < 3:
+            PARSING_ERROR_MESSAGE_FORMAT.format(kind=kind, arg=key))
+    elif len(key) < 3:
         raise RuntimeError(
-            PARSING_ERROR_MESSAGE_FORMAT.format(kind=kind, arg=arg))
-    key = arg[2:]
+            PARSING_ERROR_MESSAGE_FORMAT.format(kind=kind, arg=key))
+    key = key[2:]
     return key
 
 
@@ -438,27 +438,27 @@ def _to_kwarg_val(val: str, kind: str = 'value') -> str:
     return val
 
 
-def _parsed_args_to_dict(parsed_args: typing.List[str]):
+def _parsed_args_to_dict(parsed_args: typing.List[str], kind: str = 'count'):
+    """
+    This creates and ensures a {key: value} pair from _get_kwargs(...).
+    """
+
     if not len(parsed_args) % 2:
         raise RuntimeError(
             PARSING_ERROR_MESSAGE_FORMAT.format(kind='count', arg=parsed_args))
 
+    # _to_kwarg_key(...) and _to_kwargs_val(...) are validators
     return {
         _to_kwarg_key(arg): _to_kwarg_val(value)
         for arg, value in zip(parsed_args[0::2], parsed_args[1::2])
     }
 
 
-def _get_kwargs(args: typing.List[str]) -> dict:
+def _get_kwargs(args: typing.List[str]):
     """
-    This function will check args in an alternating way using index.
-    If the index is an even value, a key is expected other wise value.
-    The bad_pattern is `True`, then a formatted RuntimeError is raised.
-
-    For example:
-    An unexpected `--key` was found parsing arguments near `--foo`...
-
-    :return: parsed args: a dict in {key: value} format
+    This function separates arguments containing the `=` sign. Because this may introduce
+    other errors (e.g an odd number of elements, two keys `--keys=--key`) some basic validation
+    occurs. The complete validation uses _to_kwarg_[key|val] with additional checks.
     """
 
     parsed_args = []
@@ -468,28 +468,25 @@ def _get_kwargs(args: typing.List[str]) -> dict:
 
     for arg in args:
         key_expected = index % 2 == 0
-        if arg.startswith('--') and not key_expected:
+
+        if arg.startswith('--') and not key_expected or bad_pattern:
             bad_pattern = True
-            kind = '--key'
+            kind = 'key'
         elif not arg.startswith('--') and key_expected:
             bad_pattern = True
-            kind = 'arg'
-
+            kind = 'value'
         elif arg.count('=') > 1:
             bad_pattern = True
             kind = '='
         elif arg.startswith('--') and arg.count('=') == 1:
             arg = arg.split('=')
-            index += 1
-        else:
-            arg = [arg]
+            parsed_args.extend(arg)
+            continue  # arg had both --key and value on '=' split
 
         if bad_pattern:
             raise RuntimeError(
                 PARSING_ERROR_MESSAGE_FORMAT.format(kind=kind, arg=arg))
-        else:
-            parsed_args.extend(arg)
-
+        parsed_args.extend([arg])
         index += 1
 
     return _parsed_args_to_dict(parsed_args=parsed_args)

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -469,7 +469,7 @@ def _get_kwargs(args: typing.List[str]):
     for arg in args:
         key_expected = index % 2 == 0
 
-        if arg.startswith('--') and not key_expected or bad_pattern:
+        if arg.startswith('--') and not key_expected:
             bad_pattern = True
             kind = 'key'
         elif not arg.startswith('--') and key_expected:

--- a/tests/unit_tests/data_steward/cdr_cleaner/clean_cdr_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/clean_cdr_test.py
@@ -54,17 +54,38 @@ class CleanCDRTest(unittest.TestCase):
 
     def test_get_kwargs(self):
         expected = {'k1': 'v1', 'k2': 'v2'}
+
+        # All spaces
         actual_result = cc._get_kwargs(['--k1', 'v1', '--k2', 'v2'])
         self.assertEqual(expected, actual_result)
 
-        with self.assertRaises(RuntimeError) as c:
-            cc._get_kwargs(['--k1', 'v1', '--f1'])
+        # Space and `=`
+        actual_result = cc._get_kwargs(['--k1', 'v1', '--k2=v2'])
+        self.assertEqual(expected, actual_result)
 
-        with self.assertRaises(RuntimeError) as c:
+        # All `=`
+        actual_result = cc._get_kwargs(['--k1=v1', '--k2=v2'])
+        self.assertEqual(expected, actual_result)
+
+        # key mismatch, correct count
+        with self.assertRaises(RuntimeError):
+            cc._get_kwargs(['--k1', '--k2', 'v1', 'v2'])
+
+        # value mismatch, correct count
+        with self.assertRaises(RuntimeError):
+            cc._get_kwargs(['--k1', 'v1', 'v2', '--k2'])
+
+        # bad count
+        with self.assertRaises(RuntimeError):
+            cc._get_kwargs(['--k1=v1', '--k2'])
+
+        # `=` mismatched
+        with self.assertRaises(RuntimeError):
+            cc._get_kwargs(['--k1=v1=v2'])
+
+        # Empty key
+        with self.assertRaises(RuntimeError):
             cc._get_kwargs(['--', 'v1'])
-
-        with self.assertRaises(RuntimeError) as c:
-            cc._get_kwargs(['--k1', '--k2'])
 
     def test_to_kwarg_key(self):
         expected_result = 'k1'


### PR DESCRIPTION
In data_steward/cdr_cleaner/clean_cdr.py, the function _get_kwargs will fail with an error when it encounters an = operator with key value usage.  This PR fixes the issue and updates a unit test.