### PR TITLE
[DC-3631] Update cope_survey to reduce false positive results due to concept domains

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -344,7 +344,7 @@ target_tables
 #table_name="drug_exposure"
 #@column_name="drug_concept_id"
 
-def my_sql(table_name, column_name):
+def target_of(table_name, column_name):
 
     query = JINJA_ENV.from_string("""
 SELECT
@@ -388,23 +388,30 @@ JOIN (
     return r
 
 
-# -
-
+# +
 # use a loop to get table name AND column name AND run sql function
-result = [my_sql(table_name, column_name) for table_name, column_name in zip(target_tables['table_name'], target_tables['column_name'])]
-result
+tables = [t for t in target_tables['table_name']]
+columns = [c for c in target_tables['column_name']]
+
+result_list = []
+for t, c in zip(tables, columns):
+    result_list.append(target_of(t, c))
+
+
+# result = [parameterize_targets(table_name, column_name) for table_name, column_name in zip(target_tables['table_name'], target_tables['column_name'])]
+result_list
 # if Row_count is '0' in "Combined" dataset as well, '0' showing up in this check is not a problem
 
 # +
 # AND then get the result back FROM loop result list
-n=len(target_tables.index)
-res2 = pd.DataFrame(result[0])
+n = len(target_tables.index)
+final_result = pd.DataFrame(result_list[0])
 
-for x in range(1,n):
-  res2=res2.append(result[x])
+for i in range(1, n):
+  final_result = final_result.append(result_list[i])
 
 #res2=res2.sort_values(by='row_counts_failure', ascending=False)
-res2
+final_result
 # -
 
 if res2['Failure_row_counts'].sum()==0:

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -406,6 +406,14 @@ for i in range(1, n):
 
 final_result = final_result.sort_values(by='Failure_row_counts', ascending=False)
 final_result
+# -
+
+if final_result['Failure_row_counts'].sum() == 0:
+    summary = summary.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
+                             ignore_index = True)
+else:
+    summary = summary.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
+                             ignore_index = True)
 
 
 # +

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -44,12 +44,12 @@ client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
 # df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result']) 
+df = pd.DataFrame(columns = ['query', 'result'])
 
 # + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false, "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
 # # 1 done Verify that the COPE Survey Data identified to be suppressed as de-identification action in OBSERVATION table have been removed from the de-id dataset.
 #
-# these concept_ids should be suppressed as shown in the spread sheet 'COPE - All Surveys Privacy Rules', and was temporally saved to curation_sandbox.temp_cope_privacy_rules. Moving forward, we only need to update this table accordingly. 
+# these concept_ids should be suppressed as shown in the spread sheet 'COPE - All Surveys Privacy Rules', and was temporally saved to curation_sandbox.temp_cope_privacy_rules. Moving forward, we only need to update this table accordingly.
 #
 # https://docs.google.com/spreadsheets/d/1UuUVcRdlp2HkBaVdROFsM4ZX_bfffg6ZoEbqj94MlXU/edit#gid=0
 #
@@ -59,51 +59,51 @@ df = pd.DataFrame(columns = ['query', 'result'])
 # these concept_ids should be suppressed
 query = JINJA_ENV.from_string("""
 select OMOP_conceptID,New_Requirement
-from  `{{project_id}}.curation_sandbox.temp_cope_privacy_rules` 
+from  `{{project_id}}.curation_sandbox.temp_cope_privacy_rules`
 where New_Requirement like 'suppress%' or New_Requirement like 'row suppression'
 """)
 q = query.render(project_id=project_id,sandbox=sandbox)
-df1=execute(client, q)
-df1.shape
+result = execute(client, q)
+result.shape
 
-df1
+result
 
 
 query = JINJA_ENV.from_string("""
 SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,
 observation_concept_id,
-COUNT(1) AS n_row_not_pass 
+COUNT(1) AS n_row_not_pass
 FROM `{{project_id}}.{{deid_cdr}}.observation` ob
 JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.observation_source_concept_id=c.concept_id
 WHERE observation_source_concept_id IN
-(select OMOP_conceptID from `{{project_id}}.curation_sandbox.temp_cope_privacy_rules`  
+(select OMOP_conceptID from `{{project_id}}.curation_sandbox.temp_cope_privacy_rules`
 where New_Requirement like 'suppress%' or New_Requirement like 'row suppression')
 OR observation_concept_id IN
-(select OMOP_conceptID from `{{project_id}}.curation_sandbox.temp_cope_privacy_rules`  
+(select OMOP_conceptID from `{{project_id}}.curation_sandbox.temp_cope_privacy_rules`
 where New_Requirement like 'suppress%' or New_Requirement like 'row suppression')
 GROUP BY 1,2,3,4,5
 ORDER BY n_row_not_pass DESC
 """)
 q = query.render(project_id=project_id,sandbox=sandbox,deid_cdr=deid_cdr)
-df1=execute(client, q)
-df1.shape
+result = execute(client, q)
+result.shape
 
-df1
+result
 
 if df1['n_row_not_pass'].sum()==0:
- df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},
+                ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false, "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
 # # 2 done   Verify if a survey version is provided for the COPE survey.
 #
 # [DC-1040]
 #
-# expected results: all the person_id and the questionnaire_response_id has a survey_version_concept_id 
+# expected results: all the person_id and the questionnaire_response_id has a survey_version_concept_id
 # original sql missed something.
 #
 # these should be generalized 2100000002,2100000003,2100000004
@@ -112,9 +112,9 @@ else:
 # -
 
 query = JINJA_ENV.from_string("""
-SELECT survey_version_concept_id, 
+SELECT survey_version_concept_id,
 count (*) row_counts,
-CASE WHEN 
+CASE WHEN
   COUNT(*) > 0
   THEN 0 ELSE 1
 END
@@ -126,7 +126,7 @@ JOIN `{{project_id}}.{{deid_cdr}}.observation` ob on ob.observation_concept_id=c
 LEFT JOIN `{{project_id}}.{{deid_cdr}}.observation_ext` ext USING(observation_id)
 WHERE
  cr.concept_id_1 IN (1333174,1333343,1333207,1333310,1332811,1332812,1332715,1332813,1333101,1332814,1332815,1332816,1332817,1332818)
- AND cr.relationship_id = "PPI parent code of" 
+ AND cr.relationship_id = "PPI parent code of"
  group by 1
  order by row_counts
  """)
@@ -137,15 +137,15 @@ df1.shape
 df1
 
 if df1['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},
+                ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 3 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR tables
-#   
+#
 #   DC-891
 #
 # 756055,4100065,37311061,439676,37311060,45763724
@@ -157,7 +157,7 @@ query = JINJA_ENV.from_string("""
 
 SELECT measurement_concept_id, concept_name,concept_code,vocabulary_id,
 COUNT(1) AS n_row_not_pass,
-CASE WHEN 
+CASE WHEN
   COUNT(*) > 0
   THEN 0 ELSE 1
 END
@@ -177,15 +177,15 @@ df1.shape
 df1
 
 if df1['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},
+                ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 4 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR condition_occurrence
-#   
+#
 #   DC-891
 #
 # 756055,4100065,37311061,439676,37311060,45763724
@@ -197,7 +197,7 @@ query = JINJA_ENV.from_string("""
 
 SELECT condition_concept_id, concept_name,concept_code,vocabulary_id,
 COUNT(1) AS n_row_not_pass,
-CASE WHEN 
+CASE WHEN
   COUNT(*) > 0
   THEN 0 ELSE 1
 END
@@ -217,16 +217,16 @@ df1.shape
 df1
 
 if df1['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},
+                ignore_index = True)
 
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 5 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR observation
-#   
+#
 #   DC-891
 #
 # 756055,4100065,37311061,439676,37311060,45763724
@@ -238,7 +238,7 @@ query = JINJA_ENV.from_string("""
 
 SELECT observation_concept_id, concept_name,concept_code,vocabulary_id,observation_source_concept_id,
 COUNT(1) AS n_row_not_pass,
-CASE WHEN 
+CASE WHEN
   COUNT(*) > 0
   THEN 0 ELSE 1
 END
@@ -258,30 +258,30 @@ df1.shape
 df1
 
 if df1['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},
+                ignore_index = True)
 
 # # 6 done updated Verify these concepts are NOT suppressed in EHR observation
-#   
+#
 # [DC-1747]
 # these concepts 1333015, 	1333023	are not longer suppressed
 #
-# 1332737, [DC-1665] 
+# 1332737, [DC-1665]
 #
 # 1333291
 #
 # 1332904,1333140 should be generalized to 1332737 , # update ?need to rewrite??
 #
-# 1332843 should be generalized. 
+# 1332843 should be generalized.
 
 query = JINJA_ENV.from_string("""
 
 SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,observation_concept_id,
 COUNT(1) AS n_row_pass,
-CASE WHEN 
+CASE WHEN
   COUNT(*) > 0
   THEN 0 ELSE 1
 END
@@ -290,7 +290,7 @@ END
 FROM `{{project_id}}.{{deid_cdr}}.observation` ob
 JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.observation_source_concept_id=c.concept_id
-WHERE observation_source_concept_id IN  (1333015, 1333023, 1332737,1333291,1332904,1333140,1332843) 
+WHERE observation_source_concept_id IN  (1333015, 1333023, 1332737,1333291,1332904,1333140,1332843)
 OR observation_concept_id IN  (1333015, 1333023,1332737,1333291,1332904,1333140,1332843 )
 GROUP BY 1,2,3,4,5
 ORDER BY n_row_pass DESC
@@ -303,19 +303,19 @@ df1.shape
 df1
 
 if (df1['Failure_row_counts'].sum()==0) and (df1[df1['observation_source_concept_id'].isin(['1332904','1333140'])].empty) :
- df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},
+                ignore_index = True)
 
-# # 7 done Vaccine-related concepts as these EHR-submitted COVID concepts are allowed from RT 
+# # 7 done Vaccine-related concepts as these EHR-submitted COVID concepts are allowed from RT
 # DC-2374
-# this query was from DC-1752 
+# this query was from DC-1752
 
 query = JINJA_ENV.from_string("""
 
-DECLARE vocabulary_tables DEFAULT ['vocabulary', 'concept', 'source_to_concept_map', 
+DECLARE vocabulary_tables DEFAULT ['vocabulary', 'concept', 'source_to_concept_map',
                                    'concept_class', 'concept_synonym', 'concept_ancestor',
                                    'concept_relationship', 'relationship', 'drug_strength'];
 SELECT table_name,column_name
@@ -323,8 +323,8 @@ SELECT table_name,column_name
 FROM `{{project_id}}.{{deid_cdr}}.INFORMATION_SCHEMA.COLUMNS` c
 JOIN `{{project_id}}.{{deid_cdr}}.__TABLES__` t
  ON c.table_name = t.table_id
-WHERE 
-     table_name NOT IN UNNEST(vocabulary_tables) and 
+WHERE
+     table_name NOT IN UNNEST(vocabulary_tables) and
   t.row_count > 0
   AND table_name NOT LIKE '\\\_%'
   AND table_name in ('procedure_occurrence','drug_exposure')
@@ -342,23 +342,23 @@ target_tables.shape
 def my_sql(table_name,column_name):
 
     query = JINJA_ENV.from_string("""
-    
-SELECT 
+
+SELECT
 '{{table_name}}' AS table_name,
 '{{column_name}}' AS column_name,
 COUNT(*) AS row_counts,
-CASE WHEN 
+CASE WHEN
   COUNT(*) > 0
   THEN 0 ELSE 1
 END
  AS Failure_row_counts
- 
+
 FROM `{{project_id}}.{{deid_cdr}}.{{table_name}}` c
 JOIN  `{{project_id}}.{{deid_cdr}}.concept` on concept_id={{column_name}}
  WHERE (
         -- done by name and vocab -- -- this alone should be enough, no need for others --
         REGEXP_CONTAINS(concept_name, r'(?i)(COVID)') AND
-        REGEXP_CONTAINS(concept_name, r'(?i)(VAC)') AND 
+        REGEXP_CONTAINS(concept_name, r'(?i)(VAC)') AND
         vocabulary_id not in ('PPI')
     ) OR (
         -- done by code  and vocab --
@@ -388,19 +388,19 @@ result
 n=len(target_tables.index)
 res2 = pd.DataFrame(result[0])
 
-for x in range(1,n):    
+for x in range(1,n):
   res2=res2.append(result[x])
-    
+
 #res2=res2.sort_values(by='row_counts_failure', ascending=False)
 res2
 # -
 
 if res2['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
+                ignore_index = True)
 else:
- df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},  
-                ignore_index = True) 
+ df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
+                ignore_index = True)
 
 
 # # Summary_deid_COPE_survey
@@ -408,7 +408,7 @@ else:
 # +
 def highlight_cells(val):
     color = 'red' if 'Failure' in val else 'white'
-    return f'background-color: {color}' 
+    return f'background-color: {color}'
 
 df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
 # -

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -357,7 +357,7 @@ JOIN (
   SELECT concept_id as concept_id_in_combined
         FROM `{{project_id}}.{{com_cdr}}.{{table_name}}` c
         JOIN `{{project_id}}.{{deid_cdr}}.concept`
-        on concept_id=procedure_concept_id
+        on concept_id={{table_name}}_id
         WHERE (REGEXP_CONTAINS(concept_name, r'(?i)(COVID)') AND
               REGEXP_CONTAINS(concept_name, r'(?i)(VAC)') AND
         vocabulary_id not in ('PPI'))

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -322,8 +322,8 @@ DECLARE vocabulary_tables DEFAULT ['vocabulary', 'concept', 'source_to_concept_m
                                    'concept_relationship', 'relationship', 'drug_strength'];
 SELECT table_name,column_name
 
-FROM `{{project_id}}.{{deid_base_cdr}}.INFORMATION_SCHEMA.COLUMNS` c
-JOIN `{{project_id}}.{{deid_base_cdr}}.__TABLES__` t
+FROM `{{project_id}}.{{deid_cdr}}.INFORMATION_SCHEMA.COLUMNS` c
+JOIN `{{project_id}}.{{deid_cdr}}.__TABLES__` t
  ON c.table_name = t.table_id
 WHERE
      table_name NOT IN UNNEST(vocabulary_tables) and

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -355,7 +355,7 @@ END
 FROM `{{project_id}}.{{deid_cdr}}.{{table_name}}` c
 JOIN (
   SELECT concept_id as concept_id_in_combined
-        FROM `{{project_id}}.{{com_cdr}}.{{table}}` c
+        FROM `{{project_id}}.{{com_cdr}}.{{table_name}}` c
         JOIN `{{project_id}}.{{deid_cdr}}.concept`
         on concept_id=procedure_concept_id
         WHERE (REGEXP_CONTAINS(concept_name, r'(?i)(COVID)') AND
@@ -370,7 +370,7 @@ JOIN (
      )
     AND  domain_id LIKE '%LEFT(c.domain_id, 3)%'
   ) sub
-  on concept_id_in_combined={{table_name}}
+  on concept_id_in_combined={{table_name}}_id
   GROUP BY concept_id_in_combined
 
 """)

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -334,6 +334,10 @@ target_tables.shape
 target_tables
 
 
+# # 8 done foo
+# DC-2374
+# this query was from DC-1752
+
 # +
 #table_name="drug_exposure"
 #@column_name="drug_concept_id"
@@ -408,10 +412,10 @@ final_result
 # -
 
 if final_result['Failure_row_counts'].sum()==0:
-    summary = summary.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
+    summary = summary.append({'query' : 'Query8 foo', 'result' : 'Pass'},
                    ignore_index = True)
 else:
-    summary = summary.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
+    summary = summary.append({'query' : 'Query8 foo' , 'result' : 'Failure'},
                    ignore_index = True)
 
 
@@ -481,5 +485,3 @@ def highlight_cells(val):
 
 summary.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
 # -
-
-

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -33,7 +33,6 @@ project_id = ""  # The project to examine
 com_cdr = ""  # The comibend dataset
 deid_cdr = ""  # the deid dataset
 sandbox = "" # sandbox dataset
-pipeline = "" # the pipeline tables
 run_as = ""  # The account used to run checks
 
 
@@ -353,10 +352,10 @@ CASE WHEN
   THEN 0 ELSE 1
 END
  AS Failure_row_counts
-FROM `{{project_id}}.{{deid_cdr}}.procedure_occurrence` c
+FROM `{{project_id}}.{{deid_cdr}}.{{table_name}}` c
 JOIN (
   SELECT concept_id as concept_id_in_combined
-        FROM `{{project_id}}.{{com_cdr}}.procedure_occurrence` c
+        FROM `{{project_id}}.{{com_cdr}}.{{table}}` c
         JOIN `{{project_id}}.{{deid_cdr}}.concept`
         on concept_id=procedure_concept_id
         WHERE (REGEXP_CONTAINS(concept_name, r'(?i)(COVID)') AND
@@ -371,7 +370,7 @@ JOIN (
      )
     AND  domain_id LIKE '%LEFT(c.domain_id, 3)%'
   ) sub
-  on concept_id_in_combined=procedure_concept_id
+  on concept_id_in_combined={{table_name}}
   GROUP BY concept_id_in_combined
 
 """)

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -392,8 +392,6 @@ columns = [c for c in target_tables['column_name']]
 result_list = []
 for t, c in zip(tables, columns):
     result_list.append(target_of(t, c))
-# -
-
 result_list
 
 # +

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -44,8 +44,8 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
-# df will have a summary in the end
-df = pd.DataFrame(columns = ['query', 'result'])
+# a summary of results is at the end
+summary = pd.DataFrame(columns = ['query', 'result'])
 
 # + [markdown] papermill={"duration": 0.02327, "end_time": "2021-02-02T22:30:32.708257", "exception": false, "start_time": "2021-02-02T22:30:32.684987", "status": "completed"} tags=[]
 # # 1 done Verify that the COPE Survey Data identified to be suppressed as de-identification action in OBSERVATION table have been removed from the de-id dataset.
@@ -93,11 +93,11 @@ result.shape
 result
 
 if result['n_row_not_pass'].sum()==0:
-    df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},
+                             ignore_index = True)
 else:
-    df = df.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},
+                             ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false, "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
 # # 2 done   Verify if a survey version is provided for the COPE survey.
@@ -138,11 +138,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
-    df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},
+                             ignore_index = True)
 else:
-    df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},
+                             ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 3 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR tables
@@ -155,7 +155,6 @@ else:
 # -
 
 query = JINJA_ENV.from_string("""
-
 SELECT measurement_concept_id, concept_name,concept_code,vocabulary_id,
 COUNT(1) AS n_row_not_pass,
 CASE WHEN
@@ -178,11 +177,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
-    df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},
+                             ignore_index = True)
 else:
-    df = df.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},
+                             ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 4 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR condition_occurrence
@@ -216,11 +215,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
-    df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},
-                ignore_index = True)
+    summary = summary.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},
+                             ignore_index = True)
 else:
-    df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},
-                ignore_index = True)
+    summary = summary.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},
+                             ignore_index = True)
 
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
@@ -256,11 +255,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
-    df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},
+                             ignore_index = True)
 else:
