### PR TITLE
[DC-3673] Remove notebook check regarding cause_source_concept_id for aou_death

### DIFF
--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
@@ -36,8 +36,8 @@ impersonation_creds = auth.get_impersonation_credentials(
 client = BigQueryClient(project_id, credentials=impersonation_creds)
 # -
 
-# df will have a summary in the end
-df = pd.DataFrame(columns=['query', 'result'])
+# summary will have a summary in the end
+summary = pd.DataFrame(columns=['query', 'result'])
 
 # ## QA queries on new CDR_deid_clean drop rows with 0 OR null
 
@@ -58,13 +58,13 @@ FROM `{{project_id}}.{{deid_clean_cdr}}.observation`
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query1 observation',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query1 observation',
         'result': 'Failure'
     },
@@ -91,13 +91,13 @@ OR ( condition_source_concept_id IS NULL AND condition_concept_id IS NULL)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query2 condition',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query2 condition',
         'result': 'Failure'
     },
@@ -119,13 +119,13 @@ FROM `{{project_id}}.{{deid_clean_cdr}}.procedure_occurrence`
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query3 procedure',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query3 procedure',
         'result': 'Failure'
     },
@@ -148,13 +148,13 @@ FROM `{{project_id}}.{{deid_clean_cdr}}.visit_occurrence`
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query4 visit',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query4 visit',
         'result': 'Failure'
     },
@@ -178,13 +178,13 @@ FROM `{{project_id}}.{{deid_clean_cdr}}.drug_exposure`
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query5 drug_exposure',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query5 drug_exposure',
         'result': 'Failure'
     },
@@ -207,13 +207,13 @@ FROM `{{project_id}}.{{deid_clean_cdr}}.device_exposure`
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query6 device',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query6 device',
         'result': 'Failure'
     },
@@ -236,13 +236,13 @@ FROM`{{project_id}}.{{deid_clean_cdr}}.measurement`
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 if result.loc[0].sum() == 0:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query7 measurement',
         'result': 'PASS'
     },
                    ignore_index=True)
 else:
-    df = df.append({
+    summary = summary.append({
         'query': 'Query7, measurement',
         'result': 'Failure'
     },
@@ -271,14 +271,14 @@ q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
 result = execute(client, q)
 
 if result.loc[0].sum() == 0:
-    df = df.append(
+    summary = summary.append(
         {
             'query': 'Query 8, State_of_Residence in person_ext',
             'result': ' Failure'
         },
         ignore_index=True)
 else:
-    df = df.append(
+    summary = summary.append(
         {
             'query': 'Query 8, State_of_Residence in person_ext',
             'result': 'PASS'
@@ -296,4 +296,4 @@ def highlight_cells(val):
     return f'background-color: {color}'
 
 
-df.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})
+summary.style.applymap(highlight_cells).set_properties(**{'text-align': 'left'})

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
@@ -161,6 +161,7 @@ else:
                    ignore_index=True)
 df1.T
 
+
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 5 Verify that in drug_exposure table if drug_exposure_source_concept_id AND the drug_exposure_concept_id both of those fields are null OR zero, the row should be removed.
 
@@ -242,55 +243,14 @@ if df1.loc[0].sum() == 0:
                    ignore_index=True)
 else:
     df = df.append({
-        'query': 'Query7 measurement',
+        'query': 'Query7, measurement',
         'result': 'Failure'
     },
                    ignore_index=True)
 df1.T
 # -
 
-# # 8 Verify that in aou_death table both cause_source_concept_id and cause_concept_id are null OR zero.
-#
-#
-
-# +
-# how to COUNT NaN
-# in old cdr_clean , the value is NaN; in contrast, the value is empty in new cdr_clean
-query = JINJA_ENV.from_string("""
-
-SELECT
-SUM(CASE WHEN cause_source_concept_id != 0 AND cause_concept_id != 0 THEN 1 ELSE 0 END) AS n_cause_source_concept_id_both_not_0,
-SUM(CASE WHEN cause_source_concept_id IS NOT NULL AND cause_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_source_concept_id_both_not_null,
-SUM(CASE WHEN cause_source_concept_id != 0 AND cause_concept_id IS NOT NULL THEN 1 ELSE 0 END) AS n_cause_source_concept_id_either_0,
-SUM(CASE WHEN cause_source_concept_id IS NOT NULL AND cause_concept_id !=0 THEN 1 ELSE 0 END) AS n_cause_source_concept_id_either_null
-FROM `{{project_id}}.{{deid_clean_cdr}}.aou_death`
-
-""")
-q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
-    df = df.append(
-        {
-            'query':
-                'Query8 cause_source_concept_id/cause_concept_id is null in aou_death table',
-            'result':
-                'PASS'
-        },
-        ignore_index=True)
-else:
-    df = df.append(
-        {
-            'query':
-                'Query8 cause_source_concept_id/cause_concept_id is null in aou_death table',
-            'result':
-                'Failure'
-        },
-        ignore_index=True)
-
-df1.T
-# -
-
-# # 9  check State_of_Residence fields in the person_ext table in deid_clean
+# # 8  check State_of_Residence fields in the person_ext table in deid_clean
 #
 # Generalization Rules for reference
 #
@@ -308,24 +268,23 @@ ON  d.person_id = e.person_id
 WHERE state_of_residence_concept_id IS NOT NULL OR state_of_residence_source_value IS NOT NULL
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
+result = execute(client, q)
 
-if df1.loc[0].sum() == 0:
+if result.loc[0].sum() == 0:
     df = df.append(
         {
-            'query': 'Query9 State_of_Residence in person_ext',
+            'query': 'Query 8, State_of_Residence in person_ext',
             'result': ' Failure'
         },
         ignore_index=True)
 else:
     df = df.append(
         {
-            'query': 'Query9 State_of_Residence in person_ext',
+            'query': 'Query 8, State_of_Residence in person_ext',
             'result': 'PASS'
         },
         ignore_index=True)
-df1
-
+result
 # -
 
 # # Summary_row_ICD_suppression

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
@@ -56,8 +56,8 @@ SUM(CASE WHEN observation_source_concept_id IS NULL AND observation_concept_id=0
 FROM `{{project_id}}.{{deid_clean_cdr}}.observation`
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query1 observation',
         'result': 'PASS'
@@ -69,7 +69,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 
 # + [markdown] papermill={"duration": 0.023633, "end_time": "2021-02-02T22:30:36.860798", "exception": false, "start_time": "2021-02-02T22:30:36.837165", "status": "completed"} tags=[]
 # # 2   Verify that in condition_occurrence if condition_occurrence_source_concept_id AND the condition_occurrence_concept_id both of those fields are null OR zero, the row should be removed.
@@ -89,8 +89,8 @@ WHERE (condition_source_concept_id = 0 AND  condition_concept_id=0)
 OR ( condition_source_concept_id IS NULL AND condition_concept_id IS NULL)
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query2 condition',
         'result': 'PASS'
@@ -102,7 +102,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 
 # # 3  Verify that in procedure_occurrence table if procedure_occurrence_source_concept_id AND the procedure_occurrence_concept_id both of those fields are null OR zero, the row should be removed.
 
@@ -117,8 +117,8 @@ SUM(CASE WHEN procedure_source_concept_id IS NULL AND procedure_concept_id=0 THE
 FROM `{{project_id}}.{{deid_clean_cdr}}.procedure_occurrence`
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query3 procedure',
         'result': 'PASS'
@@ -130,7 +130,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 4 Verify that in visit_occurrence table if visit_occurrence_source_concept_id AND the visit_occurrence_concept_id both of those fields are null OR zero, the row should be removed.
@@ -146,8 +146,8 @@ SUM(CASE WHEN visit_source_concept_id IS NULL AND visit_concept_id =0 THEN 1 ELS
 FROM `{{project_id}}.{{deid_clean_cdr}}.visit_occurrence`
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query4 visit',
         'result': 'PASS'
@@ -159,7 +159,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
@@ -176,8 +176,8 @@ SUM(CASE WHEN drug_source_concept_id IS NULL AND drug_concept_id =0 THEN 1 ELSE 
 FROM `{{project_id}}.{{deid_clean_cdr}}.drug_exposure`
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query5 drug_exposure',
         'result': 'PASS'
@@ -189,7 +189,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 6 Verify that in device_exposure table if device_exposure_source_concept_id AND the device_exposure_concept_id both of those fields are null OR zero, the row should be removed.
@@ -205,8 +205,8 @@ SUM(CASE WHEN device_source_concept_id IS NULL AND device_concept_id =0 THEN 1 E
 FROM `{{project_id}}.{{deid_clean_cdr}}.device_exposure`
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query6 device',
         'result': 'PASS'
@@ -218,7 +218,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 
 # + [markdown] papermill={"duration": 0.023649, "end_time": "2021-02-02T22:30:39.115495", "exception": false, "start_time": "2021-02-02T22:30:39.091846", "status": "completed"} tags=[]
 # # 7 Verify that in measurement table if measurement_source_concept_id AND the measurement_concept_id both of those fields are null OR zero, the row should be removed.
@@ -234,8 +234,8 @@ SUM(CASE WHEN measurement_source_concept_id IS NULL AND measurement_concept_id =
 FROM`{{project_id}}.{{deid_clean_cdr}}.measurement`
 """)
 q = query.render(project_id=project_id, deid_clean_cdr=deid_clean_cdr)
-df1 = execute(client, q)
-if df1.loc[0].sum() == 0:
+result = execute(client, q)
+if result.loc[0].sum() == 0:
     df = df.append({
         'query': 'Query7 measurement',
         'result': 'PASS'
@@ -247,7 +247,7 @@ else:
         'result': 'Failure'
     },
                    ignore_index=True)
-df1.T
+result.T
 # -
 
 # # 8  check State_of_Residence fields in the person_ext table in deid_clean

--- a/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
+++ b/data_steward/analytics/cdr_ops/rt_cdr_qc/cdr_deid_clean_qa_report1.py
@@ -273,14 +273,14 @@ result = execute(client, q)
 if result.loc[0].sum() == 0:
     summary = summary.append(
         {
-            'query': 'Query 8, State_of_Residence in person_ext',
+            'query': 'Query8, State_of_Residence in person_ext',
             'result': ' Failure'
         },
         ignore_index=True)
 else:
     summary = summary.append(
         {
-            'query': 'Query 8, State_of_Residence in person_ext',
+            'query': 'Query8, State_of_Residence in person_ext',
             'result': 'PASS'
         },
         ignore_index=True)


### PR DESCRIPTION
DC-1661 removed the death(currently aou_death) table from the affected tables of drop_zero_concept_ids. However, the notebook check regarding this issue was not removed.

This PR removes the check

See [DC-3673](https://precisionmedicineinitiative.atlassian.net/browse/DC-3673), the ticket
See [DC-1661](https://precisionmedicineinitiative.atlassian.net/browse/DC-1661), ticket excluding death table in RT.

Note:
variable `df1` is renamed to `result` for better clarity and context
variable `df` is renamed to `summary` for better clarity and context
These are mostly in two separate commits should the reviewer want to revert the names `df` and/or `df1` for convenience.

[DC-3673]: https://precisionmedicineinitiative.atlassian.net/browse/DC-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-1661]: https://precisionmedicineinitiative.atlassian.net/browse/DC-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