### PR TITLE
[DC-3504] `ConflictingHpoStateGeneralize` QC notebook update and test cases update

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report8_household_state_genera.py
@@ -17,7 +17,9 @@
 
 import urllib
 import pandas as pd
-from common import JINJA_ENV
+from common import (CONDITION_OCCURRENCE, DEVICE_EXPOSURE, DRUG_EXPOSURE,
+                    JINJA_ENV, MEASUREMENT, OBSERVATION, PROCEDURE_OCCURRENCE,
+                    VISIT_OCCURRENCE)
 from utils import auth
 from gcloud.bq import BigQueryClient
 from analytics.cdr_ops.notebook_utils import execute, IMPERSONATION_SCOPES
@@ -25,13 +27,12 @@ pd.options.display.max_rows = 120
 
 # + tags=["parameters"]
 project_id = ""
-deid_cdr=""
+deid_cdr = ""
 combine = ""
-reg_combine=''
+reg_combine = ''
 pipeline = ""
 deid_sand = ""
-pid_threshold=""
-run_as=""
+run_as = ""
 
 # +
 impersonation_creds = auth.get_impersonation_credentials(
@@ -41,7 +42,7 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
 # df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+df = pd.DataFrame(columns=['query', 'result'])
 
 # # Query1 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585890, the value_as_concept_id field in de-id table should populate : 2000000012
 #
@@ -49,14 +50,14 @@ df = pd.DataFrame(columns = ['query', 'result'])
 #
 # Expected result:
 #
-# Null is the value poplulated in the value_as_number fields 
+# Null is the value poplulated in the value_as_number fields
 #
 # AND 2000000012, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field  in the deid table.
 #
-# Per Francis, the other two values are valid. so it is pass. 
+# Per Francis, the other two values are valid. so it is pass.
 
 # +
-query=JINJA_ENV.from_string("""
+query = JINJA_ENV.from_string("""
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM `{{project_id}}.{{deid_cdr}}.observation`
@@ -64,15 +65,23 @@ WHERE
   observation_source_concept_id = 1585890
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
 """)
-q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
+q = query.render(project_id=project_id, deid_cdr=deid_cdr)
+df1 = execute(client, q)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query1 observation_source_concept_id 1585890', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query1 observation_source_concept_id 1585890',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query1 observation_source_concept_id 1585890', 'result' : 'Failure'},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query1 observation_source_concept_id 1585890',
+            'result': 'Failure'
+        },
+        ignore_index=True)
 df1
 # -
 
@@ -87,7 +96,7 @@ df1
 # ## one row had error in new cdr
 
 # +
-query=JINJA_ENV.from_string("""
+query = JINJA_ENV.from_string("""
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM `{{project_id}}.{{deid_cdr}}.observation`
@@ -95,19 +104,27 @@ WHERE
   observation_source_concept_id = 1333023
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
 """)
-q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
+q = query.render(project_id=project_id, deid_cdr=deid_cdr)
+df1 = execute(client, q)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query2 observation_source_concept_id 1333023', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query2 observation_source_concept_id 1333023',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query2 observation_source_concept_id 1333023', 'result' : 'Failure'},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query2 observation_source_concept_id 1333023',
+            'result': 'Failure'
+        },
+        ignore_index=True)
 df1
 # -
 
-query=JINJA_ENV.from_string("""
+query = JINJA_ENV.from_string("""
 
 SELECT *
 FROM `{{project_id}}.{{deid_cdr}}.observation`
@@ -115,8 +132,8 @@ WHERE
   observation_source_concept_id = 1333023
   AND value_as_concept_id NOT IN (2000000012,2000000010,903096)
 """)
-q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
+q = query.render(project_id=project_id, deid_cdr=deid_cdr)
+df1 = execute(client, q)
 df1
 
 # # Query3 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1585889,  the value_as_concept_id field in de-id table should populate : 2000000013
@@ -125,44 +142,52 @@ df1
 #
 # expected results:
 #
-# Null is the value poplulated in the value_as_number fields 
+# Null is the value poplulated in the value_as_number fields
 #
 # AND 2000000013, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 
 # +
-query=JINJA_ENV.from_string("""
+query = JINJA_ENV.from_string("""
 SELECT COUNT (*) AS n_row_not_pass
 FROM  `{{project_id}}.{{deid_cdr}}.observation`
 WHERE
   observation_source_concept_id = 1585889
   AND value_as_concept_id NOT IN (2000000013,2000000010,903096)
 """)
-q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
+q = query.render(project_id=project_id, deid_cdr=deid_cdr)
+df1 = execute(client, q)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query3 observation_source_concept_id 1585889', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query3 observation_source_concept_id 1585889',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query3 observation_source_concept_id 1585889', 'result' : 'Failure'},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query3 observation_source_concept_id 1585889',
+            'result': 'Failure'
+        },
+        ignore_index=True)
 df1
 # -
 
 # # Query4 Verify that if the observation_source_concept_id  field in OBSERVATION table populates: 1333015,  the value_as_concept_id field in de-id table should populate : 2000000013
 #