-    df = df.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},
+                             ignore_index = True)
 
 # # 6 done updated Verify these concepts are NOT suppressed in EHR observation
 #
@@ -301,11 +300,11 @@ result.shape
 result
 
 if (result['Failure_row_counts'].sum()==0) and (result[result['observation_source_concept_id'].isin(['1332904','1333140'])].empty) :
-    df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},
+                             ignore_index = True)
 else:
-    df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},
-                   ignore_index = True)
+    summary = summary.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},
+                             ignore_index = True)
 
 # # 7 done Vaccine-related concepts as these EHR-submitted COVID concepts are allowed from RT
 # DC-2374
@@ -409,10 +408,10 @@ final_result
 # -
 
 if final_result['Failure_row_counts'].sum()==0:
-    df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
+    summary = summary.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
                    ignore_index = True)
 else:
-    df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
+    summary = summary.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
                    ignore_index = True)
 
 
@@ -480,7 +479,7 @@ def highlight_cells(val):
     color = 'red' if 'Failure' in val else 'white'
     return f'background-color: {color}'
 
-df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+summary.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
 # -
 
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -93,11 +93,11 @@ result.shape
 result
 
 if result['n_row_not_pass'].sum()==0:
- df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},
+                   ignore_index = True)
 else:
- df = df.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query1 No COPE in deid_observation table' , 'result' : 'Failure'},
+                   ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false, "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
 # # 2 done   Verify if a survey version is provided for the COPE survey.
