### PR TITLE
[DC-3439]  verify free text responses for race/ethnicity are suppressed

### DIFF
--- a/data_steward/analytics/cdr_ops/controlled_tier_qc/check_controlled_tier_part2.py
+++ b/data_steward/analytics/cdr_ops/controlled_tier_qc/check_controlled_tier_part2.py
@@ -1406,6 +1406,33 @@ else:
         ignore_index=True)
 result
 
+# Query 20: verify free text responses for Race/ethnicity is suppressed
+# -
+
+query = JINJA_ENV.from_string("""
+SELECT * FROM `{{project_id}}.{{ct_dataset}}.observation`
+WHERE value_as_concept_id = 1586149
+""")
+q = query.render(project_id=project_id, ct_dataset=ct_dataset)
+result = execute(client, q)
+if result.empty:
+    df = df.append(
+        {
+            'query': 'No text found for "NoneOfTheseDescribeMe" free text.',
+            'result': 'PASS'
+        },
+        ignore_index=True)
+else:
+    df = df.append(
+        {
+            'query': '"NoneOfTheseDescribeMe" response have free text.',
+            'result': 'Failure'
+        },
+        ignore_index=True)
+result
+
+# -
+
 
 # +
 def highlight_cells(val):


### PR DESCRIPTION
Scope:

Even though we are opening up the scope to expand the subcategories of race and ethnicity to be allowed in the controlled tier, we still need to suppress free text responses for race/ethnicity questions. The free text suppression is handled in a cleaning rule, which is not being modified in this story.

Add a check in controlled_tier_qc to verify that race/ethnicity subcategories exist in the observation table.

Added check should summarise the existence of the subcategories, not display everything.

We can use the logic in the [cleaning rule](https://precisionmedicineinitiative.atlassian.net/browse/DC-3436) that will be dropped to identify the race/ethnicity records.

‘AIA: tribe’ does not have 'text' in the string but needs to be suppressed.

Acceptance Criteria:

A check is added to controlled_tier_qc that confirms free text suppression.