### PR TITLE
[DC-3323] Update `ValidDeathDates` to handle aou_death's NULL death_date

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates.py
@@ -6,6 +6,8 @@ Original Issues: DC-431, DC-822
 The intent is to ensure there are no death dates that occur before the start of the AoU program or after the current
 date. A death date is considered "valid" if it is after the program start date and before the current date. Allowing for
  more flexibility, we chose Jan 1, 2017 as the program start date.
+
+For AOU_DEATH, records with NULL death_date are valid and this CR does not remove such records.
 """
 
 # Python imports
@@ -24,6 +26,7 @@ current_date = 'CURRENT_DATE()'
 
 # Keeps any rows where the death_date is after the AoU program start or before the current date by comparing person_ids
 # of the death table and sandbox tables. If the person_id is not in the sandbox table the row is kept, else, dropped.
+# For AOU_DEATH, null death_date records will be kept.
 KEEP_VALID_DEATH_DATE_ROWS = JINJA_ENV.from_string("""
 SELECT * FROM `{{project_id}}.{{dataset_id}}.{{table}}` 
 {% if table == 'death' %}
@@ -35,7 +38,7 @@ FROM `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}`)
 """)
 
 # Selects all the invalid rows. Invalid means the death_date occurs before the AoU program start
-# or after the current date.
+# or after the current date. Null death_date records are valid for AOU_DEATH.
 SANDBOX_INVALID_DEATH_DATE_ROWS = JINJA_ENV.from_string("""
 CREATE OR REPLACE TABLE `{{project_id}}.{{sandbox_id}}.{{sandbox_table}}` AS (
 SELECT d.*

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/valid_death_dates_test.py
@@ -63,7 +63,9 @@ AOU_DEATH_DATA_QUERY = JINJA_ENV.from_string("""
       ('a107', 101, '2019-01-01', 0, 'hpo_g', False),
       ('a108', 102, '2019-01-01', 0, 'hpo_h', False),
       -- record should be dropped because a PPI record exists after this date --
-      ('a109', 109, '2020-08-01', 0, 'hpo_i', True)
+      ('a109', 109, '2020-08-01', 0, 'hpo_i', True),
+      -- record won't be dropped because NULL death_date records should be kept for aou_death --
+      ('a110', 109, NULL, 0, 'hpo_e', False)
 """)
 
 INSERT_OBSERVATIONS_QUERY = JINJA_ENV.from_string("""
@@ -178,13 +180,13 @@ class ValidDeathDatesTest(BaseTest.CleaningRulesTestBase):
             'fq_sandbox_table_name': self.fq_sandbox_table_names[1],
             'loaded_ids': [
                 'a101', 'a102', 'a103', 'a104', 'a105', 'a106', 'a107', 'a108',
-                'a109'
+                'a109', 'a110'
             ],
             'sandboxed_ids': [
                 'a101', 'a102', 'a103', 'a104', 'a107', 'a108', 'a109'
             ],
             'fields': ['aou_death_id'],
-            'cleaned_values': [('a105',), ('a106',)]
+            'cleaned_values': [('a105',), ('a106',), ('a110',)]
         }]
 
         self.default_test(tables_and_counts)


### PR DESCRIPTION
- The cleaning rule can handle the null death_date without an update.
- I updated the integration test to ensure that.