@@ -138,11 +138,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},
+                   ignore_index = True)
 else:
- df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Failure'},
+                   ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 3 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR tables
@@ -178,11 +178,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},
+                   ignore_index = True)
 else:
- df = df.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query3 No COPE in deid_measurement table' , 'result' : 'Failure'},
+                   ignore_index = True)
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 4 done no change Verify that all structured concepts related  to COVID are NOT suppressed in EHR condition_occurrence
@@ -195,7 +195,6 @@ else:
 # -
 
 query = JINJA_ENV.from_string("""
-
 SELECT condition_concept_id, concept_name,concept_code,vocabulary_id,
 COUNT(1) AS n_row_not_pass,
 CASE WHEN
@@ -209,7 +208,6 @@ ON ob.condition_concept_id=c.concept_id
 WHERE condition_concept_id IN  (4100065, 37311061, 439676)
 GROUP BY 1,2,3,4
 ORDER BY n_row_not_pass DESC
-
  """)
 q = query.render(project_id=project_id,deid_cdr=deid_cdr)
 result = execute(client, q)
@@ -218,10 +216,10 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},
+    df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},
                 ignore_index = True)
 else:
- df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},
+    df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table' , 'result' : 'Failure'},
                 ignore_index = True)
 
 
@@ -236,7 +234,6 @@ else:
 # -
 
 query = JINJA_ENV.from_string("""
-
 SELECT observation_concept_id, concept_name,concept_code,vocabulary_id,observation_source_concept_id,
 COUNT(1) AS n_row_not_pass,
 CASE WHEN
@@ -259,11 +256,11 @@ result.shape
 result
 
 if result['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},
+                   ignore_index = True)
 else:
- df = df.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query5 COVID concepts suppression in observation table' , 'result' : 'Failure'},
+                   ignore_index = True)
 
 # # 6 done updated Verify these concepts are NOT suppressed in EHR observation
 #
@@ -279,7 +276,6 @@ else:
 # 1332843 should be generalized.
 
 query = JINJA_ENV.from_string("""
-
 SELECT observation_source_concept_id, concept_name,concept_code,vocabulary_id,observation_concept_id,
 COUNT(1) AS n_row_pass,
 CASE WHEN
@@ -305,23 +301,22 @@ result.shape
 result
 
 if (result['Failure_row_counts'].sum()==0) and (result[result['observation_source_concept_id'].isin(['1332904','1333140'])].empty) :
- df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},
+                   ignore_index = True)
 else:
