### PR TITLE
[DC-3667] Use Standard concepts and classification for notebook check

### DIFF
--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -383,7 +383,7 @@ p_results = utils.bq.query(p_query)
 p_results
 
 p_cleaning_rule_failure = p_results.loc[(p_results['post_cr_standard_concept']
-                                         != 'S')]
+                                         not in ('S', 'C'))]
 
 p_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -314,7 +314,7 @@ v_results = utils.bq.query(v_query)
 v_results
 
 v_cleaning_rule_failure = v_results.loc[(v_results['post_cr_standard_concept']
-                                         != 'S')]
+                                         not in ('S', 'C')]
 
 v_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -29,7 +29,7 @@
 # - The original concept was non-standard
 # - The original concept was standard and subsequently converted to a nonstandard concept
 #
-# #### This notebook, however, can be modified to look for instances where non-standard concepts failed to map to standard concepts by adding the 'WHERE c1.standard_concept NOT IN ('S')' to the queries.
+# #### This notebook checks where non-standard concepts failed to map to standard concepts using c1.standard_concept NOT IN ('S', 'C')'.
 #
 #
 # #### This notebook also does not exclude instances where the concept_id = 0.

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -172,7 +172,7 @@ de_results
 # #### Check instances where the final concept is not standard
 
 de_cleaning_rule_failure = de_results.loc[(
-    de_results['post_cr_standard_concept'] != 'S')]
+    de_results['post_cr_standard_concept'] not in ('S', 'C'))]
 
 de_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -53,7 +53,7 @@ Combined Dataset: {combined}
 co_query = """
 SELECT
 DISTINCT
-co.condition_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn, 
+co.condition_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn,
 co_combined.condition_concept_id as post_cr_concept_id, c2.standard_concept as post_cr_standard_concept, c2.concept_name as post_cr_cn,
 (LOWER(c2.domain_id) LIKE '%condition%') as post_cr_domain_correct,
 COUNT(*) as count, COUNT(DISTINCT mco.src_hpo_id) as num_sites_w_change
@@ -127,7 +127,7 @@ print(
 de_query = """
 SELECT
 DISTINCT
-de.drug_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn, 
+de.drug_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn,
 de_combined.drug_concept_id as post_cr_concept_id, c2.standard_concept as post_cr_standard_concept, c2.concept_name as post_cr_cn,
 (LOWER(c2.domain_id) LIKE '%drug%') as post_cr_domain_correct,
 COUNT(*) as count, COUNT(DISTINCT mde.src_hpo_id) as num_sites_w_change
@@ -202,7 +202,7 @@ print(
 m_query = """
 SELECT
 DISTINCT
-m.measurement_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn, 
+m.measurement_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn,
 m_combined.measurement_concept_id as post_cr_concept_id, c2.standard_concept as post_cr_standard_concept, c2.concept_name as post_cr_cn,
 (LOWER(c2.domain_id) LIKE '%measurement%') as post_cr_domain_correct,
 COUNT(*) as count, COUNT(DISTINCT mm.src_hpo_id) as num_sites_w_change
@@ -272,7 +272,7 @@ print(
 v_query = """
 SELECT
 DISTINCT
-v.visit_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn, 
+v.visit_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn,
 v_combined.visit_concept_id as post_cr_concept_id, c2.standard_concept as post_cr_standard_concept, c2.concept_name as post_cr_cn,
 (LOWER(c2.domain_id) LIKE '%visit%') as post_cr_domain_correct,
 COUNT(*) as count, COUNT(DISTINCT mv.src_hpo_id) as num_sites_w_change
@@ -342,7 +342,7 @@ print(
 p_query = """
 SELECT
 DISTINCT
-p.procedure_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn, 
+p.procedure_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn,
 p_combined.procedure_concept_id as post_cr_concept_id, c2.standard_concept as post_cr_standard_concept, c2.concept_name as post_cr_cn,
 (LOWER(c2.domain_id) LIKE '%procedure%') as post_cr_domain_correct,
 COUNT(*) as count, COUNT(DISTINCT mp.src_hpo_id) as num_sites_w_change
@@ -411,7 +411,7 @@ print(
 o_query = """
 SELECT
 DISTINCT
-o.observation_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn, 
+o.observation_concept_id as pre_cr_concept_id, c1.standard_concept as pre_cr_standard_concept, c1.concept_name as pre_cr_cn,
 o_combined.observation_concept_id as post_cr_concept_id, c2.standard_concept as post_cr_standard_concept, c2.concept_name as post_cr_cn,
 (LOWER(c2.domain_id) LIKE '%observation%') as post_cr_domain_correct,
 COUNT(*) as count, COUNT(DISTINCT mo.src_hpo_id) as num_sites_w_change

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -244,7 +244,7 @@ m_results = utils.bq.query(m_query)
 m_results
 
 m_cleaning_rule_failure = m_results.loc[(m_results['post_cr_standard_concept']
-                                         != 'S')]
+                                         not in ('S', 'C'))]
 
 m_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -28,7 +28,8 @@
 #
 # - The original concept was non-standard
 # - The original concept was standard and subsequently converted to a nonstandard concept
-#
+
+##### DC-3667:
 # #### This notebook checks where non-standard concepts failed to map to standard concepts using c1.standard_concept NOT IN ('S', 'C')'.
 #
 #

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -453,7 +453,7 @@ o_results = utils.bq.query(o_query)
 o_results
 
 o_cleaning_rule_failure = o_results.loc[(o_results['post_cr_standard_concept']
-                                         not in ('S', 'C')]
+                                         not in ('S', 'C'))]
 
 o_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -29,7 +29,7 @@
 # - The original concept was non-standard
 # - The original concept was standard and subsequently converted to a nonstandard concept
 
