### PR TITLE
[DC-3435] Add check in combined.py to verify no participant in the pdr_ehr_dup_report list have EHR data

### DIFF
--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -862,12 +862,20 @@ execute(client, results)
 # ## Verify no participant in the pdr_ehr_dup_report list has EHR data.
 
 unconsented_records_tpl = JINJA_ENV.from_string("""
-SELECT
-  person_id
+SELECT *
 FROM
-  `{{project_id}}.{{dataset_id}}.person`
-WHERE EXISTS (
-    SELECT person_id FROM `{{project_id}}.{{dataset_id}}_sandbox.{{unconsented}}`
+    `{{project}}.{{dataset}}.{{domain_table}}` d
+  JOIN
+    `{{project}}.{{dataset}}.{{mapping_domain_table}}` md
+  USING
+    ({{domain_table}}_id)
+  WHERE
+    person_id IN (
+    SELECT
+      person_id
+    FROM
+      `{{project}}.{{sandbox_dataset}}.{{unconsented_lookup}}`)
+    AND src_dataset_id LIKE '%ehr%'
   )
 """)
 query = unconsented_records_tpl.render(project_id=PROJECT_ID,

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -878,12 +878,15 @@ FROM
     AND src_dataset_id LIKE '%ehr%'
   )
 """)
-query = unconsented_records_tpl.render(project=PROJECT_ID,
-                                       dataset=DATASET_ID,
-                                       domain_table='wip',
-                                       mapping_domain_table='wip',
-                                       sandbox_dataset='wip',
-                                       unconsented_lookup=UNCONSENTED)
+
+for table in MAPPED_CLINICAL_DATA_TABLES:
+    query = unconsented_records_tpl.render(
+        project=PROJECT_ID,
+        dataset=DATASET_ID,
+        domain_table=table,
+        mapping_domain_table=f'_mapping_{table}',
+        sandbox_dataset='wip',
+        unconsented_lookup=UNCONSENTED)
 result = execute(client, query)
 print(f"found {len(result)} PIDs'")
 result

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -878,6 +878,10 @@ FROM
     AND src_dataset_id LIKE '%ehr%'
 """)
 
+# +
+success_msg_if_empty = "All PID's are consenting PID's"
+failure_msg_if_empty = "Unconsented PID's where FOUND"
+
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,
@@ -888,6 +892,8 @@ for table in MAPPED_CLINICAL_DATA_TABLES:
         unconsented_lookup=UNCONSENTED)
 
     result = execute(client, query)
-    if result.any():
+    if any(result):
         break
-result
+
+render_message(result, success_msg_if_empty, failure_msg_if_empty)
+# -

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -862,7 +862,7 @@ execute(client, results)
 # ## Verify no participant in the pdr_ehr_dup_report list has EHR data.
 
 unconsented_records_tpl = JINJA_ENV.from_string("""
-SELECT person_id AS {{domain_table}}
+SELECT \'{{domain_table}}\' AS domain_table, person_id
 FROM
     `{{project}}.{{dataset}}.{{domain_table}}` d
   JOIN

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -860,6 +860,8 @@ results = '\nUNION ALL\n'.join(result)
 execute(client, results)
 
 # ## Verify no participant in the pdr_ehr_dup_report list has EHR data.
+#
+# Curation will receive a table of unconsented PID's stored in the table `...combined_sandbox._ehr_unconsented_pids` from the PDR.  This check will verify that every mapped EHR table will not contain these PID's.  If any of these PID's are found, a failue is raised, otherwise this check ends with a pass.  See [DC-3435](https://precisionmedicineinitiative.atlassian.net/browse/DC-3435)
 
 unconsented_records_tpl = JINJA_ENV.from_string("""
 SELECT \'{{domain_table}}\' AS domain_table, person_id

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -876,17 +876,25 @@ FROM
     FROM
       `{{project}}.{{sandbox_dataset}}.{{unconsented_lookup}}`)
     AND src_dataset_id LIKE '%ehr%'
-  )
 """)
 
+row_counts = []
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,
         dataset=DATASET_ID,
         domain_table=table,
         mapping_domain_table=f'_mapping_{table}',
-        sandbox_dataset='wip',
+        sandbox_dataset=f'{DATASET_ID}_sandbox',
         unconsented_lookup=UNCONSENTED)
-result = execute(client, query)
-print(f"found {len(result)} PIDs'")
-result
+
+    count = execute(client, query)
+    row_counts.append(count)
+
+if any(row_counts):
+    print("PASS, all PIDs' are consenting")
+else:
+    print("FAIL, unconsenting PIDs' are PRESENT")
+    row_counts
+
+

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -878,7 +878,6 @@ FROM
     AND src_dataset_id LIKE '%ehr%'
 """)
 
