### PR TITLE
[DC-2905] Remove exec parameter

### DIFF
--- a/data_steward/validation/email_notification.py
+++ b/data_steward/validation/email_notification.py
@@ -194,5 +194,5 @@ def send_email(email_message):
     except mandrill.Error as e:
         # Mandrill errors are thrown as exceptions
         msg = f"A mandrill error occurred: {e.__class__} - {e}"
-        LOGGER.exception(msg, exec_info=True)
+        LOGGER.exception(msg)
     return result


### PR DESCRIPTION
## Background:

GCP alerted the ‘curation-automated-alerts’ slack channel about the [linked incident](https://console.cloud.google.com/monitoring/alerting/incidents/0.mpn73fq3kqxb?project=aou-res-curation-prod) occurring at 2:22 AM 11-28-2022. 

The send_email function of /validation/email_notification.py did not complete without exception.  When the except statement ran it also produced an error. TypeError: _log() got an unexpected keyword argument 'exec_info' referencing line 193.

## Scope:

This ticket is to resolve the TypeError in the send_email function

 except statement. The probable cause is that the exec_info argument used should be exc_info. [Documentation here](https://docs.python.org/3/library/logging.html)

## Acceptance Criteria:

Complete one of two tasks

Remove the exec_info argument altogether.

Confirm exc_info is the correct argument and make the correction in /validation/email_notification.py.