- df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table' , 'result' : 'Failure'},
+                   ignore_index = True)
 
 # # 7 done Vaccine-related concepts as these EHR-submitted COVID concepts are allowed from RT
 # DC-2374
 # this query was from DC-1752
 
 query = JINJA_ENV.from_string("""
-
 DECLARE vocabulary_tables DEFAULT ['vocabulary', 'concept', 'source_to_concept_map',
                                    'concept_class', 'concept_synonym', 'concept_ancestor',
                                    'concept_relationship', 'relationship', 'drug_strength'];
-SELECT table_name,column_name
 
+SELECT table_name,column_name
 FROM `{{project_id}}.{{deid_cdr}}.INFORMATION_SCHEMA.COLUMNS` c
 JOIN `{{project_id}}.{{deid_cdr}}.__TABLES__` t
  ON c.table_name = t.table_id
@@ -414,12 +409,11 @@ final_result
 # -
 
 if final_result['Failure_row_counts'].sum()==0:
- df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
-                ignore_index = True)
+    df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables', 'result' : 'Pass'},
+                   ignore_index = True)
 else:
- df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
-                ignore_index = True)
-
+    df = df.append({'query' : 'Query7 COVID Vaccine-related concepts NOT suppressed in EHR tables' , 'result' : 'Failure'},
+                   ignore_index = True)
 
 
 def target_of(table_name, column_name):

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -32,7 +32,7 @@ pd.options.display.max_rows = 120
 project_id = ""  # The project to examine
 com_cdr = ""  # The comibend dataset
 deid_cdr = ""  # the deid dataset
-sandbox = "" # sandbox dataset
+sandbox = "" # curation_sandbox dataset, not one related to deid_stage
 run_as = ""  # The account used to run checks
 
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -31,7 +31,8 @@ pd.options.display.max_rows = 120
 # Parameters
 project_id = ""  # The project to examine
 com_cdr = ""  # The comibend dataset
-deid_base_cdr = ""  # the deid dataset
+deid_cdr = ""  # the deid dataset
+sandbox = "" # sandbox dataset
 pipeline = ""  # the pipeline tables
 run_as = ""  # The account used to run checks
 
@@ -91,7 +92,7 @@ result.shape
 
 result
 
-if df1['n_row_not_pass'].sum()==0:
+if result['n_row_not_pass'].sum()==0:
  df = df.append({'query' : 'Query1 No COPE in deid_observation table', 'result' : 'Pass'},
                 ignore_index = True)
 else:
@@ -131,12 +132,12 @@ WHERE
  order by row_counts
  """)
 q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
