### PR TITLE
[DC-3605] [DC-3600] Exclude 'person_ext' from being removed by cleaning Rule

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/create_person_ext_table.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/create_person_ext_table.py
@@ -54,7 +54,8 @@ ON
   o.observation_id = e.observation_id
   AND o.observation_source_concept_id = 1585249
 LEFT JOIN
-  `{{project}}.{{dataset}}.observation` os
+  (SELECT DISTINCT person_id, observation_source_concept_id, value_as_concept_id, value_source_concept_id
+   FROM `{{project}}.{{dataset}}.observation`) os
 ON
   p.person_id = os.person_id
   AND os.observation_source_concept_id = 1585845

--- a/data_steward/cdr_cleaner/cleaning_rules/remove_extra_tables.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/remove_extra_tables.py
@@ -66,7 +66,7 @@ class RemoveExtraTables(BaseCleaningRule):
         extension_tables = list({
             f'{table}_ext' for table in cdm_schemas().keys()
             if has_domain_table_id(table)
-        } - {'person_ext'}) + ['person_src_hpos_ext']
+        }) + ['person_src_hpos_ext']
         # To Keep AOU_DEATH table
         custom_tables = AOU_CUSTOM_TABLES + [WEAR_STUDY]
         affected_tables = cdm_achilles_vocab_tables + extension_tables + custom_tables

--- a/data_steward/tools/create_combined_backup_dataset.py
+++ b/data_steward/tools/create_combined_backup_dataset.py
@@ -500,7 +500,7 @@ def main(raw_args=None):
                           f'{client.project}.{combined_backup}.{table}')
 
     LOGGER.info('Generating combined mapping tables ...')
-    for domain_table in combine_consts.DOMAIN_TABLES + [SURVEY_CONDUCT]:
+    for domain_table in combine_consts.DOMAIN_TABLES + [SURVEY_CONDUCT, PERSON]:
         LOGGER.info(f'Mapping {domain_table}...')
         generate_combined_mapping_tables(client, domain_table, args.rdr_dataset,
                                          args.unioned_ehr_dataset,

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/generate_ext_tables_test.py
@@ -67,11 +67,11 @@ class GenerateExtTablesTest(unittest.TestCase):
                 "The provenance of the data associated with the foo_id."
         }]
 
-        # Excluding PERSON, DEATH, and FACT_RELATIONSHIP beacuse they do not
+        # Excluding DEATH, and FACT_RELATIONSHIP beacuse they do not
         # have mapping tables in the combined dataset.
         mapped_table_names = [
-            cdm_table for cdm_table in common.CATI_TABLES if cdm_table not in
-            [common.PERSON, common.DEATH, common.FACT_RELATIONSHIP]
+            cdm_table for cdm_table in common.CATI_TABLES
+            if cdm_table not in [common.DEATH, common.FACT_RELATIONSHIP]
         ]
 
         mapping_table_names = [
@@ -178,9 +178,7 @@ class GenerateExtTablesTest(unittest.TestCase):
             mapping_fields = _get_field_names(
                 f'{common.MAPPING_PREFIX}{cdm_table}')
 
-            if cdm_table not in [
-                    common.PERSON, common.DEATH, common.FACT_RELATIONSHIP
-            ]:
+            if cdm_table not in [common.DEATH, common.FACT_RELATIONSHIP]:
                 query = dict()
                 query[cdr_consts.QUERY] = gen_ext.REPLACE_SRC_QUERY.render(
                     project_id=self.project_id,

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_extra_tables_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_extra_tables_test.py
@@ -57,8 +57,7 @@ class RemoveExtraTablesTest(unittest.TestCase):
                         include_vocabulary=True).keys()) | {'_cdr_metadata'} | {
                             f'{table}_ext' for table in cdm_schemas().keys()
                             if has_domain_table_id(table)
-                        } - {'person_src_hpos_ext'} | {'aou_death'
-                                                      } | {'wear_study'}
+                        } | {'person_src_hpos_ext', 'aou_death', 'wear_study'}
         self.assertCountEqual(self.rule_instance.affected_tables, final_tables)
 
         expected_list = [{

--- a/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_extra_tables_test.py
+++ b/tests/unit_tests/data_steward/cdr_cleaner/cleaning_rules/remove_extra_tables_test.py
@@ -57,8 +57,8 @@ class RemoveExtraTablesTest(unittest.TestCase):
                         include_vocabulary=True).keys()) | {'_cdr_metadata'} | {
                             f'{table}_ext' for table in cdm_schemas().keys()
                             if has_domain_table_id(table)
-                        } - {'person_ext'} | {'person_src_hpos_ext'
-                                             } | {'aou_death'} | {'wear_study'}
+                        } - {'person_src_hpos_ext'} | {'aou_death'
+                                                      } | {'wear_study'}
         self.assertCountEqual(self.rule_instance.affected_tables, final_tables)
 
         expected_list = [{


### PR DESCRIPTION
Updates made to ensure person_ext is created, populated, and kept at CT base.