### PR TITLE
[DC-3349] Update the key rotation service to rotate keys more frequently than 180 days

### DIFF
--- a/data_steward/admin/key_rotation.py
+++ b/data_steward/admin/key_rotation.py
@@ -8,7 +8,7 @@ import os
 
 LOGGER = logging.getLogger(__name__)
 
-KEY_EXPIRE_DAYS = 180
+KEY_EXPIRE_DAYS = 150
 KEY_EXPIRE_ALERT_DAYS = 7
 GCP_DTM_FMT = '%Y-%m-%dT%H:%M:%SZ'
 


### PR DESCRIPTION
updated expiration date.