### PR TITLE
[DC-3261] Update `NoDataAfterDeath` to use primary death record, not the earliest death record

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -221,7 +221,6 @@ COMBINED_CLEANING_CLASSES = [
     # wiping out the needed consent related data for cleaning.
     (
         ValidDeathDates,),
-    (NoDataAfterDeath,),
     (RemoveEhrDataWithoutConsent,),
     (DedupMeasurementValueAsConceptId,),
     (DrugRefillsDaysSupply,),
@@ -240,6 +239,7 @@ COMBINED_CLEANING_CLASSES = [
     ),  # Should run after GenerateExtTables and before CleanMappingExtTables
     (PopulateSurveyConductExt,),
     (CalculatePrimaryDeathRecord,),
+    (NoDataAfterDeath,),  # should run after CalculatePrimaryDeathRecord
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
@@ -304,6 +304,7 @@ REGISTERED_TIER_DEID_CLEAN_CLEANING_CLASSES = [
     (DropZeroConceptIDs,),
     (DropOrphanedSurveyConductIds,),
     (CalculatePrimaryDeathRecord,),
+    (NoDataAfterDeath,),  # should run after CalculatePrimaryDeathRecord
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 
@@ -360,6 +361,7 @@ CONTROLLED_TIER_DEID_CLEAN_CLEANING_CLASSES = [
     (DropZeroConceptIDs,),
     (DropOrphanedSurveyConductIds,),
     (CalculatePrimaryDeathRecord,),
+    (NoDataAfterDeath,),  # should run after CalculatePrimaryDeathRecord
     (CleanMappingExtTables,),  # should be one of the last cleaning rules run
 ]
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
@@ -22,58 +22,77 @@ PERSON_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.person`
 (person_id, birth_datetime, gender_concept_id, year_of_birth, race_concept_id, ethnicity_concept_id)
 VALUES
-      (1, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
-      (2, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
-      (3, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0)
+    -- Cleaned. The birth date is after the primary death date. --
+    (1, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
+    -- No change --
+    (2, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
+    (3, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0),
+    (9, '1970-01-01 00:00:00 EST', 0, 1970, 0, 0)
 """)
 
 AOU_DEATH_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.aou_death`
 (aou_death_id, person_id, death_date, death_type_concept_id, src_id, primary_death_record)
 VALUES
-      ('a1', 1, '1969-01-01', 0, 'rdr', False),
-      ('b1', 1, '2023-01-01', 0, 'hpo_a', True),
-      ('a2', 2, '2020-01-01', 0, 'hpo_b', True),
-      ('b2', 2, '2023-01-01', 0, 'hpo_c', False)
+    ('a1', 1, '1969-01-01', 0, 'hpo_a', True),
+    ('b1', 1, '2023-01-01', 0, 'hpo_b', False),
+    ('a2', 2, '2020-01-01', 0, 'hpo_a', True),
+    ('b2', 2, '2023-01-01', 0, 'hpo_b', False),
+    ('h3', 3, '2020-01-01', 0, 'Staff Portal: HealthPro', False),
+    ('b3', 3, '2023-01-01', 0, 'hpo_b', True)
 """)
 
 VISIT_OCCURRENCE_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.visit_occurrence`
 (visit_occurrence_id, person_id, visit_start_date, visit_end_date, visit_concept_id, visit_type_concept_id)
 VALUES
-      (1, 1, '2000-01-01', '2000-01-02', 0, 0),
-      (2, 1, '2000-01-02', '2000-01-03', 0, 0),
-      (3, 2, '2000-01-01', '2020-03-01', 0, 0),
-      (4, 3, '2000-01-02', '2000-01-03', 0, 0)
+    -- Cleand. visit_[start|end]_date are after the primary death date. --
+    (11, 1, '2000-01-01', '2000-01-02', 0, 0),
+    (12, 1, '2000-01-02', '2000-01-03', 0, 0),
+    -- Cleand. visit_end_date is after the primary death date. --
+    (21, 2, '2000-01-01', '2020-03-01', 0, 0),
+    -- No change --
+    (31, 3, '2000-01-01', '2020-03-01', 0, 0),
+    (91, 9, '2000-01-02', '2000-01-03', 0, 0)
 """)
 
 OBSERVATION_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
 (observation_id, person_id, observation_date, observation_concept_id, observation_type_concept_id)
 VALUES
-      (1, 1, '2000-01-01', 0, 0),
-      (2, 1, '2000-01-02', 0, 0),
-      (3, 2, '2020-03-01', 0, 0),
-      (4, 2, '2020-01-05', 0, 0),
-      (5, 3, '2020-05-05', 0, 0)
+    -- Cleand. observation_date is after the primary death date. --
+    (11, 1, '2000-01-01', 0, 0),
+    (12, 1, '2000-01-02', 0, 0),
+    (21, 2, '2020-03-01', 0, 0),
+    -- No change --
+    (22, 2, '2020-01-05', 0, 0),
+    (31, 3, '2020-03-01', 0, 0),
+    (32, 3, '2020-01-05', 0, 0),
+    (91, 9, '2020-05-05', 0, 0)
 """)
 
 CONDITION_OCCURRENCE_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.condition_occurrence`
 (condition_occurrence_id, person_id, condition_concept_id, condition_start_date, condition_start_datetime, condition_end_date, condition_end_datetime, condition_type_concept_id)
 VALUES
-    (1, 1, 80502, '1969-08-20', '1968-08-20 00:00:00 UTC', null, null, 38000245),
-    (2, 2, 321661, '2020-09-10', '2020-09-10 00:00:00 UTC', '2020-10-10', null, 38000245),
-    (3, 3, 435928, '2017-08-15', '2017-08-15 00:00:00 UTC' , null, null, 38000245)
+    -- Cleand. condition_[start|end]_date are after the primary death date. --
+    (11, 1, 80502, '1969-08-20', '1969-08-20 00:00:00 UTC', null, null, 38000245),
+    (21, 2, 321661, '2020-09-10', '2020-09-10 00:00:00 UTC', '2020-10-10', null, 38000245),
+    -- No change --
+    (31, 3, 321661, '2020-09-10', '2020-09-10 00:00:00 UTC', '2020-10-10', null, 38000245),
+    (91, 9, 435928, '2017-08-15', '2017-08-15 00:00:00 UTC' , null, null, 38000245)
 """)
 
 DEVICE_EXPOSURE_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.device_exposure`
 (device_exposure_id, person_id, device_concept_id, device_exposure_start_date, device_exposure_start_datetime, device_exposure_end_date, device_type_concept_id)
 VALUES
-    (1, 1, 4206863, '1969-05-15', TIMESTAMP('2015-07-15'), null, 44818707),
-    (2, 2, 320128, '2021-07-15', TIMESTAMP('2015-07-15'), null, 99999),
-    (3, 3, 2101931, '2015-07-15', TIMESTAMP('2015-07-15'), null, 99999)
+    -- Cleand. device_exposure_[start|end]_date are after the primary death date. --
+    (11, 1, 4206863, '1969-05-15', TIMESTAMP('2015-07-15'), null, 44818707),
+    (21, 2, 320128, '2021-07-15', TIMESTAMP('2015-07-15'), null, 99999),
+    -- No change --
+    (31, 3, 320128, '2021-07-15', TIMESTAMP('2015-07-15'), null, 99999),
+    (91, 9, 2101931, '2015-07-15', TIMESTAMP('2015-07-15'), null, 99999)
 """)
 
 
@@ -133,103 +152,68 @@ class NoDataAfterDeathTest(BaseTest.CleaningRulesTestBase):
 
     def test_no_data_30_days_after_death(self):
         """
-        1. person_id=1, this hypothetical person passed away on 1969-01-01, which is a year 
-        before the person was born. This person should be removed. This person also had two 
-        visits ( visit_occurrence_id=1, visit_occurrence_id=2) that occurred after 2000, 
-        they should be removed too. The person had two observations (observation_id=1, 
-        observation=2) that occurred after 2000, they should be removed. 
-        
-        2. person_id=2, this hypothetical person passed away on 2020-01-01. This person had a 
-        visit (visit_occurrence_id = 3) that started on 2000-01-01 and ended on 2020-03-01, 
-        because we take the maximum date of (visit_start_date and visit_end_date), this visit 
-        exceeded the death date more than 30 days, therefore it should be removed. 
-        
-        3. person_id=3, this hypothetical person didn't pass away, so we keep all of the records 
-        associated with this person. 
+        person_id=1.
+            All of its records, including its birth date, are before the primary death date. 
+            All records are removed.
+
+        person_id=2.
+            There are records that are after the primary death date. Such records are removed.
+            Note that its visit record's start date is before the death date, but the end date
+            is after the death date. It is removed as well.
+
+        person_id=3.
+            All records are before the primary death date. The non-primary death date is 
+            ignored. All records will be unchanged.
+
+        person_id=9.
+            No death record exists for this person. All records will be unchanged.
         """
 
-        # BigQuery returns timestamp in UTC, the expected datetime needs to be converted to UTC.
-        local_timezone = pytz.timezone('US/Eastern')
-        native_time = datetime.datetime.strptime('1970-01-01 00:00:00',
-                                                 '%Y-%m-%d %H:%M:%S')
-        expected_birth_datetime = local_timezone.localize(
-            native_time, is_dst=None).astimezone(pytz.utc)
-        # Expected results list
         tables_and_counts = [{
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{PERSON}',
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(PERSON)}',
-            'loaded_ids': [1, 2, 3],
+            'loaded_ids': [1, 2, 3, 9],
             'sandboxed_ids': [1],
-            'fields': ['person_id', 'birth_datetime'],
-            'cleaned_values': [(2, expected_birth_datetime),
-                               (3, expected_birth_datetime)]
+            'fields': ['person_id'],
+            'cleaned_values': [(2,), (3,), (9,)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{VISIT_OCCURRENCE}',
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(VISIT_OCCURRENCE)}',
-            'loaded_ids': [1, 2, 3, 4],
-            'sandboxed_ids': [1, 2, 3],
-            'fields': [
-                'visit_occurrence_id', 'person_id', 'visit_start_date',
-                'visit_end_date'
-            ],
-            'cleaned_values': [
-                (4, 3, datetime.datetime.strptime('2000-01-02',
-                                                  '%Y-%m-%d').date(),
-                 datetime.datetime.strptime('2000-01-03', '%Y-%m-%d').date())
-            ]
+            'loaded_ids': [11, 12, 21, 31, 91],
+            'sandboxed_ids': [11, 12, 21],
+            'fields': ['visit_occurrence_id', 'person_id'],
+            'cleaned_values': [(31, 3), (91, 9)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBSERVATION}',
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(OBSERVATION)}',
-            'loaded_ids': [1, 2, 3, 4, 5],
-            'sandboxed_ids': [1, 2, 3],
-            'fields': ['observation_id', 'person_id', 'observation_date'],
-            'cleaned_values': [
-                (4, 2, datetime.datetime.strptime('2020-01-05',
-                                                  '%Y-%m-%d').date()),
-                (5, 3, datetime.datetime.strptime('2020-05-05',
-                                                  '%Y-%m-%d').date())
-            ]
+            'loaded_ids': [11, 12, 21, 22, 31, 32, 91],
+            'sandboxed_ids': [11, 12, 21],
+            'fields': ['observation_id', 'person_id'],
+            'cleaned_values': [(22, 2), (31, 3), (32, 3), (91, 9)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{CONDITION_OCCURRENCE}',
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(CONDITION_OCCURRENCE)}',
-            'loaded_ids': [1, 2, 3],
-            'sandboxed_ids': [1, 2],
-            'fields': [
-                'condition_occurrence_id', 'person_id', 'condition_concept_id',
-                'condition_start_date', 'condition_start_datetime',
-                'condition_end_date', 'condition_end_datetime',
-                'condition_type_concept_id'
-            ],
-            'cleaned_values': [
-                (3, 3, 435928,
-                 datetime.datetime.strptime('2017-08-15', '%Y-%m-%d').date(),
-                 parser.parse('2017-08-15 00:00:00 UTC'), None, None, 38000245)
-            ]
+            'loaded_ids': [11, 21, 31, 91],
+            'sandboxed_ids': [11, 21],
+            'fields': ['condition_occurrence_id', 'person_id'],
+            'cleaned_values': [(31, 3), (91, 9)]
         }, {
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{DEVICE_EXPOSURE}',
             'fq_sandbox_table_name':
                 f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(DEVICE_EXPOSURE)}',
-            'loaded_ids': [1, 2, 3],
-            'sandboxed_ids': [1, 2],
-            'fields': [
-                'device_exposure_id', 'person_id', 'device_concept_id',
-                'device_exposure_start_date', 'device_exposure_start_datetime',
-                'device_exposure_end_date', 'device_type_concept_id'
-            ],
-            'cleaned_values': [
-                (3, 3, 2101931,
-                 datetime.datetime.strptime('2015-07-15', '%Y-%m-%d').date(),
-                 parser.parse('2015-07-15 00:00:00 UTC'), None, 99999)
-            ]
+            'loaded_ids': [11, 21, 31, 91],
+            'sandboxed_ids': [11, 21],
+            'fields': ['device_exposure_id', 'person_id'],
+            'cleaned_values': [(31, 3), (91, 9)]
         }]
 
         self.default_test(tables_and_counts)

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
@@ -46,10 +46,10 @@ VISIT_OCCURRENCE_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.visit_occurrence`
 (visit_occurrence_id, person_id, visit_start_date, visit_end_date, visit_concept_id, visit_type_concept_id)
 VALUES
