### PR TITLE
[DC-3440] Add a check in controlled_tier_qc to verify only higher level race/ethnicity is being shown in person after deid

### DIFF
--- a/data_steward/analytics/cdr_ops/controlled_tier_qc/check_controlled_tier_part2.py
+++ b/data_steward/analytics/cdr_ops/controlled_tier_qc/check_controlled_tier_part2.py
@@ -1385,22 +1385,27 @@ WHERE value_source_concept_id IN (1585605, 1585606, 1585607, 1585608, 1585609, 1
 GROUP BY value_source_value
 ORDER BY value_source_value
 """)
-q = query.render(project_id=project_id,
-                 ct_dataset=ct_dataset,
+q = query.render(
+    project_id=project_id,
+    ct_dataset=ct_dataset,
 )
 result = execute(client, q)
 if not result.empty:
     df = df.append(
         {
-            'query': 'Query19 existence of at least one race/ethnicity sub-categories',
-            'result': 'PASS'
+            'query':
+                'Query19 existence of at least one race/ethnicity sub-categories',
+            'result':
+                'PASS'
         },
         ignore_index=True)
 else:
     df = df.append(
         {
-            'query': 'Query19 At least one race/ethnicity sub-categories DOES NOT exist',
-            'result': 'Failure'
+            'query':
+                'Query19 At least one race/ethnicity sub-categories DOES NOT exist',
+            'result':
+                'Failure'
         },
         ignore_index=True)
 result
@@ -1409,22 +1414,18 @@ result
 # -
 
 query = JINJA_ENV.from_string("""
-SELECT ethnicity_concept_id, ethnicity_source_concept_id, ethnicity_source_value, count(*)
+SELECT race_concept_id,
+  race_source_concept_id,
+  race_source_value,
+  race_concept_id,
+  ethnicity_concept_id,
+  ethnicity_source_concept_id,
+  ethnicity_source_value
 FROM `{{project_id}}.{{ct_dataset}}.person`
-WHERE ethnicity_concept_id NOT IN (38003563, 38003564, 1586148, 903079, 903096, 0)
-AND ethnicity_source_concept_id NOT IN (38003563, 38003564, 1586148, 903079, 903096, 0)
-GROUP BY 1, 2, 3
-
-UNION ALL
-
-SELECT race_concept_id, race_source_concept_id, race_source_value, count(*)
-FROM `{{project_id}}.{{ct_dataset}}.person`
-WHERE race_concept_id NOT IN (2000000008, 1177221, 45882607, 903096, 0)
-AND race_source_concept_id NOT IN (1586141, 1586142, 1586143, 1586144, 1586145, 1586146, 903079, 0)
-GROUP BY 1, 2, 3
+WHERE race_source_concept_id NOT IN (1586141, 1586142, 1586143, 1586144, 1586145, 1586146, 903079, 0)
+AND ethnicity_concept_id NOT IN (38003563, 38003564, 1586148, 903079, 903096, 0)
 """)
-q = query.render(project_id=project_id,
-                 ct_dataset=ct_dataset)
+q = query.render(project_id=project_id, ct_dataset=ct_dataset)
 result = execute(client, q)
 if result.empty:
     df = df.append(
@@ -1441,6 +1442,7 @@ else:
         },
         ignore_index=True)
 result
+
 
 # +
 def highlight_cells(val):


### PR DESCRIPTION
We are removing the suppression of race/ethnicity subcategories and recreating the person from observation. We would need to add a check in our QC notebooks to verify that no subcategories are being displayed in the person table.

## Scope:

Add a check in controlled_tier_qc to verify that race/ethnicity subcategories don’t exist in the person table.

## Acceptance Criteria:

A check is added to controlled_tier_qc part 2

Check fails if subcategories are identified in the person table.