### PR TITLE
[DC-3611] Update QC notebook for Indian Health Services responses generalization CR

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -56,8 +56,8 @@ df = pd.DataFrame(columns=['query', 'result'])
 
 # ## Step 1
 # - Verify the following columns in the deid_cdr Observation table have been set to null:
-# o   value_as_string
-# o   value_source_value
+#   - value_as_string
+#   - value_source_value
 #
 # has been done in first sql for deid, can be skipped here
 #


### PR DESCRIPTION
[DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597): Check if insurance selections are “Indian Health Services” (or a variant).

Even though this option does not overtly identify a participant as AI/AN, it suggests so.  Therefore, these responses are generalized to "Other" at the registered tier de-id stage.
The observation_concept_id's are: 
- `40766241`
- `1585389`
- `43528428`

[DC-3597]: https://precisionmedicineinitiative.atlassian.net/browse/DC-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