-    -- Cleand. visit_[start|end]_date are after the primary death date. --
+    -- Cleaned. visit_[start|end]_date are after the primary death date. --
     (11, 1, '2000-01-01', '2000-01-02', 0, 0),
     (12, 1, '2000-01-02', '2000-01-03', 0, 0),
-    -- Cleand. visit_end_date is after the primary death date. --
+    -- Cleaned. visit_end_date is after the primary death date. --
     (21, 2, '2000-01-01', '2020-03-01', 0, 0),
     -- No change --
     (31, 3, '2000-01-01', '2020-03-01', 0, 0),
@@ -60,7 +60,7 @@ OBSERVATION_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.observation`
 (observation_id, person_id, observation_date, observation_concept_id, observation_type_concept_id)
 VALUES
-    -- Cleand. observation_date is after the primary death date. --
+    -- Cleaned. observation_date is after the primary death date. --
     (11, 1, '2000-01-01', 0, 0),
     (12, 1, '2000-01-02', 0, 0),
     (21, 2, '2020-03-01', 0, 0),
@@ -75,7 +75,7 @@ CONDITION_OCCURRENCE_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.condition_occurrence`
 (condition_occurrence_id, person_id, condition_concept_id, condition_start_date, condition_start_datetime, condition_end_date, condition_end_datetime, condition_type_concept_id)
 VALUES
