### PR TITLE
[DC-3197] Update prod ID violation check CRON job to ignore views

### DIFF
--- a/data_steward/resource_files/scheduled_queries/monitor_nonprod_person_id_violation.txt
+++ b/data_steward/resource_files/scheduled_queries/monitor_nonprod_person_id_violation.txt
@@ -72,13 +72,17 @@ BEGIN
     "  SELECT",
     "    table_catalog AS project_id,",
     "    table_schema AS dataset_id,",
-    "    table_name AS table_id,",
+    "    table_name AS table_id",
     "  FROM `", project_id, ".", dataset_id, ".INFORMATION_SCHEMA.COLUMNS`",
     "  WHERE LOWER(COLUMN_NAME) = 'person_id'",
     "  AND table_name IN (",
     "    SELECT table_id FROM `", project_id, ".", dataset_id, ".__TABLES__`",
     "    WHERE TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), TIMESTAMP_MILLIS(last_modified_time), DAY) <= 3",
-    "  )"), 
+    "  )", 
+    "  AND table_name NOT IN (",
+    "    SELECT table_name FROM `", project_id, ".", dataset_id, ".INFORMATION_SCHEMA.TABLES`",
+    "    WHERE table_type = 'VIEW'",
+    "  )"),
     "  UNION ALL \n") FROM tmp_nonprod_datasets WHERE row_num BETWEEN head AND tail)
     , ")"
     );


### PR DESCRIPTION
- I already updated the scheduled query in our BigQuery. This PR is to update the SQL file to date
- [This trailing comma](https://github.com/all-of-us/curation/pull/1559/files#diff-550818130a2e109e2f2ba6262b720d614d8c39cad4a387fe0948e8b81f2e2a66R75) was grammatically incorrect but it was working without a problem it seems.