### PR TITLE
[DL-2215] Publish script in Curation to copy data in us-central1 location in output prod project

### DIFF
--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -187,7 +187,8 @@ class BigQueryClient(Client):
                                           dataset_id=dataset_id)
 
     def define_dataset(self, dataset_id: str, description: str,
-                       label_or_tag: dict) -> bigquery.Dataset:
+                       label_or_tag: dict,
+                       output_prod=False) -> bigquery.Dataset:
         """
         Define the dataset reference.
 
@@ -195,6 +196,8 @@ class BigQueryClient(Client):
         :param description:  description for the dataset
         :param label_or_tag:  labels for the dataset = Dict[str, str]
                             tags for the dataset = Dict[str, '']
+        :param output_prod:  boolean indicating whether the target dataset is
+                            output-prod or not. This will define dataset location.
 
         :return: a dataset reference object.
         :raises: google.api_core.exceptions.Conflict if the dataset already exists
@@ -214,7 +217,7 @@ class BigQueryClient(Client):
         dataset = bigquery.Dataset(dataset_id)
         dataset.description = description
         dataset.labels = label_or_tag
-        dataset.location = "US"
+        dataset.location = "us-central1" if output_prod else "US"
 
         return dataset
 

--- a/data_steward/gcloud/bq/__init__.py
+++ b/data_steward/gcloud/bq/__init__.py
@@ -186,7 +186,9 @@ class BigQueryClient(Client):
         return DATASET_COLUMNS_TPL.render(project_id=self.project,
                                           dataset_id=dataset_id)
 
-    def define_dataset(self, dataset_id: str, description: str,
+    def define_dataset(self,
+                       dataset_id: str,
+                       description: str,
                        label_or_tag: dict,
                        output_prod=False) -> bigquery.Dataset:
         """

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -183,7 +183,7 @@ def generate_output_prod(tier,
         f'Creating dataset {output_dataset_name} in {output_prod_project_id}...'
     )
     dataset_object = bq_client.define_dataset(output_dataset_name, description,
-                                              labels)
+                                              labels, output_prod=True)
     bq_client.create_dataset(dataset_object, exists_ok=False)
 
     # Optionally copy fitbit tables to source dataset
@@ -224,7 +224,7 @@ def generate_output_prod(tier,
             f'Creating dataset {serology_output} in {output_prod_project_id}...'
         )
         dataset_object = bq_client.define_dataset(serology_output, description,
-                                                  labels)
+                                                  labels, output_prod=True)
         bq_client.create_dataset(dataset_object, exists_ok=False)
         _ = bq_client.copy_dataset(
             f'{src_project_id}.{serology_input}',

--- a/data_steward/tools/copy_dataset_to_output_prod.py
+++ b/data_steward/tools/copy_dataset_to_output_prod.py
@@ -182,8 +182,10 @@ def generate_output_prod(tier,
     LOGGER.info(
         f'Creating dataset {output_dataset_name} in {output_prod_project_id}...'
     )
-    dataset_object = bq_client.define_dataset(output_dataset_name, description,
-                                              labels, output_prod=True)
+    dataset_object = bq_client.define_dataset(output_dataset_name,
+                                              description,
+                                              labels,
+                                              output_prod=True)
     bq_client.create_dataset(dataset_object, exists_ok=False)
 
     # Optionally copy fitbit tables to source dataset
@@ -223,8 +225,10 @@ def generate_output_prod(tier,
         LOGGER.info(
             f'Creating dataset {serology_output} in {output_prod_project_id}...'
         )
-        dataset_object = bq_client.define_dataset(serology_output, description,
-                                                  labels, output_prod=True)
+        dataset_object = bq_client.define_dataset(serology_output,
+                                                  description,
+                                                  labels,
+                                                  output_prod=True)
         bq_client.create_dataset(dataset_object, exists_ok=False)
         _ = bq_client.copy_dataset(
             f'{src_project_id}.{serology_input}',


### PR DESCRIPTION
Updated `define_dataset` function & `copy_dataset_to_output_prod.py` file to ensure only output-datasets are being marked for location `us-central1` without affecting other pipeline steps.