-    -- Cleand. condition_[start|end]_date are after the primary death date. --
+    -- Cleaned. condition_[start|end]_date are after the primary death date. --
     (11, 1, 80502, '1969-08-20', '1969-08-20 00:00:00 UTC', null, null, 38000245),
     (21, 2, 321661, '2020-09-10', '2020-09-10 00:00:00 UTC', '2020-10-10', null, 38000245),
     -- No change --
@@ -87,7 +87,7 @@ DEVICE_EXPOSURE_DATA_TEMPLATE = JINJA_ENV.from_string("""
 INSERT INTO `{{project_id}}.{{dataset_id}}.device_exposure`
 (device_exposure_id, person_id, device_concept_id, device_exposure_start_date, device_exposure_start_datetime, device_exposure_end_date, device_type_concept_id)
 VALUES
-    -- Cleand. device_exposure_[start|end]_date are after the primary death date. --
+    -- Cleaned. device_exposure_[start|end]_date are after the primary death date. --
     (11, 1, 4206863, '1969-05-15', TIMESTAMP('2015-07-15'), null, 44818707),
     (21, 2, 320128, '2021-07-15', TIMESTAMP('2015-07-15'), null, 99999),
     -- No change --


### PR DESCRIPTION
Because `primary_death_record` can change in each data stage, I added this CR to the following, in addition to `COMBINED_CLEANING_CLASSES`.
- `REGISTERED_TIER_DEID_CLEAN_CLEANING_CLASSES`
- `CONTROLLED_TIER_DEID_CLEAN_CLEANING_CLASSES`