-df1.shape
+result = execute(client, q)
+result.shape
 
-df1
+result
 
-if df1['Failure_row_counts'].sum()==0:
+if result['Failure_row_counts'].sum()==0:
  df = df.append({'query' : 'Query2 survey version provided', 'result' : 'Pass'},
                 ignore_index = True)
 else:
@@ -171,12 +172,12 @@ ORDER BY n_row_not_pass DESC
 
  """)
 q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
-df1.shape
+result = execute(client, q)
+result.shape
 
-df1
+result
 
-if df1['Failure_row_counts'].sum()==0:
+if result['Failure_row_counts'].sum()==0:
  df = df.append({'query' : 'Query3 No COPE in deid_measurement table', 'result' : 'Pass'},
                 ignore_index = True)
 else:
@@ -211,12 +212,12 @@ ORDER BY n_row_not_pass DESC
 
  """)
 q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
-df1.shape
+result = execute(client, q)
+result.shape
 
-df1
+result
 
-if df1['Failure_row_counts'].sum()==0:
+if result['Failure_row_counts'].sum()==0:
  df = df.append({'query' : 'Query4 COVID concepts suppression in deid_observation table', 'result' : 'Pass'},
                 ignore_index = True)
 else:
@@ -251,13 +252,13 @@ GROUP BY 1,2,3,4,5
 ORDER BY n_row_not_pass DESC
 """)
 q = query.render(project_id=project_id,deid_cdr=deid_cdr)
-df1=execute(client, q)
-df1.shape
+result = execute(client, q)
+result.shape
 
 
-df1
+result
 
-if df1['Failure_row_counts'].sum()==0:
+if result['Failure_row_counts'].sum()==0:
  df = df.append({'query' : 'Query5 COVID concepts suppression in observation table', 'result' : 'Pass'},
                 ignore_index = True)
 else:
@@ -287,8 +288,8 @@ CASE WHEN
 END
  AS Failure_row_counts
 
-FROM `{{project_id}}.{{deid_base_cdr}}.observation` ob
-JOIN `{{project_id}}.{{deid_base_cdr}}.concept` c
+FROM `{{project_id}}.{{deid_cdr}}.observation` ob
+JOIN `{{project_id}}.{{deid_cdr}}.concept` c
 ON ob.observation_source_concept_id=c.concept_id
 WHERE observation_source_concept_id IN  (1333015, 1333023, 1332737,1333291,1332904,1333140,1332843)
 OR observation_concept_id IN  (1333015, 1333023,1332737,1333291,1332904,1333140,1332843 )
@@ -296,14 +297,14 @@ GROUP BY 1,2,3,4,5
 ORDER BY n_row_pass DESC
 """)
 q = query.render(project_id=project_id,
-                 deid_base_cdr=deid_base_cdr)
-df1=execute(client, q)
-df1.shape
+                 deid_cdr=deid_cdr)
+result = execute(client, q)
+result.shape
 
 
-df1
+result
 