-row_counts = []
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,
@@ -892,5 +891,3 @@ for table in MAPPED_CLINICAL_DATA_TABLES:
     if result.any():
         break
 result
-
-

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -898,5 +898,4 @@ for table in MAPPED_CLINICAL_DATA_TABLES:
 full_query = '\nUNION ALL\n'.join(sub_queries)
 result = execute(client, full_query)
 render_message(result, success_msg_if_empty, failure_msg_if_empty)
-result
 # -

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -878,9 +878,12 @@ FROM
     AND src_dataset_id LIKE '%ehr%'
   )
 """)
-query = unconsented_records_tpl.render(project_id=PROJECT_ID,
-                                       dataset_id=DATASET_ID,
-                                       unconsented=UNCONSENTED)
+query = unconsented_records_tpl.render(project=PROJECT_ID,
+                                       dataset=DATASET_ID,
+                                       domain_table='wip',
+                                       mapping_domain_table='wip',
+                                       sandbox_dataset='wip',
+                                       unconsented_lookup=UNCONSENTED)
 result = execute(client, query)
 print(f"found {len(result)} PIDs'")
 result

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -888,13 +888,9 @@ for table in MAPPED_CLINICAL_DATA_TABLES:
         sandbox_dataset=f'{DATASET_ID}_sandbox',
         unconsented_lookup=UNCONSENTED)
 
-    count = execute(client, query)
-    row_counts.append(count)
-
-if any(row_counts):
-    print("PASS, all PIDs' are consenting")
-else:
-    print("FAIL, unconsenting PIDs' are PRESENT")
-    row_counts
+    result = execute(client, query)
+    if result.any():
+        break
+result
 
 

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -876,13 +876,14 @@ FROM
     FROM
       `{{project}}.{{sandbox_dataset}}.{{unconsented_lookup}}`)
     AND src_dataset_id LIKE '%ehr%'
+
 """)
 
 # +
 success_msg_if_empty = "All PID's with EHR data are found consenting"
 failure_msg_if_empty = "EHR data is found for PIDs who have not consented to contribute EHR data."
 
-totals = []
+sub_queries = []
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,
@@ -892,10 +893,10 @@ for table in MAPPED_CLINICAL_DATA_TABLES:
         sandbox_dataset=f'{DATASET_ID}_sandbox',
         unconsented_lookup=UNCONSENTED)
 
-    result = execute(client, query)
-    totals.append(result)
+    sub_queries.append(query)
 
-aggregated = pd.concat(totals)
-render_message(aggregated, success_msg_if_empty, failure_msg_if_empty)
-aggregated
+full_query = '\nUNION ALL\n'.join(sub_queries)
+result = execute(client, full_query)
+render_message(result, success_msg_if_empty, failure_msg_if_empty)
+result
 # -

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -883,7 +883,6 @@ success_msg_if_empty = "All PID's with EHR data are found consenting"
 failure_msg_if_empty = "EHR data is found for PIDs who have not consented to contribute EHR data."
 
 totals = []
-
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,
@@ -900,5 +899,3 @@ aggregated = pd.concat(totals)
 render_message(aggregated, success_msg_if_empty, failure_msg_if_empty)
 aggregated
 # -
-
-

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -862,7 +862,7 @@ execute(client, results)
 # ## Verify no participant in the pdr_ehr_dup_report list has EHR data.
 
 unconsented_records_tpl = JINJA_ENV.from_string("""
-SELECT person_id
+SELECT person_id AS {{domain_table}}
 FROM
     `{{project}}.{{dataset}}.{{domain_table}}` d
   JOIN
@@ -883,6 +883,7 @@ success_msg_if_empty = "All PID's with EHR data are found consenting"
 failure_msg_if_empty = "EHR data is found for PIDs who have not consented to contribute EHR data."
 
 totals = []
+
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 from common import JINJA_ENV, MAPPED_CLINICAL_DATA_TABLES
 from cdr_cleaner.cleaning_rules.negative_ages import date_fields
+from cdr_cleaner.cleaning_rules.remove_ehr_data_without_consent import EHR_UNCONSENTED_PARTICIPANTS_LOOKUP_TABLE as UNCONSENTED
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES, render_message
@@ -767,21 +768,21 @@ render_message(df_orphaned_check,
 # +
 query = JINJA_ENV.from_string("""
 WITH qc_aou_death AS (
-    SELECT 
-        aou_death_id, 
+    SELECT
+        aou_death_id,
         CASE WHEN aou_death_id IN (
             SELECT aou_death_id FROM `{{project_id}}.{{dataset_id}}.aou_death`
             WHERE death_date IS NOT NULL -- NULL death_date records must not become primary --
             QUALIFY RANK() OVER (
-                PARTITION BY person_id 
+                PARTITION BY person_id
                 ORDER BY
                     LOWER(src_id) NOT LIKE '%healthpro%' DESC, -- EHR records are chosen over HealthPro ones --
                     death_date ASC, -- Earliest death_date records are chosen over later ones --
                     death_datetime ASC NULLS LAST, -- Earliest non-NULL death_datetime records are chosen over later or NULL ones --
                     src_id ASC -- EHR site that alphabetically comes first is chosen --
-            ) = 1   
+            ) = 1
         ) THEN TRUE ELSE FALSE END AS primary_death_record
-    FROM `{{project}}.{{dataset}}.aou_death`    
+    FROM `{{project}}.{{dataset}}.aou_death`
 )
 SELECT ad.aou_death_id
 FROM `{{project_id}}.{{dataset}}.aou_death` ad