-##### DC-3667:
+# ##### DC-3667:
 # #### This notebook checks where non-standard concepts failed to map to standard concepts using c1.standard_concept NOT IN ('S', 'C')'.
 #
 #

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -23,17 +23,17 @@
 # - domain_id of the concept matches the domain_id
 #
 # Concept IDs should be replaced if it does not meet all of the three criteria are not met.
+#
+# #### DC-3667:
+# This notebook checks where non-standard concepts failed to map to standard concepts using c1.standard_concept NOT IN ('S', 'C')'.
+#
+# This notebook also does not exclude instances where the concept_id = 0.
 
 # ## NOTE: This notebook currently looks to see if there are ANY instances in which the ultimate 'concept_id' for a table in the combined data set is either non-standard or in the incorrect domain. This includes instances where:
 #
 # - The original concept was non-standard
 # - The original concept was standard and subsequently converted to a nonstandard concept
 
-# ##### DC-3667:
-# #### This notebook checks where non-standard concepts failed to map to standard concepts using c1.standard_concept NOT IN ('S', 'C')'.
-#
-#
-# #### This notebook also does not exclude instances where the concept_id = 0.
 import bq_utils
 import utils.bq
 from notebooks import parameters

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -315,7 +315,7 @@ v_results = utils.bq.query(v_query)
 v_results
 
 v_cleaning_rule_failure = v_results.loc[(v_results['post_cr_standard_concept']
-                                         not in ('S', 'C')]
+                                         not in ('S', 'C'))]
 
 v_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -452,7 +452,7 @@ o_results = utils.bq.query(o_query)
 o_results
 
 o_cleaning_rule_failure = o_results.loc[(o_results['post_cr_standard_concept']
-                                         != 'S')]
+                                         not in ('S', 'C')]
 
 o_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
+++ b/data_steward/analytics/cdr_ops/ad_hoc_analyses/standard_concepts_cdr_389.py
@@ -96,7 +96,7 @@ co_results
 # #### Check instances where the final concept is not standard
 
 co_cleaning_rule_failure = co_results.loc[(
-    co_results['post_cr_standard_concept'] != 'S')]
+    co_results['post_cr_standard_concept'] not in ('S', 'C'))]
 
 co_cleaning_rule_failure
 

--- a/data_steward/analytics/cdr_ops/controlled_tier_qc/check_controlled_tier_part2.py
+++ b/data_steward/analytics/cdr_ops/controlled_tier_qc/check_controlled_tier_part2.py
@@ -478,7 +478,7 @@ else:
 #
 # If this check fails investigate. Ensure all participants lacking basics data have been dropped.
 #
-# Note: Since the CR `drop_participants_without_any_basics` occurs in the RDR cleaning stage it is possible that a small number of participants have their Basics data dropped between the rdr and CT pipeline stages. At this time(V8), participants without Basics data in the CT dataset are allowed in the CDR if they had Basics data in the rdr stage. 
+# Note: Since the CR `drop_participants_without_any_basics` occurs in the RDR cleaning stage it is possible that a small number of participants have their Basics data dropped between the rdr and CT pipeline stages. At this time(V8), participants without Basics data in the CT dataset are allowed in the CDR if they had Basics data in the rdr stage.
 
 # +
 query = JINJA_ENV.from_string("""
@@ -690,7 +690,7 @@ WITH
         AND REGEXP_CONTAINS(table_name, r'(?i)(visit_occurrence)')
         AND REGEXP_CONTAINS(column_name, r'(?i)(visit_occurrence)')
     AND NOT REGEXP_CONTAINS(column_name, r'(?i)(preceding)') )
-    
+
     OR (
     (table_name IN (
       SELECT
@@ -844,7 +844,7 @@ WITH
         AND REGEXP_CONTAINS(table_name, r'(?i)(visit_occurrence)')
         AND REGEXP_CONTAINS(column_name, r'(?i)(visit_occurrence)')
     AND NOT REGEXP_CONTAINS(column_name, r'(?i)(preceding)') )
-    
+
     OR (
           (table_name IN (
       SELECT
@@ -854,7 +854,7 @@ WITH
         AND REGEXP_CONTAINS(table_name, r'(?i)(visit_detail)')
         AND REGEXP_CONTAINS(column_name, r'(?i)(visit_detail_id)')
     AND NOT REGEXP_CONTAINS(column_name, r'(?i)(preceding)') )
-    
+
     OR (
           (table_name IN (
       SELECT
@@ -1015,7 +1015,7 @@ END
  AS Failure_primary_key_match
 
 FROM `{{project_id}}.{{ct_dataset}}.concept` c
-JOIN `{{project_id}}.{{ct_dataset}}.{{table_name}}`  ON (concept_id={{column_name}})
+JOIN `{{project_id}}.{{ct_dataset}}.{{table_name}}` ON (concept_id={{column_name}})
 WHERE  standard_concept not in ('S', 'C')
 AND {{column_name}} !=0
 """)


### PR DESCRIPTION
Update the check for non-standard concepts to ignore 'C' as well using `standard_concept not in ('S', 'C')` instead of `standard_concept != 'S'`

[Ticket](https://precisionmedicineinitiative.atlassian.net/browse/DC-3667)
[Investigation](https://precisionmedicineinitiative.atlassian.net/browse/DC-3506)