### PR TITLE
[DC-3235] Add `survey_conduct` to `NoDataAfterDeath` cleaning rule

### DIFF
--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/no_data_30_days_after_death_test.py
@@ -131,8 +131,7 @@ class NoDataAfterDeathTest(BaseTest.CleaningRulesTestBase):
 
         # Generates list of fully qualified table names and their corresponding sandbox table names
         # adding aou_death table name for setup/cleanup operations
-        for table_name in get_affected_tables() + [AOU_DEATH
-                                                  ] + [SURVEY_CONDUCT]:
+        for table_name in get_affected_tables() + [AOU_DEATH]:
             cls.fq_table_names.append(
                 f'{cls.project_id}.{cls.dataset_id}.{table_name}')
             sandbox_table_name = cls.rule_instance.sandbox_table_for(table_name)


### PR DESCRIPTION
- Also updated `table_namer` so it can be referenced correctly
- Also updated `depends_on` to the right value
- Technically, `survey_end_date` is `nullable`, but the column is never `NULL` as defined in the PRD for `survey_conduct`. https://github.com/all-of-us/curation/blob/develop/data_steward/resource_files/schemas/cdm/clinical/survey_conduct.json#L36