### PR TITLE
[DC-3094] Birth suppression rule should also be applied to the RT datasets

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -257,6 +257,7 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
         CovidEHRVaccineConceptSuppression,),  # should run after QRIDtoRID
     (MonkeypoxConceptSuppression,),
     (VehicularAccidentConceptSuppression,),
+    (BirthInformationSuppression,),
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),
     (ExplicitIdentifierSuppression,),

--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -257,7 +257,7 @@ REGISTERED_TIER_DEID_CLEANING_CLASSES = [
         CovidEHRVaccineConceptSuppression,),  # should run after QRIDtoRID
     (MonkeypoxConceptSuppression,),
     (VehicularAccidentConceptSuppression,),
-    (BirthInformationSuppression,),
+    (BirthInformationSuppression,),  # run after VehicularAccidentConcept
     (SectionParticipationConceptSuppression,),
     (RegisteredCopeSurveyQuestionsSuppression,),
     (ExplicitIdentifierSuppression,),

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/birth_information_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/birth_information_suppression.py
@@ -30,7 +30,10 @@ class BirthInformationSuppression(AbstractInMemoryLookupTableConceptSuppression
             'relating to birth information. ')
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
-                         affected_datasets=[cdr_consts.CONTROLLED_TIER_DEID],
+                         affected_datasets=[
+                             cdr_consts.CONTROLLED_TIER_DEID,
+                             cdr_consts.REGISTERED_TIER_DEID
+                         ],
                          project_id=project_id,
                          dataset_id=dataset_id,
                          sandbox_dataset_id=sandbox_dataset_id,


### PR DESCRIPTION
This PR adds `BirthInformationSuppression` to the  `REGISTERED_TIER_DEID_CLEANING_CLASSES` list.  It should be applied after `VehicularAccidentConceptSuppression`.  It is also added to the `affected_datasets` variable within the rule as well.