@@ -793,7 +794,7 @@ df = execute(client, query)
 
 success_msg = 'All death records have the correct `primary_death_record` values.'
 failure_msg = '''
-    <b>{code_count}</b> records do not have the correct `primary_death_record` values. 
+    <b>{code_count}</b> records do not have the correct `primary_death_record` values.
     Investigate and confirm if (a) any logic is incorrect, (b) the requirement has changed, or (c) something else.
 '''
 render_message(df,
@@ -828,9 +829,9 @@ render_message(df_if_empty, success_msg_if_empty, failure_msg_if_empty)
 ext_template = JINJA_ENV.from_string("""
     SELECT
       table_id
-    FROM 
+    FROM
         `{{project_id}}.{{dataset}}.__TABLES__`
-    WHERE 
+    WHERE
         table_id LIKE '%_ext%'
 """)
 ext_tables_query = ext_template.render(project_id=PROJECT_ID,
@@ -847,7 +848,7 @@ for _, row in ext_tables.iterrows():
         `{{project_id}}.{{dataset}}.{{table_name}}`
       WHERE NOT
           REGEXP_CONTAINS(src_id, r'(?i)(Portal)|(EHR site)')
-      OR 
+      OR
         src_id IS NULL
       GROUP BY 1,2
   """)
@@ -857,3 +858,21 @@ for _, row in ext_tables.iterrows():
     result.append(query)
 results = '\nUNION ALL\n'.join(result)
 execute(client, results)
+
+# ## Verify no participant in the pdr_ehr_dup_report list has EHR data.
+
+unconsented_records_tpl = JINJA_ENV.from_string("""
+SELECT
+  person_id
+FROM
+  `{{project_id}}.{{dataset_id}}.person`
+WHERE EXISTS (
+    SELECT person_id FROM `{{project_id}}.{{dataset_id}}_sandbox.{{unconsented}}`
+  )
+""")
+query = unconsented_records_tpl.render(project_id=PROJECT_ID,
+                                       dataset_id=DATASET_ID,
+                                       unconsented=UNCONSENTED)
+result = execute(client, query)
+print(f"found {len(result)} PIDs'")
+result

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -862,7 +862,7 @@ execute(client, results)
 # ## Verify no participant in the pdr_ehr_dup_report list has EHR data.
 
 unconsented_records_tpl = JINJA_ENV.from_string("""
-SELECT *
+SELECT person_id
 FROM
     `{{project}}.{{dataset}}.{{domain_table}}` d
   JOIN
@@ -882,6 +882,7 @@ FROM
 success_msg_if_empty = "All PID's with EHR data are found consenting"
 failure_msg_if_empty = "EHR data is found for PIDs who have not consented to contribute EHR data."
 
+totals = []
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(
         project=PROJECT_ID,
@@ -892,8 +893,11 @@ for table in MAPPED_CLINICAL_DATA_TABLES:
         unconsented_lookup=UNCONSENTED)
 
     result = execute(client, query)
-    if any(result):
-        break
+    totals.append(result)
 
-render_message(result, success_msg_if_empty, failure_msg_if_empty)
+aggregated = pd.concat(totals)
+render_message(aggregated, success_msg_if_empty, failure_msg_if_empty)
+aggregated
 # -
+
+

--- a/data_steward/analytics/cdr_ops/combined.py
+++ b/data_steward/analytics/cdr_ops/combined.py
@@ -879,8 +879,8 @@ FROM
 """)
 
 # +
-success_msg_if_empty = "All PID's are consenting PID's"
-failure_msg_if_empty = "Unconsented PID's where FOUND"
+success_msg_if_empty = "All PID's with EHR data are found consenting"
+failure_msg_if_empty = "EHR data is found for PIDs who have not consented to contribute EHR data."
 
 for table in MAPPED_CLINICAL_DATA_TABLES:
     query = unconsented_records_tpl.render(


### PR DESCRIPTION
## Scope

In the combined.py notebook, it is necessary to add a verification step to ensure that all EHR records are removed for duplicated accounts with conflicting statuses. This check should analyze the data from all CDM/clinical tables. A failure message with a list of these items should be added if any PIDs still exist.