-if (df1['Failure_row_counts'].sum()==0) and (df1[df1['observation_source_concept_id'].isin(['1332904','1333140'])].empty) :
+if (result['Failure_row_counts'].sum()==0) and (result[result['observation_source_concept_id'].isin(['1332904','1333140'])].empty) :
  df = df.append({'query' : 'Query6 The concepts are not suppressed in observation table', 'result' : 'Pass'},
                 ignore_index = True)
 else:
@@ -332,7 +333,7 @@ WHERE
   AND column_name in ('procedure_concept_id','procedure_source_concept_id','drug_concept_id','drug_source_concept_id')
 """)
 q = query.render(project_id=project_id,
-                 deid_base_cdr=deid_base_cdr)
+                 deid_cdr=deid_cdr)
 target_tables = execute(client, q)
 target_tables.shape
 
@@ -374,9 +375,12 @@ AND  domain_id LIKE '%LEFT(c.domain_id, 3)%'
   GROUP BY concept_id_in_combined
 
 """)
-    q = query.render(project_id=project_id,deid_cdr=deid_cdr,table_name=table_name,column_name=column_name)
-    df11=execute(client, q)
-    return df11
+    q = query.render(project_id=project_id,
+                     deid_cdr=deid_cdr,
+                     table_name=table_name,
+                     column_name=column_name)
+    r = execute(client, q)
+    return r
 
 
 # -

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -379,7 +379,7 @@ JOIN  `{{project_id}}.{{deid_cdr}}.concept` on concept_id={{column_name}}
 # -
 
 # use a loop to get table name AND column name AND run sql function
