### PR TITLE
[DC-3193] Stop DEATH creation in Unioned EHR

### DIFF
--- a/data_steward/validation/ehr_union.py
+++ b/data_steward/validation/ehr_union.py
@@ -1,10 +1,13 @@
 """
 Create a new CDM dataset which is the union of all EHR datasets submitted by HPOs
+NOTE We DO NOT create unioned_ehr_death in this script. We create unioned_ehr_aou_death instead.
+     We use aou_death here, not death, because we want to keep the src info and assign unique 
+     keys to the death records. 
 
  1) Create empty output tables to ensure proper schema, clustering, etc.
 
- 2) For all tables -EXCEPT person- that have numeric primary key columns, create mapping tables used to assign new
-    IDs in output.
+ 2) For all tables -EXCEPT person, death, and aou_death- that have numeric primary key columns, 
+    create mapping tables used to assign new IDs in output.
 
     The structure of the mapping table follows this convention:
 
@@ -56,9 +59,12 @@ Create a new CDM dataset which is the union of all EHR datasets submitted by HPO
       SUBSTR(src_table_id, 1, STRPOS(src_table_id, "_measurement")-1) AS src_hpo_id
     FROM all_measurement
 
- 3) For all tables, compose a query to fetch the union of records submitted by all HPOs and save the results in output.
+ 3) For all tables -EXCEPT death and aou_death-, compose a query to fetch the union of 
+    records submitted by all HPOs and save the results in output.
    * Use new primary keys in output where applicable
    * Use new visit_occurrence_id where applicable
+
+ 4) Create and load aou_death. death is not created in this process.
 
 ## Notes
 Currently the following environment variables must be set:

--- a/tests/integration_tests/data_steward/validation/ehr_union_test.py
+++ b/tests/integration_tests/data_steward/validation/ehr_union_test.py
@@ -229,7 +229,9 @@ class EhrUnionTest(unittest.TestCase):
             if not table == common.SURVEY_CONDUCT
         ]
         output_cdm_tables = [
-            ehr_union.output_table_for(table) for table in resources.CDM_TABLES
+            ehr_union.output_table_for(table)
+            for table in resources.CDM_TABLES
+            if not table == common.DEATH
         ]
         sandbox_tables = [
             f'{self.output_dataset_id}_dc2340_unioned_ehr_observation'
@@ -304,7 +306,7 @@ class EhrUnionTest(unittest.TestCase):
 
         # check for each output table
         for table_name in resources.CDM_TABLES:
-            if not table_name == common.SURVEY_CONDUCT:
+            if not table_name in [common.SURVEY_CONDUCT, common.DEATH]:
                 # output table exists and row count is sum of those submitted by hpos
                 result_table = ehr_union.output_table_for(table_name)
                 expected_rows = self.expected_tables[result_table]


### PR DESCRIPTION
- `AOU_DEATH` creation will be handled in `DC-3134.`
- This PR is to suppress the `DEATH` table.