### PR TITLE
[DC-3436] Remove `race_ethnicity_record_suppression.py` to stop suppressing race/ethnicity sub categories

### DIFF
--- a/data_steward/cdr_cleaner/clean_cdr.py
+++ b/data_steward/cdr_cleaner/clean_cdr.py
@@ -341,9 +341,9 @@ CONTROLLED_TIER_DEID_CLEANING_CLASSES = [
     (TableSuppression,),
     (ControlledTierReplacedConceptSuppression,),
     (GeneralizeZipCodes,),  # Should run after any data remapping rules
-    (RaceEthnicityRecordSuppression,
-    ),  # Should run after any data remapping rules
-    (MotorVehicleAccidentSuppression,),
+    # (RaceEthnicityRecordSuppression,),  # Should run after any data remapping rules
+    (
+        MotorVehicleAccidentSuppression,),
     (VehicularAccidentConceptSuppression,),
     (ExplicitIdentifierSuppression,),
     (GeoLocationConceptSuppression,),


### PR DESCRIPTION
Background:

We apply this suppression in the controlled tier cleaning stage with the help of a cleaning rule. To stop suppressing these records and expand race/ethnicity subcategories, we would need to remove the cleaning rule from the controlled tier cleaning classes.

Scope:
- ~Remove the data_steward/cdr_cleaner/cleaning_rules/race_ethnicity_record_suppression.py cleaning rule from the repo.~

- ~Remove integration test - tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/race_ethnicity_record_suppression_test.py from the repo.~

- ~Remove~ disable the RaceEthnicityRecordSuppression from [CONTROLLED_TIER_CLEANING_CLASSES](https://github.com/all-of-us/curation/blob/4c3006a766cfe7c66d2cd8a67b153be99fbdd2c7/data_steward/cdr_cleaner/clean_cdr.py#L344C4-L344C4) in data_steward/cdr_cleaner/clean_cdr.py