-result = [my_sql (table_name, column_name) for table_name, column_name in zip(target_tables['table_name'], target_tables['column_name'])]
+result = [my_sql(table_name, column_name) for table_name, column_name in zip(target_tables['table_name'], target_tables['column_name'])]
 result
 # if Row_count is '0' in "Combined" dataset as well, '0' showing up in this check is not a problem
 

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_qa_report7_cope_survey.py
@@ -29,11 +29,11 @@ pd.options.display.max_rows = 120
 
 # + papermill={"duration": 0.023643, "end_time": "2021-02-02T22:30:31.880820", "exception": false, "start_time": "2021-02-02T22:30:31.857177", "status": "completed"} tags=["parameters"]
 # Parameters
-project_id = ""
-com_cdr = ""
-deid_cdr = ""
-sandbox=""
-run_as=""
+project_id = ""  # The project to examine
+com_cdr = ""  # The comibend dataset
+deid_base_cdr = ""  # the deid dataset
+pipeline = ""  # the pipeline tables
+run_as = ""  # The account used to run checks
 
 
 # +


### PR DESCRIPTION
**Background:**
"The issue with the `procedure_occurence` covid vaccine concepts failing due to 'being suppressed in RT' is caused by the vocabulary `domain_id`'s for the associated Standard concepts which populate `procedure_concept_id` (failing column) being 'Drug' in the combined stage. These records are not actually suppressed they get moved to the Drug table by a combined CR."

**This PR:**
Updated to look for concepts that are being suppressed in the deid stage. 
- If they existed at combined stage, they should still be in deid.
- If they did not exist in combined stage, they should not be expected to exist in died.

See Jira issue [DC-3631](https://precisionmedicineinitiative.atlassian.net/browse/DC-3631) for the complete description and scope
See Jira issue [DC-3625](https://precisionmedicineinitiative.atlassian.net/browse/DC-3625) for the investigation.

[DC-3631]: https://precisionmedicineinitiative.atlassian.net/browse/DC-3631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-3625]: https://precisionmedicineinitiative.atlassian.net/browse/DC-3625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


**Helpful:**  Changes occur around lines 312 / 309 lower