-# Generalization Rules for reference 
+# Generalization Rules for reference
 #
 # Living Situation: COPE survey Generalize household size >10
 #
 # expected results:
 #
-# Null is the value poplulated in the value_as_number fields 
+# Null is the value poplulated in the value_as_number fields
 #
 # AND 2000000013, 2000000010 AND 903096 are the values that are populated in value_as_concept_id field in the deid table.
 
 # +
-query=JINJA_ENV.from_string("""
+query = JINJA_ENV.from_string("""
 
 SELECT COUNT (*) AS n_row_not_pass
 FROM  `{{project_id}}.{{deid_cdr}}.observation`
@@ -170,127 +195,101 @@ WHERE
   observation_source_concept_id = 1333015
   AND value_as_concept_id NOT IN (2000000013,2000000010,903096)
 """)
-q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
+q = query.render(project_id=project_id, deid_cdr=deid_cdr)
+df1 = execute(client, q)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query4 observation_source_concept_id 1333015', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query4 observation_source_concept_id 1333015',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query4 observation_source_concept_id 1333015', 'result' : 'Failure'},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query4 observation_source_concept_id 1333015',
+            'result': 'Failure'
+        },
+        ignore_index=True)
 df1
 # -
 
-# # Query5 update to verifie that value_as_concept_id and value_source_concept_id are set to 2000000011 for states with less than 200 participants.
+# # Query5 State generalization cleaning rules
+# `ConflictingHpoStateGeneralize` and `GeneralizeStateByPopulation` updates participants' state records in observation to
+# value_source_concept_id = 2000000011 and value_as_concept_id = 2000000011 based on the criteria.
+# Query5.1 and Query5.2 check if the state generalization is working as expected.
 #
-# Set the value_source_concept_id = 2000000011 and value_as_concept_id =2000000011 
-#
-# DC-2377 and DC-1614, DC-2782, DC-2785
+# Related tickets: DC-2377, DC-1614, DC-2782, DC-2785, DC-3504
 
 # ## Query5.1 Generalize state info (2000000011) for participants who have EHR data from states other than the state they are currently living in.
+# The CR `ConflictingHpoStateGeneralize` takes care of this criteria. Look at the CR's sandbox tables and related logics if this QC fails.
 
 # +
 query = JINJA_ENV.from_string("""
 
-with df_ehr_site as (
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'observation' table
-FROM `{{project_id}}.{{reg_combine}}.observation` com
-join `{{project_id}}.{{reg_combine}}._mapping_observation` map on map.observation_id=com.observation_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+with participant_hpo_sites as (
 
-union distinct 
+{% for table in tables %}
+SELECT DISTINCT deid.person_id, mask.value_source_concept_id
+FROM `{{project_id}}.{{deid_cdr}}.{{table}}` deid
+JOIN `{{project_id}}.{{deid_cdr}}.{{table}}_ext` ext ON deid.{{table}}_id = ext.{{table}}_id
+JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON ext.src_id = mask.src_id
 
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'condition' table
-FROM `{{project_id}}.{{reg_combine}}.condition_occurrence` com
-join `{{project_id}}.{{reg_combine}}._mapping_condition_occurrence` map on map.condition_occurrence_id=com.condition_occurrence_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+{% if not loop.last -%} UNION DISTINCT {% endif %}
 
-union distinct 
-
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'measurement' table
-FROM `{{project_id}}.{{reg_combine}}.measurement` com
-join `{{project_id}}.{{reg_combine}}._mapping_measurement` map on map.measurement_id=com.measurement_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
-
-union distinct 
-
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'device_exposure' table
-FROM `{{project_id}}.{{reg_combine}}.device_exposure` com
-join `{{project_id}}.{{reg_combine}}._mapping_device_exposure` map on map.device_exposure_id=com.device_exposure_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
-
-union distinct 
-
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'drug_exposure' table
-FROM `{{project_id}}.{{reg_combine}}.drug_exposure` com
-join `{{project_id}}.{{reg_combine}}._mapping_drug_exposure` map on map.drug_exposure_id=com.drug_exposure_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
-
-union distinct 
-
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'procedure' table
-FROM `{{project_id}}.{{reg_combine}}.procedure_occurrence` com
-join `{{project_id}}.{{reg_combine}}._mapping_procedure_occurrence` map on map.procedure_occurrence_id=com.procedure_occurrence_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
-
-union distinct 
-
-SELECT distinct com.person_id, research_id deid_pid, map_state.State EHR_site_state,'visit' table
-FROM `{{project_id}}.{{reg_combine}}.visit_occurrence` com
-join `{{project_id}}.{{reg_combine}}._mapping_visit_occurrence` map on map.visit_occurrence_id=com.visit_occurrence_id
-JOIN `{{project_id}}.{{deid_sand}}._deid_map` deid_map on deid_map.person_id=com.person_id
-JOIN `{{project_id}}.{{reg_combine}}._mapping_src_hpos_to_allowed_states`  map_state ON map_state.src_hpo_id=map.src_hpo_id
-JOIN `{{project_id}}.{{pipeline}}.site_maskings` mask ON hpo_id=map_state.src_hpo_id
+{% endfor %}
 ),
 
 df2 as (
 
-SELECT distinct deid.person_id,
-com.value_source_concept_id, 
-com.value_source_value com_residency_state, EHR_site_state
+SELECT DISTINCT deid.person_id
 FROM `{{project_id}}.{{deid_cdr}}.observation` deid
-join `{{project_id}}.{{reg_combine}}.observation` com on com.observation_id=deid.observation_id
-join df_ehr_site on deid.person_id=df_ehr_site.deid_pid
-where deid.observation_source_concept_id = 1585249
-and deid.value_source_concept_id !=2000000011
-and com.value_source_value !=EHR_site_state 
+JOIN participant_hpo_sites hpo ON deid.person_id = hpo.person_id
+WHERE deid.observation_source_concept_id = 1585249
+AND deid.value_source_concept_id != hpo.value_source_concept_id
+AND (deid.value_source_concept_id != 2000000011 OR 
+     deid.value_as_concept_id != 2000000011
+    )
 )
    
 select count (*) AS row_counts_failure_state_generalization from df2
 
-""")
+""").render(project_id=project_id,
+            deid_cdr=deid_cdr,
+            reg_combine=reg_combine,
+            deid_sand=deid_sand,
+            pipeline=pipeline,
+            tables=[
+                CONDITION_OCCURRENCE, DEVICE_EXPOSURE, DRUG_EXPOSURE,
+                MEASUREMENT, OBSERVATION, PROCEDURE_OCCURRENCE, VISIT_OCCURRENCE
+            ])
 
-q = query.render(project_id=project_id,deid_cdr=deid_cdr,reg_combine=reg_combine,deid_sand=deid_sand,pipeline=pipeline)
+df1 = execute(client, query)
 
-df1=execute(client, q)
-
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query5.1 state generalization to 2000000011', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query5.1 state generalization to 2000000011',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query5.1 state generalization to 2000000011', 'result' : 'Failure'},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query5.1 state generalization to 2000000011',
+            'result': 'Failure'
+        },
+        ignore_index=True)
 df1
 
 # -
 
 # ## Query5.2 Generalize state info for participants where the identified number of participants living in the state without EHR records from a different state < 200 (the generalization threshold)”
