### PR TITLE
[DC-3128] Update `CleanByBirthYear` to include `aou_death`

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year.py
@@ -97,7 +97,8 @@ class CleanByBirthYear(BaseCleaningRule):
         NOTE This CR runs on both RDR and UNIONED_EHR. RDR does not have
         AOU_DEATH, and UNIONED_EHR does not have SURVEY_CONDUCT. That is why
         the default affected_tables is AOU_REQUIRED. This setup_rule() will
-        add any tables with person_id that are missing in AOU_REQUIRED.        
+        add any tables with person_id that are missing in AOU_REQUIRED to
+        affected_tables.
         """
         columns_query = LIST_PERSON_ID_TABLES.render(project_id=self.project_id,
                                                      dataset_id=self.dataset_id)

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year.py
@@ -9,7 +9,7 @@ import logging
 import constants.cdr_cleaner.clean_cdr as cdr_consts
 import resources
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
-from common import JINJA_ENV, PERSON, AOU_REQUIRED
+from common import AOU_DEATH, CATI_TABLES, JINJA_ENV, PERSON
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +70,8 @@ class CleanByBirthYear(BaseCleaningRule):
             'indicates he/she was born before 1800, in the last 17 years, or in '
             'the future.')
 
-        person_id_tables = resources.get_person_id_tables(AOU_REQUIRED)
+        person_id_tables = resources.get_person_id_tables(CATI_TABLES +
+                                                          [AOU_DEATH])
 
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
@@ -91,8 +92,8 @@ class CleanByBirthYear(BaseCleaningRule):
         For thoroughness, this will query to get the table names
         of all tables in the dataset containing a person_id.  This
         will then be used to create the queries.  If setup_rule is not run,
-        then the list will default to the set of AoU Required tables with a
-        person_id column.
+        then the list will default to the set of (1) AoU Required tables with a
+        person_id column, (2) survey_conduct, and (3) aou_death.
         """
         columns_query = LIST_PERSON_ID_TABLES.render(project_id=self.project_id,
                                                      dataset_id=self.dataset_id)

--- a/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year.py
@@ -9,7 +9,7 @@ import logging
 import constants.cdr_cleaner.clean_cdr as cdr_consts
 import resources
 from cdr_cleaner.cleaning_rules.base_cleaning_rule import BaseCleaningRule, query_spec_list
-from common import AOU_DEATH, CATI_TABLES, JINJA_ENV, PERSON
+from common import JINJA_ENV, PERSON, AOU_REQUIRED
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,8 +70,7 @@ class CleanByBirthYear(BaseCleaningRule):
             'indicates he/she was born before 1800, in the last 17 years, or in '
             'the future.')
 
-        person_id_tables = resources.get_person_id_tables(CATI_TABLES +
-                                                          [AOU_DEATH])
+        person_id_tables = resources.get_person_id_tables(AOU_REQUIRED)
 
         super().__init__(issue_numbers=ISSUE_NUMBERS,
                          description=desc,
@@ -92,8 +91,13 @@ class CleanByBirthYear(BaseCleaningRule):
         For thoroughness, this will query to get the table names
         of all tables in the dataset containing a person_id.  This
         will then be used to create the queries.  If setup_rule is not run,
-        then the list will default to the set of (1) AoU Required tables with a
-        person_id column, (2) survey_conduct, and (3) aou_death.
+        then the list will default to the set of AoU Required tables with a
+        person_id column.
+        
+        NOTE This CR runs on both RDR and UNIONED_EHR. RDR does not have
+        AOU_DEATH, and UNIONED_EHR does not have SURVEY_CONDUCT. That is why
+        the default affected_tables is AOU_REQUIRED. This setup_rule() will
+        add any tables with person_id that are missing in AOU_REQUIRED.        
         """
         columns_query = LIST_PERSON_ID_TABLES.render(project_id=self.project_id,
                                                      dataset_id=self.dataset_id)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year_test.py
@@ -5,13 +5,10 @@ Original Issue: DC-392
 # Python imports
 import os
 
-# Third party imports
-from google.cloud import bigquery
-
 # Project Imports
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.clean_by_birth_year import (CleanByBirthYear)
-from common import JINJA_ENV, AOU_REQUIRED, OBSERVATION, PERSON
+from common import AOU_DEATH, CATI_TABLES, JINJA_ENV, OBSERVATION, PERSON
 from resources import get_person_id_tables
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import (
     BaseTest)
@@ -92,7 +89,7 @@ class CleanByBirthYearTest(BaseTest.CleaningRulesTestBase):
 
     def test_setup_rule(self):
 
-        has_person_id = get_person_id_tables(AOU_REQUIRED)
+        has_person_id = get_person_id_tables(CATI_TABLES + [AOU_DEATH])
         self.assertEqual(set(has_person_id),
                          set(self.rule_instance.affected_tables))
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/clean_by_birth_year_test.py
@@ -5,10 +5,13 @@ Original Issue: DC-392
 # Python imports
 import os
 
+# Third party imports
+from google.cloud import bigquery
+
 # Project Imports
 from app_identity import PROJECT_ID
 from cdr_cleaner.cleaning_rules.clean_by_birth_year import (CleanByBirthYear)
-from common import AOU_DEATH, CATI_TABLES, JINJA_ENV, OBSERVATION, PERSON
+from common import JINJA_ENV, AOU_REQUIRED, OBSERVATION, PERSON
 from resources import get_person_id_tables
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import (
     BaseTest)
@@ -89,7 +92,7 @@ class CleanByBirthYearTest(BaseTest.CleaningRulesTestBase):
 
     def test_setup_rule(self):
 
-        has_person_id = get_person_id_tables(CATI_TABLES + [AOU_DEATH])
+        has_person_id = get_person_id_tables(AOU_REQUIRED)
         self.assertEqual(set(has_person_id),
                          set(self.rule_instance.affected_tables))
 


### PR DESCRIPTION
- No change was needed in the logic. I updated the docstring for `setup_rule()` to add more background.
- This cleaning rule runs both on `RDR` and `Unioned_EHR` data tiers. `RDR` data tier does not have an `AOU_DEATH` table, so changing the default `affected_tables` to include `AOU_DEATH` is not a good idea. `setup_rule()` updates affected_tables to the correct list of the tables anyway.
- `SURVEY_CONDUCT` is not included in the default affected_tables for the same reason.