### PR TITLE
[DC-3455] Update Unioned EHR process to have mapping tables as expected

### DIFF
--- a/data_steward/tools/generate_unioned_ehr_dataset.sh
+++ b/data_steward/tools/generate_unioned_ehr_dataset.sh
@@ -114,7 +114,7 @@ python "${DATA_STEWARD_DIR}/cdm.py" --component vocabulary ${unioned_ehr_dataset
 
 #----------------------------------------------------------------------
 # Step 5 copy mapping tables tables
-"${TOOLS_DIR}/table_copy.sh" --source_app_id ${app_id} --target_app_id ${app_id} --source_dataset ${ehr_snapshot} --source_prefix _mapping_ --target_dataset ${unioned_ehr_dataset_backup} --target_prefix _mapping_ --sync false
+"${TOOLS_DIR}/table_copy.sh" --source_app_id ${app_id} --target_app_id ${app_id} --source_dataset ${ehr_snapshot} --source_prefix _mapping_ --target_dataset ${unioned_ehr_dataset_backup} --target_prefix _mapping_
 
 echo "removing tables copies unintentionally"
 bq rm -f ${unioned_ehr_dataset_backup}._mapping_ipmc_nu_condition_occurrence

--- a/data_steward/validation/ehr_union.py
+++ b/data_steward/validation/ehr_union.py
@@ -954,6 +954,7 @@ def main(input_dataset_id,
                                        dataset_id=output_dataset_id)
 
     # Create mapping tables. AOU_DEATH and DEATH are not included here.
+    # SURVEY_CONDUCT's mapping table is created empty here b/c HPO sites do not submit survery_conduct records.
     for domain_table in cdm.tables_to_map():
         if domain_table == SURVEY_CONDUCT:
             bq_client.create_tables([
@@ -966,6 +967,7 @@ def main(input_dataset_id,
 
     # Load all tables with union of submitted tables
     # AOU_DEATH and DEATH are not loaded here.
+    # SURVEY_CONDUCT is skipped here b/c HPO sites do not submit survery_conduct records.
     for table_name in CDM_TABLES:
         if table_name in [DEATH, SURVEY_CONDUCT]:
             continue

--- a/data_steward/validation/ehr_union.py
+++ b/data_steward/validation/ehr_union.py
@@ -956,7 +956,10 @@ def main(input_dataset_id,
     # Create mapping tables. AOU_DEATH and DEATH are not included here.
     for domain_table in cdm.tables_to_map():
         if domain_table == SURVEY_CONDUCT:
-            continue
+            bq_client.create_tables([
+                f'{project_id}.{output_dataset_id}.{mapping_table_for(SURVEY_CONDUCT)}'
+            ],
+                                    exists_ok=True)
         logging.info(f'Mapping {domain_table}...')
         mapping(domain_table, hpo_ids, input_dataset_id, output_dataset_id,
                 project_id, bq_client)

--- a/tests/unit_tests/data_steward/validation/ehr_union_test.py
+++ b/tests/unit_tests/data_steward/validation/ehr_union_test.py
@@ -309,14 +309,13 @@ class EhrUnionTest(unittest.TestCase):
         mock_hpo_info.return_value = [{
             'hpo_id': hpo_id
         } for hpo_id in self.hpo_ids]
-        self.mock_bq_client.return_value = 'client'
         eu.main("input_dataset_id",
                 "output_dataset_id",
                 "project_id",
                 hpo_ids_ex=[self.FAKE_SITE_2])
         mock_mapping.assert_called_with(ANY, [self.FAKE_SITE_1],
                                         "input_dataset_id", "output_dataset_id",
-                                        "project_id", 'client')
+                                        "project_id", ANY)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Dear reviewer,
- See the comment section of the JIRA ticket DC-3455 for findings from the investigation.
- `generate_unioned_ehr_dataset.sh` ... I removed `--sync false` from the command that copies mapping tables. `--sync false` is still there in the commands before it, but having it in sync mode here will give the preceding commands ample time to finish copying. Making it in sync mode will make the execution longer but the impact is acceptable (~10 minutes).