### PR TITLE
[DC-3096] [DC-3097] Abstract class for backfill/ Backfill CR for "The Basics"

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -10,6 +10,7 @@ import logging
 # Project imports
 import cdr_cleaner.clean_cdr_engine as clean_engine
 from cdr_cleaner.cleaning_rules.backfill_pmi_skip_codes import BackfillPmiSkipCodes
+from cdr_cleaner.cleaning_rules.backfill_the_basics import BackfillTheBasics
 from cdr_cleaner.cleaning_rules.clean_by_birth_year import CleanByBirthYear
 from cdr_cleaner.cleaning_rules.convert_pre_post_coordinated_concepts import ConvertPrePostCoordinatedConcepts
 from cdr_cleaner.cleaning_rules.create_expected_ct_list import StoreExpectedCTList
@@ -167,7 +168,8 @@ RDR_CLEANING_CLASSES = [
     (UpdateFieldsNumbersAsStrings,),
     (UpdateCopeFluQuestionConcept,),
     (MapsToValuePpiVocabUpdate,),
-    (BackfillPmiSkipCodes,),
+    (BackfillPmiSkipCodes,),  # Will be removed by DC-3100
+    (BackfillTheBasics,),
     (CleanPPINumericFieldsUsingParameters,),
     (RemoveMultipleRaceEthnicityAnswersQueries,),
     (UpdatePpiNegativePainLevel,),

--- a/data_steward/cdr_cleaner/cleaning_rules/backfill_survey_records.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/backfill_survey_records.py
@@ -1,0 +1,188 @@
+"""
+An abstract survey backfill class that expects an instantiating class to
+provide a list of observation_source_concept_ids to use for backfilling.
+If a participant has answered at least one of these questions, but has not
+answered them all, this rule is responsible for filling in the missing
+responses with skip codes.  
+
+This abstract class does most of the backfill work with customization provided
+by extending classes. It expects extending classes to provide the list of
+concepts that will be used to determine backfill eligibility.  
+It also allows extending classes to define criteria that may be specific to a
+sub-group (e.g. we only backfill menstruation questions for female participants).
+
+Original issue: DC-3096
+"""
+# Python imports
+from typing import Dict, List
+
+# Project imports
+import logging
+from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
+from constants.cdr_cleaner.clean_cdr import QUERY
+from common import JINJA_ENV, OBSERVATION, PERSON
+from resources import fields_for
+
+LOGGER = logging.getLogger(__name__)
+
+BACKFILL_QUERY = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.{{obs}}`
+({{obs_fields}})
+WITH person_who_answered_survey AS (
+    SELECT
+        person_id,
+        MAX(observation_date) AS observation_date,
+        MAX(observation_datetime) AS observation_datetime,
+    FROM `{{project}}.{{dataset}}.{{obs}}`
+    WHERE observation_source_concept_id IN ({{backfill_concepts}})
+    GROUP BY person_id
+),
+backfill_survey AS (
+    SELECT DISTINCT 
+        observation_concept_id,
+        observation_source_concept_id,
+        observation_source_value,
+        observation_type_concept_id
+    FROM `{{project}}.{{dataset}}.{{obs}}`
+    WHERE observation_source_concept_id IN ({{backfill_concepts}})
+),
+{% if additional_backfill_conditions -%}
+person_info_for_additional_condition AS (
+    SELECT * FROM `{{project}}.{{dataset}}.{{pers}}`
+    WHERE person_id IN (
+        SELECT person_id FROM person_who_answered_survey
+    )
+),
+{% endif %}
+missing_survey AS (
+    SELECT 
+        pwas.person_id,
+        bs.observation_concept_id,
+        pwas.observation_date,
+        pwas.observation_datetime,
+        bs.observation_type_concept_id,
+        bs.observation_source_value,
+        bs.observation_source_concept_id
+    FROM person_who_answered_survey pwas
+    CROSS JOIN backfill_survey bs
+    {% if additional_backfill_conditions -%}
+    JOIN person_info_for_additional_condition pi
+    ON pwas.person_id = pi.person_id
+    {% endif %}
+    WHERE NOT EXISTS (
+        SELECT 1 FROM `{{project}}.{{dataset}}.{{obs}}` o
+        WHERE pwas.person_id = o.person_id
+        AND bs.observation_source_concept_id = o.observation_source_concept_id
+    )
+    {% if additional_backfill_conditions -%}
+    AND {% for concept in additional_backfill_conditions %}
+        (
+            observation_source_concept_id != {{concept}}
+            OR (
+                observation_source_concept_id = {{concept}}
+                AND {{additional_backfill_conditions[concept]}}
+            )
+        )
+    {% if not loop.last -%} AND {% endif %}
+    {% endfor %}
+    {% endif %}
+)
+SELECT
+    ROW_NUMBER() OVER(
+        ORDER BY person_id, observation_source_concept_id
+    ) + (
+        SELECT MAX(observation_id) 
+        FROM `{{project}}.{{dataset}}.{{obs}}`
+    ) AS observation_id,
+    person_id,
+    observation_concept_id,
+    observation_date,
+    observation_datetime,
+    observation_type_concept_id,
+    NULL AS value_as_number,
+    CAST(NULL AS STRING) AS value_as_string,
+    903096 AS value_as_concept_id,
+    0 AS qualifier_concept_id,
+    0 AS unit_concept_id,
+    NULL AS provider_id,
+    NULL AS visit_occurrence_id,
+    NULL AS visit_detail_id,
+    observation_source_value,
+    observation_source_concept_id,
+    CAST(NULL AS STRING) AS unit_source_value,
+    CAST(NULL AS STRING) AS qualifier_source_value,
+    903096 AS value_source_concept_id,
+    'PMI_Skip' AS value_source_value, 
+    NULL AS questionnaire_response_id 
+FROM missing_survey
+""")
+
+
+class AbstractBackfillSurveyRecords(BaseCleaningRule):
+    """
+    Abstract class for creating backfill rules
+    """
+
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 issue_numbers,
+                 description,
+                 affected_datasets,
+                 affected_tables,
+                 backfill_concepts: List[int],
+                 additional_backfill_conditions: Dict[int, str] = {},
+                 table_namer=None):
+        """
+        Args that are unique to this abstract class:
+        - backfill_concepts
+            List of the concept IDs that need backfilling.            
+        - additional_backfill_conditions
+            Dict of the additional condition for backfilling.
+            Key: Concept ID that the additional condition is applied to.
+            Value: Condition written using BigQuery operators('=', '!=', '<', etc)
+                   for the concept ID.
+            Example:
+                An example for concept ID = 1585784 if it needs to be
+                backfilled only when the partiticipant's
+                gender_concept_id is 8532:
+                '''        
+                additional_backfill_conditions = {
+                    1585784: 'gender_concept_id = 8532',
+                }
+                '''
+        """
+
+        super().__init__(issue_numbers=issue_numbers,
+                         description=description,
+                         affected_datasets=affected_datasets,
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         affected_tables=affected_tables,
+                         table_namer=table_namer)
+
+        self.backfill_concepts = backfill_concepts
+        self.additional_backfill_conditions = additional_backfill_conditions
+
+    def setup_rule(self, client):
+        pass
+
+    def get_sandbox_tablenames(self):
+        # No sandbox table exists for this CR because it runs only an INSERT statement.
+        return []
+
+    def get_query_specs(self) -> query_spec_list:
+        query = BACKFILL_QUERY.render(
+            project=self.project_id,
+            dataset=self.dataset_id,
+            obs=OBSERVATION,
+            pers=PERSON,
+            obs_fields=', '.join(
+                field['name'] for field in fields_for(OBSERVATION)),
+            backfill_concepts=", ".join(
+                [str(concept_id) for concept_id in self.backfill_concepts]),
+            additional_backfill_conditions=self.additional_backfill_conditions)
+
+        return [{QUERY: query}]

--- a/data_steward/cdr_cleaner/cleaning_rules/backfill_survey_records.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/backfill_survey_records.py
@@ -14,10 +14,10 @@ sub-group (e.g. we only backfill menstruation questions for female participants)
 Original issue: DC-3096
 """
 # Python imports
+import logging
 from typing import Dict, List
 
 # Project imports
-import logging
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
 from constants.cdr_cleaner.clean_cdr import QUERY
 from common import JINJA_ENV, OBSERVATION, PERSON
@@ -120,7 +120,7 @@ FROM missing_survey
 
 class AbstractBackfillSurveyRecords(BaseCleaningRule):
     """
-    Abstract class for creating backfill rules
+    Abstract class for backfill cleaning rules.
     """
 
     def __init__(self,
@@ -136,9 +136,9 @@ class AbstractBackfillSurveyRecords(BaseCleaningRule):
                  table_namer=None):
         """
         Args that are unique to this abstract class:
-        - backfill_concepts
+        - backfill_concepts (mandatory)
             List of the concept IDs that need backfilling.            
-        - additional_backfill_conditions
+        - additional_backfill_conditions (optional)
             Dict of the additional condition for backfilling.
             Key: Concept ID that the additional condition is applied to.
             Value: Condition written using BigQuery operators('=', '!=', '<', etc)

--- a/data_steward/cdr_cleaner/cleaning_rules/backfill_the_basics.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/backfill_the_basics.py
@@ -1,0 +1,78 @@
+"""
+There are 15 questions that are expected to have answers for every participant
+who has taken TheBasics survey. If a participant has answered one or more of
+these 15 questions, curation is expected to backfill the answers with skip
+codes for any missing Q/A responses.
+
+This rule extends the abstract class for the skip record creation and run the
+backfill.
+
+Original issue: DC-3097
+"""
+# Python imports
+import logging
+
+# Project imports
+import constants.cdr_cleaner.clean_cdr as cdr_consts
+from cdr_cleaner.cleaning_rules.backfill_survey_records import AbstractBackfillSurveyRecords
+from common import OBSERVATION
+
+LOGGER = logging.getLogger(__name__)
+
+BACKFILL_CONCEPTS = [
+    1586135, 1586140, 1585838, 1585899, 1585940, 1585892, 1585889, 1585890,
+    1585386, 1585389, 1585952, 1585375, 1585370, 1585879, 1585886
+]
+
+
+class BackfillTheBasics(AbstractBackfillSurveyRecords):
+
+    def __init__(self,
+                 project_id,
+                 dataset_id,
+                 sandbox_dataset_id,
+                 table_namer=None):
+        desc = (
+            'Backfills TheBasics survey data with skip codes for participants who have any missing Q/A responses. '
+            'This rule extends the abstract class AbstractBackfillSurveyRecords for the skip record creation.'
+        )
+
+        super().__init__(issue_numbers=['DC3097'],
+                         description=desc,
+                         affected_datasets=[cdr_consts.RDR],
+                         affected_tables=[OBSERVATION],
+                         project_id=project_id,
+                         dataset_id=dataset_id,
+                         sandbox_dataset_id=sandbox_dataset_id,
+                         backfill_concepts=BACKFILL_CONCEPTS,
+                         table_namer=table_namer)
+
+    def setup_rule(self, client):
+        pass
+
+    def setup_validation(self, client):
+        raise NotImplementedError("Please fix me.")
+
+    def validate_rule(self, client):
+        raise NotImplementedError("Please fix me.")
+
+
+if __name__ == '__main__':
+    import cdr_cleaner.args_parser as parser
+    import cdr_cleaner.clean_cdr_engine as clean_engine
+
+    ARGS = parser.parse_args()
+
+    if ARGS.list_queries:
+        clean_engine.add_console_logging()
+        query_list = clean_engine.get_query_list(ARGS.project_id,
+                                                 ARGS.dataset_id,
+                                                 ARGS.sandbox_dataset_id,
+                                                 [(BackfillTheBasics,)])
+        for query in query_list:
+            LOGGER.info(query)
+    else:
+        clean_engine.add_console_logging(ARGS.console_log)
+        clean_engine.clean_dataset(ARGS.project_id, ARGS.dataset_id,
+                                   ARGS.sandbox_dataset_id,
+                                   [(BackfillTheBasics,)])

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/backfill_the_basics_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/backfill_the_basics_test.py
@@ -1,7 +1,6 @@
 """
 Integration test for BackfillTheBasics.
 """
-
 # Python Imports
 import os
 
@@ -104,6 +103,7 @@ class BackfillTheBasicsTest(BaseTest.CleaningRulesTestBase):
         person_id = 3:
             It has some missing TheBasics records. Backfill happens.
             Backfilled skip records have this participant's MAX observation_date ('2022-01-01') as its date.
+            Backfilled skip records have the newly assigned observation_ids.
         """
         tables_and_counts = [{
             'fq_table_name':

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/backfill_the_basics_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/backfill_the_basics_test.py
@@ -1,0 +1,158 @@
+"""
+Integration test for BackfillTheBasics.
+"""
+
+# Python Imports
+import os
+
+# Third party imports
+from dateutil import parser
+
+# Project imports
+from app_identity import PROJECT_ID
+from cdr_cleaner.cleaning_rules.backfill_the_basics import BackfillTheBasics
+from common import JINJA_ENV, OBSERVATION, PERSON
+from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
+
+OBSERVATION_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.observation`
+(observation_id, person_id, observation_concept_id, observation_date, observation_type_concept_id, observation_source_concept_id)
+VALUES
+    -- person_id=1 has all TheBasics records. Nothing happens. --
+    (101, 1, 1585370, date('2020-01-01'), 45905771, 1585370),
+    (102, 1, 46235933, date('2020-01-01'), 45905771, 1585375),
+    (103, 1, 40766240, date('2020-01-01'), 45905771, 1585386),
+    (104, 1, 1585389, date('2020-01-01'), 45905771, 1585389),
+    (105, 1, 1585838, date('2020-01-01'), 45905771, 1585838),
+    (106, 1, 1585879, date('2020-01-01'), 45905771, 1585879),
+    (107, 1, 1585886, date('2020-01-01'), 45905771, 1585886),
+    (108, 1, 1585889, date('2020-01-01'), 45905771, 1585889),
+    (109, 1, 1585890, date('2020-01-01'), 45905771, 1585890),
+    (110, 1, 3046344, date('2020-01-01'), 45905771, 1585892),
+    (111, 1, 1585899, date('2020-01-01'), 45905771, 1585899),
+    (112, 1, 40771091, date('2020-01-01'), 45905771, 1585940),
+    (113, 1, 40771090, date('2020-01-01'), 45905771, 1585952),
+    (114, 1, 3005917, date('2020-01-01'), 45905771, 1586135),
+    (115, 1, 1586140, date('2020-01-01'), 45905771, 1586140),
+    -- person_id=2 has NO TheBasics records. Nothing happens. --
+    (201, 2, 9999999, date('2020-01-01'), 99999999, 9999999),
+    -- person_id=3 has some missing TheBasics records. Backfill happens. --
+    -- Backfilled skip records have the MAX date ('2022-01-01') as its date. --
+    (301, 3, 1585370, date('2020-01-01'), 45905771, 1585370),
+    (302, 3, 46235933, date('2021-01-01'), 45905771, 1585375),
+    (303, 3, 40766240, date('2022-01-01'), 45905771, 1585386)
+""")
+
+PERSON_TMPL = JINJA_ENV.from_string("""
+INSERT INTO `{{project}}.{{dataset}}.person`
+(person_id, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
+VALUES
+    (1, 8532, 2001, 999, 99999),
+    (2, 8532, 2001, 999, 99999),
+    (3, 8532, 2001, 999, 99999)
+""")
+
+
+class BackfillTheBasicsTest(BaseTest.CleaningRulesTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+        super().initialize_class_vars()
+
+        cls.project_id = os.environ.get(PROJECT_ID)
+        cls.dataset_id = os.environ.get('RDR_DATASET_ID')
+        cls.sandbox_id = f'{cls.dataset_id}_sandbox'
+
+        cls.rule_instance = BackfillTheBasics(cls.project_id, cls.dataset_id,
+                                              cls.sandbox_id)
+
+        cls.fq_sandbox_table_names = []
+
+        cls.fq_table_names = [
+            f'{cls.project_id}.{cls.dataset_id}.{OBSERVATION}',
+            f'{cls.project_id}.{cls.dataset_id}.{PERSON}',
+        ]
+
+        super().setUpClass()
+
+    def setUp(self):
+        self.date_2020 = parser.parse('2020-01-01').date()
+        self.date_2021 = parser.parse('2021-01-01').date()
+        self.date_2022 = parser.parse('2022-01-01').date()
+
+        super().setUp()
+
+        insert_observation = OBSERVATION_TMPL.render(project=self.project_id,
+                                                     dataset=self.dataset_id)
+        insert_person = PERSON_TMPL.render(project=self.project_id,
+                                           dataset=self.dataset_id)
+
+        queries = [insert_observation, insert_person]
+        self.load_test_data(queries)
+
+    def test_backfill_the_basics(self):
+        """
+        Test cases:
+        person_id = 1:
+            It has all TheBasics records. Nothing happens.
+        person_id = 2:
+            It has NO TheBasics records. Nothing happens.
+        person_id = 3:
+            It has some missing TheBasics records. Backfill happens.
+            Backfilled skip records have this participant's MAX observation_date ('2022-01-01') as its date.
+        """
+        tables_and_counts = [{
+            'fq_table_name':
+                f'{self.project_id}.{self.dataset_id}.{OBSERVATION}',
+            'fq_sandbox_table_name':
+                None,
+            'loaded_ids': [
+                101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
+                114, 115, 201, 301, 302, 303
+            ],
+            'sandboxed_ids': [],
+            'fields': [
+                'observation_id', 'person_id', 'observation_concept_id',
+                'observation_date', 'observation_type_concept_id',
+                'observation_source_concept_id'
+            ],
+            'cleaned_values': [
+                (101, 1, 1585370, self.date_2020, 45905771, 1585370),
+                (102, 1, 46235933, self.date_2020, 45905771, 1585375),
+                (103, 1, 40766240, self.date_2020, 45905771, 1585386),
+                (104, 1, 1585389, self.date_2020, 45905771, 1585389),
+                (105, 1, 1585838, self.date_2020, 45905771, 1585838),
+                (106, 1, 1585879, self.date_2020, 45905771, 1585879),
+                (107, 1, 1585886, self.date_2020, 45905771, 1585886),
+                (108, 1, 1585889, self.date_2020, 45905771, 1585889),
+                (109, 1, 1585890, self.date_2020, 45905771, 1585890),
+                (110, 1, 3046344, self.date_2020, 45905771, 1585892),
+                (111, 1, 1585899, self.date_2020, 45905771, 1585899),
+                (112, 1, 40771091, self.date_2020, 45905771, 1585940),
+                (113, 1, 40771090, self.date_2020, 45905771, 1585952),
+                (114, 1, 3005917, self.date_2020, 45905771, 1586135),
+                (115, 1, 1586140, self.date_2020, 45905771, 1586140),
+                (201, 2, 9999999, self.date_2020, 99999999, 9999999),
+                (301, 3, 1585370, self.date_2020, 45905771, 1585370),
+                (302, 3, 46235933, self.date_2021, 45905771, 1585375),
+                (303, 3, 40766240, self.date_2022, 45905771, 1585386),
+                (304, 3, 1585389, self.date_2022, 45905771, 1585389),
+                (305, 3, 1585838, self.date_2022, 45905771, 1585838),
+                (306, 3, 1585879, self.date_2022, 45905771, 1585879),
+                (307, 3, 1585886, self.date_2022, 45905771, 1585886),
+                (308, 3, 1585889, self.date_2022, 45905771, 1585889),
+                (309, 3, 1585890, self.date_2022, 45905771, 1585890),
+                (310, 3, 3046344, self.date_2022, 45905771, 1585892),
+                (311, 3, 1585899, self.date_2022, 45905771, 1585899),
+                (312, 3, 40771091, self.date_2022, 45905771, 1585940),
+                (313, 3, 40771090, self.date_2022, 45905771, 1585952),
+                (314, 3, 3005917, self.date_2022, 45905771, 1586135),
+                (315, 3, 1586140, self.date_2022, 45905771, 1586140)
+            ]
+        }]
+
+        self.default_test(tables_and_counts)


### PR DESCRIPTION
## This PR's scope
- Creating the abstract class `AbstractBackfillSurveyRecords` for the backfill.
- `BackfillTheBasics` and its test are also included in this PR as the pilot case for using the abstract class.
- `BackfillTheBasics` does not use the arg `additional_backfill_conditions`. It will be used when implementing the backfill for the Overall Health survey (`DC-3099`)

## Change in the `observation_id` assignment logic
- The original cleaning rule used to add `1000000000000` for the newly assigned `observation_ids`. ([BackfillPmiSkipCodes](https://github.com/all-of-us/curation/blob/develop/data_steward/cdr_cleaner/cleaning_rules/backfill_pmi_skip_codes.py#L84)). With `AbstractBackfillSurveyRecords`, new `observation_ids` are created based on the max `observation_id` in `observation`. ([link](https://github.com/all-of-us/curation/pull/1522/files#diff-181ea7b99537ef8a6765d1e5fb6ceeec741e2ea8724d4893a4c65ffc367078f2R94))
- The QC [clean_rdr_export_qc.py](https://github.com/all-of-us/curation/blob/develop/data_steward/analytics/cdr_ops/clean_rdr_export_qc.py#L663) assumes the backfilled records to be `observation_id >= 1000000000000`. This QC needs an update. **I will create a new ticket to address this issue once this PR is approved.**