### PR TITLE
[DC-3611] Update QC notebook for Indian Health Services responses generalization CR

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -48,11 +48,12 @@ df = pd.DataFrame(columns=['query', 'result'])
 
 # ## Query 1.0
 #
-# Even though this option does not overtly identify a participant as AI/AN, it suggests so.  Therefore, these responses are generalized to "Other" and later deduplicate the rows that were created as a result
+# Participants answer multiple choice insurance questions on multiple surveys.  One of the available insurance selections is “Indian Health Services” (or a variant).  This option does not necessarily identify a participant as a self identifying AI/AN participant.  Even though this option does not overtly identify a participant as AI/AN, it suggests so.  Hence, we generalize these responses to the category "Other" and subsequently eliminate duplicate rows generated during this process.
 #
-# We need a check for each part: We update both the value_source_concept_id and value_as_concept_id. Therefore, it is essential to include a validation check to confirm the success of the update.
-#
-# See [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597)
+# This check verifies records were suppressed. The observation_concept_id's are:
+# - `40766241`
+# - `1585389`
+# - `43528428`
 
 # +
 query = JINJA_ENV.from_string("""SELECT
@@ -101,14 +102,7 @@ result
 
 # ## Query 1.1
 #
-# [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597): Insurance selections of “Indian Health Services” (or a variant) were duplicated to "Other."  This check verifies records were supressed. 
-#
-# The observation_concept_id's are:
-# - `40766241`
-#
-# - `1585389`
-#
-# - `43528428`
+# Generalized Insurance selections of “Indian Health Services” (or a variant) should not result in duplicate responses. [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597)
 
 # +
 query = JINJA_ENV.from_string("""

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -109,7 +109,7 @@ else:
     df = df.append(
         {
             'query':
-                "Query1.1 observation_id's were found that indicate Indian Health Services or similar",
+                "Query 1.1 observation_id's were found that indicate Indian Health Services or similar",
             'result':
                 'Failure'
         },

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -44,8 +44,8 @@ df = pd.DataFrame(columns=['query', 'result'])
 # test steps:
 #
 # - Verify the following columns in the de-id Observation table have been set to null:
-# o   value_as_string
-# o   value_source_value"
+#   - value_as_string
+#   - value_source_value"
 #  however, this is already done in query 1, no need here anymore
 # - Find person_ids in pre_deid_com_cdr person table who have ethnicity_source_concept_id values AS 1586147  & race_source_concept_id AS ( 1586146 OR 1586142 OR 1586143) , then verify that the output in the deid_base_cdr observation table for that person_id  will results in 2-rows .
 # - Verify that the 2-rows have 2-different value_source_concept_id values in the deid_base_cdr Observation table.
@@ -54,10 +54,10 @@ df = pd.DataFrame(columns=['query', 'result'])
 #
 #
 
-# ## step1
+# ## Step1
 # - Verify the following columns in the deid_cdr Observation table have been set to null:
-# o   value_as_string
-# o   value_source_value
+#   - value_as_string
+#   - value_source_value
 #
 # has been done in first sql for deid, can be skipped here
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -593,19 +593,19 @@ q = query.render(project_id=project_id,
 df1 = execute(client, q)
 if df1.loc[0].sum() == 0:
     df = df.append({
-        'query': 'Query 3.3 date not shifited',
+        'query': 'Query 4.0 date not shifited',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
     df = df.append({
-        'query': 'Query 3.3 date not shifited',
+        'query': 'Query 4.0 date not shifited',
         'result': 'Failure'
     },
                    ignore_index=True)
 df1
 
-# ##  Query 4.0 [DC-1051] Verify that "PPI Drop Duplicates" Rule is excluded COPE responses
+# ##  Query 5.0 [DC-1051] Verify that "PPI Drop Duplicates" Rule is excluded COPE responses
 #
 # steps:
 #
@@ -653,20 +653,20 @@ df1 = execute(client, q)
 if df1.loc[0].sum() == 0:
     df = df.append(
         {
-            'query': 'Query 4.0 PPI Drop Duplicates rule exclusion',
+            'query': 'Query 5.0 PPI Drop Duplicates rule exclusion',
             'result': 'PASS'
         },
         ignore_index=True)
 else:
     df = df.append(
         {
-            'query': 'Query 4.1 PPI Drop Duplicates rule exclusion',
+            'query': 'Query 5.0 PPI Drop Duplicates rule exclusion',
             'result': 'Failure'
         },
         ignore_index=True)
 df1
 
-# # Qury 5.0 equal counts for sex_at_birth columns
+# # Qury 6.0 equal counts for sex_at_birth columns
 #
 # to ensure that there are equal counts FROM both the observation and person_ext tables for the sex_at_birth_* columns that can be added to the RT validation notebook:
 #
@@ -709,14 +709,14 @@ df1 = execute(client, q)
 if df1.loc[0].sum() == 0:
     df = df.append(
         {
-            'query': 'Query 5.0 equal counts for sex_at_birth columns',
+            'query': 'Query 6.0 equal counts for sex_at_birth columns',
             'result': 'PASS'
         },
         ignore_index=True)
 else:
     df = df.append(
         {
-            'query': 'Query 5.0 equal counts for sex_at_birth columns',
+            'query': 'Query 6.0 equal counts for sex_at_birth columns',
             'result': 'Failure'
         },
         ignore_index=True)

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_base_qa_report1.py
@@ -48,7 +48,11 @@ df = pd.DataFrame(columns=['query', 'result'])
 
 # ## Query 1.0
 #
-# We are generalizing Indian Health Services, and then deduplicated the rows that are created as a result.  Therefore we need a check for each part.  As part of generalization, we are updating value_source_concept_id and value_as_concept_id so this check verifies if the update was successful or not.
+# Even though this option does not overtly identify a participant as AI/AN, it suggests so.  Therefore, these responses are generalized to "Other" and later deduplicate the rows that were created as a result
+#
+# We need a check for each part: We update both the value_source_concept_id and value_as_concept_id. Therefore, it is essential to include a validation check to confirm the success of the update.
+#
+# See [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597)
 
 # +
 query = JINJA_ENV.from_string("""SELECT
@@ -97,9 +101,7 @@ result
 
 # ## Query 1.1
 #
-# [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597): Check if insurance selections are “Indian Health Services” (or a variant).
-#
-# Even though this option does not overtly identify a participant as AI/AN, it suggests so.  Therefore, these responses are generalized to "Other" at the registered tier de-id stage.
+# [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597): Insurance selections of “Indian Health Services” (or a variant) were duplicated to "Other."  This check verifies records were supressed. 
 #
 # The observation_concept_id's are:
 # - `40766241`
@@ -134,7 +136,7 @@ if result.empty:
     df = df.append(
         {
             'query':
-                "Query 1.1 No observation_id's indicate Indian Health Services or similar",
+                "Query 1.1 Duplaced observation_id's indicating Indian Health Services or similar were removed",
             'result':
                 'PASS'
         },
@@ -143,7 +145,7 @@ else:
     df = df.append(
         {
             'query':
-                "Query 1.1 observation_id's were found that indicate Indian Health Services or similar",
+                "Query 1.1 observation_id's indicate indian Health Services are present",
             'result':
                 'Failure'
         },


### PR DESCRIPTION
Description:

Participants answer multiple-choice insurance questions on multiple surveys.  One of the available insurance selections is “Indian Health Services” (or a variant).  This option does not necessarily identify a participant as a self-identifying AI/AN participant.  This check ensures this data is indeed removed via this check.

See related ticket [DC-3597](https://precisionmedicineinitiative.atlassian.net/browse/DC-3597)

Note: some partial re-formatting occurred, resulting in 5 superfluous diff's.

[DC-3597]: https://precisionmedicineinitiative.atlassian.net/browse/DC-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