### PR TITLE
[DC-2846] Remove hardcode value into variable

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report10_extra.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report10_extra.py
@@ -60,12 +60,13 @@ cdr_cutoff_date
 # + papermill={"duration": 4.105203, "end_time": "2021-02-02T22:30:36.813460", "exception": false, "start_time": "2021-02-02T22:30:32.708257", "status": "completed"} tags=[]
 query = JINJA_ENV.from_string("""
 
-SELECT COUNT(*) as n_participants_over_89 FROM `{{project_id}}.{{rt_cdr_deid}}.person`
+SELECT COUNT(*) as n_participants_over_{{max_age}} FROM `{{project_id}}.{{rt_cdr_deid}}.person`
 WHERE FLOOR(DATE_DIFF(DATE('{{cdr_cutoff_date}}'),DATE(birth_datetime), DAY)/365.25) > {{max_age}}
 """)
 q = query.render(project_id=project_id,
                  rt_cdr_deid=rt_cdr_deid,
-                 cdr_cutoff_date=cdr_cutoff_date)
+                 cdr_cutoff_date=cdr_cutoff_date,
+                 max_age=max_age)
 
 df1 = execute(client, q)
 if df1.loc[0].sum() == 0:


### PR DESCRIPTION
Updated the No person exists over 89 in the dataset in the cdr_deid_qa_report10_extra.py notebook to use a parameterized version of the CDR cutoff date instead of the current date.  The current implementation can create false positives.

