### PR TITLE
[DC-3233] `AbstractBqLookupTableConceptSuppression` is leaving a dirty integration test environment

### DIFF
--- a/data_steward/cdr_cleaner/cleaning_rules/deid/concept_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/concept_suppression.py
@@ -198,6 +198,12 @@ class AbstractBqLookupTableConceptSuppression(AbstractConceptSuppression):
         # Create the suppression lookup table
         self.create_suppression_lookup_table(client)
 
+    def get_sandbox_tablenames(self):
+        # Use the Super class method
+        return super().get_sandbox_tablenames() + [
+            self._concept_suppression_lookup_table
+        ]
+
     @abstractmethod
     def create_suppression_lookup_table(self, client: Client):
         """

--- a/data_steward/cdr_cleaner/cleaning_rules/deid/recent_concept_suppression.py
+++ b/data_steward/cdr_cleaner/cleaning_rules/deid/recent_concept_suppression.py
@@ -212,9 +212,8 @@ class RecentConceptSuppression(AbstractBqLookupTableConceptSuppression):
         raise NotImplementedError("Please fix me.")
 
     def get_sandbox_tablenames(self):
-        return super().get_sandbox_tablenames() + [
-            SUPPRESSION_RULE_CONCEPT_TABLE, CONCEPT_FIRST_USE_TABLE
-        ]
+        # Use the Super class method
+        return super().get_sandbox_tablenames() + [CONCEPT_FIRST_USE_TABLE]
 
 
 if __name__ == '__main__':

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/cancer_concept_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/cancer_concept_suppression_test.py
@@ -19,7 +19,8 @@ from dateutil import parser
 
 #Project imports
 from app_identity import PROJECT_ID
-from cdr_cleaner.cleaning_rules.cancer_concept_suppression import CancerConceptSuppression
+from cdr_cleaner.cleaning_rules.cancer_concept_suppression import CancerConceptSuppression, \
+SUPPRESSION_RULE_CONCEPT_TABLE
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from common import CONCEPT, OBSERVATION
 
@@ -51,6 +52,9 @@ class CancerConceptSuppressionTest(BaseTest.CleaningRulesTestBase):
 
         cls.fq_sandbox_table_names.append(
             f'{cls.project_id}.{cls.sandbox_id}.{sb_table_names}')
+        cls.fq_sandbox_table_names.append(
+            f'{cls.project_id}.{cls.sandbox_id}.{SUPPRESSION_RULE_CONCEPT_TABLE}'
+        )
 
         cls.fq_table_names = [
             f'{project_id}.{dataset_id}.{OBSERVATION}',

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/missing_concept_record_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/missing_concept_record_suppression_test.py
@@ -9,7 +9,8 @@ import os
 
 #Project imports
 from app_identity import PROJECT_ID
-from cdr_cleaner.cleaning_rules.missing_concept_record_suppression import MissingConceptRecordSuppression
+from cdr_cleaner.cleaning_rules.missing_concept_record_suppression import MissingConceptRecordSuppression, \
+SUPPRESSION_RULE_CONCEPT_TABLE
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from common import AOU_DEATH, DEATH, OBSERVATION, CONCEPT
 
@@ -51,6 +52,7 @@ class MissingConceptRecordSuppressionTest(BaseTest.CleaningRulesTestBase):
             f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(AOU_DEATH)}',
             f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(DEATH)}',
             f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(OBSERVATION)}',
+            f'{cls.project_id}.{cls.sandbox_id}.{SUPPRESSION_RULE_CONCEPT_TABLE}'
         ]
 
         super().setUpClass()

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/section_participation_concept_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/section_participation_concept_suppression_test.py
@@ -12,7 +12,8 @@ import os
 
 # Project imports
 from app_identity import PROJECT_ID
-from cdr_cleaner.cleaning_rules.section_participation_concept_suppression import SectionParticipationConceptSuppression
+from cdr_cleaner.cleaning_rules.section_participation_concept_suppression \
+    import SectionParticipationConceptSuppression, SUPPRESSION_RULE_CONCEPT_TABLE
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from common import OBSERVATION, VOCABULARY_TABLES
 
@@ -57,6 +58,8 @@ class SectionParticipationConceptSuppressionTest(BaseTest.CleaningRulesTestBase
         cls.fq_sandbox_table_names = [
             f'{project_id}.{sandbox_id}.{cls.rule_instance.sandbox_table_for(OBSERVATION)}',
         ]
+        cls.fq_sandbox_table_names.append(
+            f'{project_id}.{sandbox_id}.{SUPPRESSION_RULE_CONCEPT_TABLE}')
 
         # call super to set up the client, create datasets, and create
         # empty test tables

--- a/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/vehicular_accident_concept_suppression_test.py
+++ b/tests/integration_tests/data_steward/cdr_cleaner/cleaning_rules/vehicular_accident_concept_suppression_test.py
@@ -9,7 +9,8 @@ import os
 
 #Project imports
 from app_identity import PROJECT_ID
-from cdr_cleaner.cleaning_rules.vehicular_accident_concept_suppression import VehicularAccidentConceptSuppression
+from cdr_cleaner.cleaning_rules.vehicular_accident_concept_suppression import VehicularAccidentConceptSuppression, \
+SUPPRESSION_RULE_CONCEPT_TABLE
 from tests.integration_tests.data_steward.cdr_cleaner.cleaning_rules.bigquery_tests_base import BaseTest
 from common import JINJA_ENV, CONDITION_OCCURRENCE, CONCEPT, CONCEPT_RELATIONSHIP, CONCEPT_ANCESTOR
 
@@ -49,6 +50,9 @@ class VehicularAccidentConceptSuppressionTest(BaseTest.CleaningRulesTestBase):
 
         cls.fq_sandbox_table_names.append(
             f'{cls.project_id}.{cls.sandbox_id}.{cls.rule_instance.sandbox_table_for(CONDITION_OCCURRENCE)}'
+        )
+        cls.fq_sandbox_table_names.append(
+            f'{cls.project_id}.{cls.sandbox_id}.{SUPPRESSION_RULE_CONCEPT_TABLE}'
         )
 
         # call super to set up the client, create datasets, and create


### PR DESCRIPTION
updated concept suppression integration env cleanup.