+# The CR `GeneralizeStateByPopulation` takes care of this criteria. Look at the CR's sandbox tables and related logics if this QC fails.
 
 # +
-query=JINJA_ENV.from_string(""" 
+query = JINJA_ENV.from_string(""" 
 with df_state_pid_200 as (
 select value_source_concept_id,
 count(distinct person_id) as participant_count
@@ -306,25 +305,36 @@ WHERE observation_source_concept_id = 1585249
 and (value_source_concept_id !=2000000011 or value_as_concept_id !=2000000011) 
 and value_source_concept_id in (select value_source_concept_id from df_state_pid_200)
 """)
-q = query.render(project_id=project_id,deid_cdr=deid_cdr,pid_threshold=pid_threshold,reg_combine=reg_combine)
-df1=execute(client, q)
+q = query.render(project_id=project_id,
+                 deid_cdr=deid_cdr,
+                 reg_combine=reg_combine)
+df1 = execute(client, q)
 
-if df1.loc[0].sum()==0:
- df = df.append({'query' : 'Query5.2 state generalization if counts <200', 'result' : 'PASS'},  
-                ignore_index = True) 
+if df1.loc[0].sum() == 0:
+    df = df.append(
+        {
+            'query': 'Query5.2 state generalization if counts <200',
+            'result': 'PASS'
+        },
+        ignore_index=True)
 else:
- df = df.append({'query' : 'Query5.2 state generalization if counts <200', 'result' : 'Failure'},  
-                ignore_index = True) 
+    df = df.append(
+        {
+            'query': 'Query5.2 state generalization if counts <200',
+            'result': 'Failure'
+        },
+        ignore_index=True)
 df1
-
 
 # -
 
 # # Summary_deid_household AND state generalization
 
+
 # +
 def highlight_cells(val):
     color = 'red' if 'Failure' in val else 'white'
-    return f'background-color: {color}' 
+    return f'background-color: {color}'
+
 
 df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/conflicting_hpo_state_generalization.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/conflicting_hpo_state_generalization.py
@@ -22,16 +22,11 @@ MAP_TABLE_NAME = "person_src_hpos_lookup_ext"
 SCHEMA_MAP_TABLE = "person_src_hpos_ext"
 
 HPO_ID_NOT_RDR_QUERY = JINJA_ENV.from_string("""
-  SELECT
-  DISTINCT person_id, src_id
-  FROM
-    `{{project_id}}.{{dataset_id}}.{{table}}_ext`
-  JOIN
-    `{{project_id}}.{{dataset_id}}.{{table}}`
-  USING
-    ({{table}}_id)
-  WHERE
-    NOT REGEXP_CONTAINS(src_id, r'(?i)(Portal)')
+  SELECT DISTINCT person_id, src_id
+  FROM `{{project_id}}.{{dataset_id}}.{{table}}_ext`
+  JOIN `{{project_id}}.{{dataset_id}}.{{table}}`
+  USING ({{table}}_id)
+  WHERE NOT REGEXP_CONTAINS(src_id, r'(?i)(Portal)')
 """)
 
 LIST_PERSON_ID_TABLES = JINJA_ENV.from_string("""
@@ -48,8 +43,7 @@ LIST_PERSON_ID_TABLES = JINJA_ENV.from_string("""
 
 INSERT_TO_MAP_TABLE_NAME = JINJA_ENV.from_string("""
   INSERT INTO `{{project_id}}.{{sandbox_dataset_id}}.{{table_name}}`
-  (person_id,
-   src_id)
+  (person_id, src_id)
   {{select_query}}
 """)
 

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/conflicting_hpo_state_generalization_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/deid/conflicting_hpo_state_generalization_test.py
@@ -12,52 +12,67 @@ from dateutil.parser import parse
 
 # Project Imports
 from app_identity import PROJECT_ID
-from cdr_cleaner.cleaning_rules.deid.conflicting_hpo_state_generalization import ConflictingHpoStateGeneralize
-from common import JINJA_ENV, OBSERVATION, PIPELINE_TABLES
+from cdr_cleaner.cleaning_rules.deid.conflicting_hpo_state_generalization import (
+    ConflictingHpoStateGeneralize, MAP_TABLE_NAME)
+from common import EXT_SUFFIX, JINJA_ENV, OBSERVATION, SITE_MASKING_TABLE_ID
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 
 INSERT_RAW_DATA_OBS = JINJA_ENV.from_string("""
-   INSERT INTO `{{project_id}}.{{dataset_id}}.observation` (
-       observation_id,
-       person_id,
-       observation_concept_id,
-       observation_date,
-       observation_type_concept_id,
-       value_as_number,
-       value_as_string,
-       value_as_concept_id,
-       observation_source_concept_id,
-       value_source_concept_id,
-       value_source_value
+    INSERT INTO `{{project_id}}.{{dataset_id}}.observation` (
+        observation_id,
+        person_id,
+        observation_concept_id,
+        observation_date,
+        observation_type_concept_id,
+        value_as_concept_id,
+        observation_source_concept_id,
+        value_source_concept_id,
+        value_source_value
     )
     VALUES
-       (1,101,0,'2020-01-01',1,2,'',100,1585249,100,'Generalize This Value'),
-       (2,101,0,'2020-01-01',1,2,'',100,1500000,100,'Test Value'),
-       (3,103,0,'2020-01-01',1,2,'',100,1585249,1585261,'Do Not Generalize This Value'),
-       (4,103,0,'2020-01-01',1,2,'',100,1585248,100,'Test Value')
+    -- person_id 1 answered that she lives in Alabama. -- 
+    -- And all the HPO records come from a HPO site in Alabama. --
+    -- Nothing happens to person_id 1 --
+        (101, 1, 0, '2020-01-01', 1, 999, 1585249, 1585261, 'PIIState_AL'),
+        (102, 1, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+        (103, 1, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+    -- person_id 2 answered that she lives in Alabama -- 
+    -- And all the HPO records come from HPO sites in Alabama --
+    -- Nothing happens to person_id 2 --
+        (201, 2, 0, '2020-01-01', 1, 999, 1585249, 1585261, 'PIIState_AL'),
+        (202, 2, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+        (203, 2, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+    -- person_id 3 answered that she lives in Alabama. -- 
+    -- But all the HPO records come from a HPO site in Arizona. --
+    -- State info will be generalized for person_id 3 --
+        (301, 3, 0, '2020-01-01', 1, 999, 1585249, 1585261, 'PIIState_AL'),
+        (302, 3, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+        (303, 3, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+    -- person_id 4 answered that she lives in Alabama. -- 
+    -- But one of the HPO records come from a HPO site in Arizona. --
+    -- State info will be generalized for person_id 4 --
+        (401, 4, 0, '2020-01-01', 1, 999, 1585249, 1585261, 'PIIState_AL'),
+        (402, 4, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy'),
+        (403, 4, 0, '2020-01-01', 1, 999, 1500000, 9999999, 'Dummy')
  """)
 
 INSERT_RAW_DATA_EXT = JINJA_ENV.from_string("""
-   INSERT INTO `{{project_id}}.{{dataset_id}}.observation_ext`(
-       observation_id,
-       src_id
-   )
-   VALUES
-       (1,'Portal 1'),
-       (2, 'bar 000'),
-       (3, 'Portal 2'),
-       (4, 'bar 123')
+    INSERT INTO `{{project_id}}.{{dataset_id}}.observation_ext`
+        (observation_id, src_id)
+    VALUES
+        (101, 'Portal1'), (102, 'bar 001'), (103, 'bar 001'),
+        (201, 'Portal2'), (202, 'bar 001'), (203, 'bar 002'),
+        (301, 'Portal3'), (302, 'bar 003'), (303, 'bar 003'),
+        (401, 'Portal4'), (402, 'bar 001'), (403, 'bar 003')
  """)
 
 INSERT_TEMP_MASK_TABLE = JINJA_ENV.from_string("""
-    INSERT INTO `{{project_id}}.{{dataset_id}}.site_maskings` (
-        hpo_id,
-        src_id,
-        state,
-        value_source_concept_id)
+    INSERT INTO `{{project_id}}.{{dataset_id}}.site_maskings`
+        (hpo_id, src_id, state, value_source_concept_id)
     VALUES
-        ('foo', 'bar 123', 'PIIState_AL', 1585261),
-        ('bar', 'bar 000', 'PIIState_CA', 1585266)
+        ('hpo site in Alabama 1', 'bar 001', 'PIIState_AL', 1585261),
+        ('hpo site in Alabama 2', 'bar 002', 'PIIState_AL', 1585261),
+        ('hpo site in Arizona 3', 'bar 003', 'PIIState_AZ', 1585264)
 """)
 
 
@@ -82,7 +97,9 @@ class ConflictingHpoStateGeneralizeTest(BaseTest.CleaningRulesTestBase):
             cls.project_id, cls.dataset_id, cls.sandbox_id)
 
         # Generates list of fully qualified table names and their corresponding sandbox table names
-        for table in [OBSERVATION, f'{OBSERVATION}_ext', 'site_maskings']:
+        for table in [
+                OBSERVATION, f'{OBSERVATION}{EXT_SUFFIX}', SITE_MASKING_TABLE_ID
+        ]:
             cls.fq_table_names.append(
                 f'{cls.project_id}.{cls.dataset_id}.{table}')
 
@@ -100,8 +117,8 @@ class ConflictingHpoStateGeneralizeTest(BaseTest.CleaningRulesTestBase):
         raw_data_load_query_obs = INSERT_RAW_DATA_OBS.render(
             project_id=self.project_id, dataset_id=self.dataset_id)
 
-        raw_data_load_query_mapping = INSERT_RAW_DATA_EXT. \
-            render(project_id=self.project_id, dataset_id=self.dataset_id)
+        raw_data_load_query_mapping = INSERT_RAW_DATA_EXT.render(
+            project_id=self.project_id, dataset_id=self.dataset_id)
 
         # The location of the table will be mocked in the test
         temp_mask_query = INSERT_TEMP_MASK_TABLE.render(
@@ -124,29 +141,34 @@ class ConflictingHpoStateGeneralizeTest(BaseTest.CleaningRulesTestBase):
             'fq_table_name':
                 f'{self.project_id}.{self.dataset_id}.{OBSERVATION}',
             'fq_sandbox_table_name':
-                f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.get_sandbox_tablenames()[0]}',
+                f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(OBSERVATION)}',
             # The following tables are created when `setup_rule` runs,
             # so this will break the sandboxing check that runs in 'default_test()'
             # We get around the check by declaring these tables are created before
             # the rule runs and this is expected.
             'tables_created_on_setup': [
-                f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.get_sandbox_tablenames()[-1]}'
+                f'{self.project_id}.{self.sandbox_id}.{MAP_TABLE_NAME}'
             ],
-            'loaded_ids': [1, 2, 3, 4],
-            'sandboxed_ids': [1],
+            'loaded_ids': [
+                101, 102, 103, 201, 202, 203, 301, 302, 303, 401, 402, 403
+            ],
+            'sandboxed_ids': [301, 401],
             'fields': [
-                'observation_id', 'person_id', 'observation_date',
-                'value_as_concept_id', 'observation_source_concept_id',
-                'value_source_concept_id', 'value_source_value'
+                'observation_id', 'person_id', 'value_as_concept_id',
+                'observation_source_concept_id', 'value_source_concept_id'
             ],
-            'cleaned_values': [
-                (1, 101, self.date, 2000000011, 1585249, 2000000011,
-                 'Generalize This Value'),
-                (2, 101, self.date, 100, 1500000, 100, 'Test Value'),
-                (3, 103, self.date, 100, 1585249, 1585261,
-                 'Do Not Generalize This Value'),
-                (4, 103, self.date, 100, 1585248, 100, 'Test Value')
-            ]
+            'cleaned_values': [(101, 1, 999, 1585249, 1585261),
+                               (102, 1, 999, 1500000, 9999999),
+                               (103, 1, 999, 1500000, 9999999),
+                               (201, 2, 999, 1585249, 1585261),
+                               (202, 2, 999, 1500000, 9999999),
+                               (203, 2, 999, 1500000, 9999999),
+                               (301, 3, 2000000011, 1585249, 2000000011),
+                               (302, 3, 999, 1500000, 9999999),
+                               (303, 3, 999, 1500000, 9999999),
+                               (401, 4, 2000000011, 1585249, 2000000011),
+                               (402, 4, 999, 1500000, 9999999),
+                               (403, 4, 999, 1500000, 9999999)]
         }]
 
         # mock the PIPELINE_TABLES variable so tests on different branches
@@ -155,3 +177,16 @@ class ConflictingHpoStateGeneralizeTest(BaseTest.CleaningRulesTestBase):
                 'cdr_cleaner.cleaning_rules.deid.conflicting_hpo_state_generalization.PIPELINE_TABLES',
                 self.dataset_id):
             self.default_test(tables_and_counts)
+
+        self.assertTableValuesMatch(
+            f'{self.project_id}.{self.sandbox_id}.{MAP_TABLE_NAME}',
+            ['person_id', 'src_id'], [(1, 'bar 001'), (2, 'bar 001'),
+                                      (2, 'bar 002'), (3, 'bar 003'),
+                                      (4, 'bar 001'), (4, 'bar 003')])
+
+        self.assertTableValuesMatch(
+            f'{self.project_id}.{self.sandbox_id}.{self.rule_instance.sandbox_table_for(f"{OBSERVATION}_identifier")}',
+            [
+                'observation_id', 'person_id', 'src_id',
+                'value_source_concept_id'
+            ], [(301, 3, 'bar 003', 1585261), (401, 4, 'bar 003', 1585261)])


### PR DESCRIPTION
Dear reviewer,
- Please take a look at the comment section of the JIRA ticket DC-3504 for the context.
- The changes in the unrelated sections of `cdr_deid_qa_report8_household_state_genera.py` are made by Pylint.
- For `cdr_deid_qa_report8_household_state_genera.py`, I removed the parameter `pid_threshold` because it was not used anywhere.
- I updated the test cases in `conflicting_hpo_state_generalization_test.py` as a part of the investigation.