### PR TITLE
[DC-3401] Use `BigQueryClient.create_tables()` instead of `CREATE TABLE` for `aou_death` creation

### DIFF
--- a/data_steward/constants/tools/create_combined_backup_dataset.py
+++ b/data_steward/constants/tools/create_combined_backup_dataset.py
@@ -207,8 +207,7 @@ AND fact_id_2 IS NOT NULL
 """)
 
 LOAD_AOU_DEATH = JINJA_ENV.from_string("""
-CREATE TABLE `{{project}}.{{combined_backup}}.{{aou_death}}`
-AS
+INSERT INTO `{{project}}.{{combined_backup}}.{{aou_death}}`
 SELECT
     aou_death_id,
     person_id,

--- a/data_steward/tools/create_combined_backup_dataset.py
+++ b/data_steward/tools/create_combined_backup_dataset.py
@@ -17,7 +17,7 @@ Combine data sets `unioned_ehr` and `rdr` to form another data set `combined_bac
    for records that have a (valid) `visit_occurrence_id`.
 
  * Load `combined_backup.aou_death` with UNION ALL of:
-     1) all `rdr.death`s and
+     1) all `rdr.aou_death`s and
      2) `unioned_ehr.aou_death`s that link to `combined_sandbox.ehr_consent`
  * Site masking for `aou_death` happens here, too. (Other tables are site masked by GenerateExtTables)
 
@@ -44,7 +44,7 @@ from google.cloud.exceptions import GoogleCloudError, NotFound
 from google.cloud import bigquery
 
 # Project imports
-from common import (AOU_DEATH, CDR_SCOPES, DEATH, FACT_RELATIONSHIP,
+from common import (AOU_DEATH, CDR_SCOPES, FACT_RELATIONSHIP,
                     MEASUREMENT_DOMAIN_CONCEPT_ID,
                     OBSERVATION_DOMAIN_CONCEPT_ID, PERSON, PIPELINE_TABLES,
                     RDR_ID_CONSTANT, SITE_MASKING_TABLE_ID, SURVEY_CONDUCT,

--- a/data_steward/tools/create_combined_backup_dataset.py
+++ b/data_steward/tools/create_combined_backup_dataset.py
@@ -403,6 +403,9 @@ def create_load_aou_death(client, project_id, combined_backup, combined_sandbox,
         LOGGER.info(f'Copied {PIPELINE_TABLES}.{SITE_MASKING_TABLE_ID} to '
                     f'{combined_sandbox}.{SITE_MASKING_TABLE_ID}')
 
+    _ = client.create_tables(
+        [f'{client.project}.{combined_backup}.{AOU_DEATH}'])
+
     query = combine_consts.LOAD_AOU_DEATH.render(
         project=project_id,
         combined_backup=combined_backup,

--- a/data_steward/validation/ehr_union.py
+++ b/data_steward/validation/ehr_union.py
@@ -113,8 +113,19 @@ UNION_ALL = '''
 '''
 
 LOAD_AOU_DEATH = JINJA_ENV.from_string("""
-CREATE OR REPLACE TABLE `{{project}}.{{output_dataset}}.{{aou_death}}`
-AS
+INSERT INTO `{{project}}.{{output_dataset}}.{{aou_death}}`
+(
+    aou_death_id,
+    person_id,
+    death_date,
+    death_datetime,
+    death_type_concept_id,
+    cause_concept_id,
+    cause_source_value,
+    cause_source_concept_id,
+    src_id,
+    primary_death_record
+)
 WITH union_aou_death AS (
     {% for hpo_id in hpo_ids %}
     SELECT
@@ -877,6 +888,11 @@ def create_load_aou_death(bq_client, project_id, input_dataset_id,
         `CalculatePrimaryDeathRecord` updates the table at the end of the
         Unioned EHR data tier creation.
     """
+    bq_utils.create_standard_table(AOU_DEATH,
+                                   f'{UNIONED_EHR}_{AOU_DEATH}',
+                                   drop_existing=True,
+                                   dataset_id=output_dataset_id)
+
     # Filter out HPO sites without death data submission.
     hpo_ids_with_death = [
         hpo_id for hpo_id in hpo_ids


### PR DESCRIPTION
I used different `create_table()` for EHR union and Combined.
- For EHR union, I used `bq_utils.create_standard_table()`, following other CDM tables creation in EHR union. I had to use it because (1) the destination table name needs the prefix `unioned_ehr_`, and (2) this process runs every night and we need the `drop_existing=True` capability when it runs. `bq_utils.create_standard_table()` creates a partitioned table as a result, and it is not a problem since all the other CDM tables are partitioned at this stage. 
- For Combined, I used `client.create_tables()` as it does not require special consideration like EHR union.

For testing, the existing integration tests can cover these updates. No update was needed.