### PR TITLE
[DL-2445] Add CT+ ID regeneration script

### DIFF
--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -17,8 +17,10 @@ four ways:
    sorting. The random value is materialized in an inner subquery so no
    nondeterministic function is evaluated inside a window ORDER BY. The mapping table
    is persisted, so the draw does not need to be reproducible and no salt or long
-   lived secret is introduced. Mappings are re-cut per release rather than appended,
-   since offsetting by a running maximum reintroduces ordering.
+   lived secret is introduced. Mappings are appended to across releases rather than
+   re-cut, so a row published once keeps its CT+ id for good. New ids sit above the
+   running maximum, which orders releases relative to each other, but the releases
+   ship as separate datasets so that boundary is already public.
 
 3) survey_conduct gets its provider_id, visit_occurrence_id and
    response_visit_occurrence_id foreign keys remapped. regenerate_rt_ids.py returns
@@ -61,7 +63,18 @@ Required Environment variables:
 
 The mapping dataset must be empty or produced by a previous CT+ run. Pointing this
 script at a mapping dataset an RT run produced would otherwise reuse that run's
-_mapping_person and hand CT+ the RT person_ids; the script fails fast instead.
+_mapping_person and hand CT+ the RT person_ids; the script fails fast instead. Point
+every release at the same mapping dataset, or ids will not persist between them.
+
+When to run: after the deid_clean stage, as the last step before the dataset is
+published, never between deid and deid_base. Two reasons. CreateDerivedTables runs in
+both CONTROLLED_TIER_DEID_BASE_CLEANING_CLASSES and
+CONTROLLED_TIER_DEID_CLEAN_CLEANING_CLASSES and mints observation_period_id,
+drug_era_id and condition_era_id from scratch, and MoveNLPtoDomains mints
+condition_occurrence_id off a running maximum at every stage, so ids assigned earlier
+are overwritten or joined by un-re-keyed ones. The first CT+ release also re-keys a
+copy of CT deid_clean, which fixes the mapping key space at that stage; a later
+release re-keying at any other stage would not match it.
 
 Usage:
   python regenerate_ct_plus_ids.py \
@@ -71,7 +84,7 @@ Usage:
     --pipeline_dataset_id <pipeline_tables_dataset> \
     --ct_plus_ids_view <rdr_participant_research_ids_view> \
     --mapping_dataset_id <mapping_tables_dataset> \
-    --mapping_source_dataset_id <optional_source_dataset_for_mappings>
+    --mapping_namespace <optional, defaults to DEFAULT_MAPPING_NAMESPACE>
 """
 import argparse
 import logging
@@ -105,6 +118,15 @@ CT_PLUS_PERSON_ID_COLUMN = 'controlled_tier_plus_id'
 # Marks a _mapping_person built by this script, so a mapping dataset produced by an
 # RT run is not silently reused. See assert_person_mapping_is_ct_plus().
 CT_PLUS_PERSON_MAPPING_SUFFIX = 'ct_plus'
+
+# Namespace stamped into src_table_id on every mapping row. It has to be a constant
+# rather than the input dataset name: both the append filter in mapping_query() and
+# the read side join in table_query() match on this literal, so a value derived from
+# the input dataset would stop matching the moment a later release runs against a
+# differently named dataset. Every source id would then be assigned a second, higher
+# id and the load would pick that one, silently breaking ID persistence across
+# releases with no error. Do not override this without changing both call sites.
+DEFAULT_MAPPING_NAMESPACE = 'ct_plus'
 
 # fact_relationship stores a domain concept id beside each fact id rather than a
 # foreign key column, so the remap has to switch on it. The domains below are the
@@ -165,9 +187,14 @@ def person_mapping_src_table_id(pipeline_dataset_id, ct_plus_ids_view):
     return f'{pipeline_dataset_id}.{ct_plus_ids_view}.{CT_PLUS_PERSON_MAPPING_SUFFIX}'
 
 
-def mapping_query(table_name, input_dataset_id, project_id, pipeline_dataset_id,
-                  ct_plus_ids_view, mapping_source_dataset_id,
-                  mapping_dataset_id):
+def mapping_query(table_name,
+                  input_dataset_id,
+                  project_id,
+                  pipeline_dataset_id,
+                  ct_plus_ids_view,
+                  mapping_namespace,
+                  mapping_dataset_id,
+                  append=False):
     """
     Get the query used to generate new IDs for a CDM table.
 
@@ -176,13 +203,20 @@ def mapping_query(table_name, input_dataset_id, project_id, pipeline_dataset_id,
     materialized in the inner subquery because BigQuery does not accept a
     nondeterministic expression directly in a window ORDER BY.
 
+    When appending, ids already mapped by an earlier release keep their value and only
+    unmapped source ids are drawn, so a row published in one release carries the same
+    CT+ id in every later one. New ids sit above the running maximum, which does order
+    releases relative to each other, but the releases ship as separate datasets so that
+    boundary is already public.
+
     :param table_name: name of CDM table
     :param input_dataset_id: identifies the BQ dataset containing the input table
     :param project_id: identifies the GCP project containing the dataset
     :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: constant stamped into src_table_id, see DEFAULT_MAPPING_NAMESPACE
     :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param append: if True, preserve existing mappings and only draw ids for new rows
     :return: the query
     """
     # Special handling for person table - use existing mapping from pipeline_tables.
@@ -200,16 +234,32 @@ def mapping_query(table_name, input_dataset_id, project_id, pipeline_dataset_id,
           AND {CT_PLUS_PERSON_ID_COLUMN} IS NOT NULL
         '''
 
+    mapping_table = mapping_table_for(table_name)
     id_field = f'{table_name}_id'
 
-    # For all other tables, draw a random permutation. Mapping tables are re-cut per
-    # release rather than appended: offsetting new IDs by the running maximum would
-    # place later arrivals above earlier ones and leak arrival order.
+    # When appending, start above every id already handed out and skip source ids that
+    # already have one, so previously published rows keep their CT+ id.
+    if append:
+        offset_expr = (
+            f'(SELECT COALESCE(MAX({id_field}), 0) '
+            f'FROM `{project_id}.{mapping_dataset_id}.{mapping_table}`)')
+        where_clause = f"""
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM `{project_id}.{mapping_dataset_id}.{mapping_table}` mt
+        WHERE mt.src_{id_field} = t.src_{id_field} AND
+              mt.src_table_id = '{mapping_namespace}.{table_name}'
+    )"""
+    else:
+        offset_expr = '0'
+        where_clause = ''
+
+    # For all other tables, draw a random permutation.
     return f'''
     SELECT
-        '{mapping_source_dataset_id}.{table_name}' AS src_table_id,
+        '{mapping_namespace}.{table_name}' AS src_table_id,
         src_{id_field},
-        ROW_NUMBER() OVER (ORDER BY shuffle_key) AS {id_field}
+        {offset_expr} + ROW_NUMBER() OVER (ORDER BY shuffle_key) AS {id_field}
     FROM (
         -- RAND() is drawn outside the DISTINCT: pulling it into the same SELECT
         -- would make every duplicate of {id_field} a distinct row and survive it
@@ -219,6 +269,7 @@ def mapping_query(table_name, input_dataset_id, project_id, pipeline_dataset_id,
             FROM `{project_id}.{input_dataset_id}.{table_name}`
         )
     ) t
+    {where_clause}
     '''
 
 
@@ -259,14 +310,20 @@ def assert_person_mapping_is_ct_plus(client, project_id, mapping_dataset_id,
 
 
 def mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
-            pipeline_dataset_id, ct_plus_ids_view, mapping_source_dataset_id,
+            pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
             mapping_dataset_id):
     """
-    Create a table that assigns new ids to records.
+    Create or extend the table that assigns new ids to records.
 
-    Mappings are re-cut per release, so an existing mapping table is truncated rather
-    than appended to. Appending would offset later IDs above earlier ones and leak
-    arrival order, which defeats the random permutation.
+    Mappings persist across releases. An existing mapping table is appended to rather
+    than truncated, so a row published in one release keeps its CT+ id in every later
+    one. Only source ids with no mapping yet are drawn.
+
+    person is the exception and is always rebuilt from the ids view, which is the source
+    of truth for controlled_tier_plus_id and is stable there. Skipping the rebuild would
+    leave participants who first appear in a later release with no mapping at all, and
+    because every person join is a LEFT JOIN their rows would load with person_id NULL
+    instead of failing.
 
     :param domain_table: name of the CDM table
     :param input_dataset_id: identifies dataset with source data
@@ -274,27 +331,37 @@ def mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
     :param project_id: identifies GCP project that contains the datasets
     :param pipeline_dataset_id: identifies pipeline_tables dataset (for person mapping)
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: constant stamped into src_table_id, see DEFAULT_MAPPING_NAMESPACE
     :param mapping_dataset_id: identifies the dataset where mapping tables are stored
     :return:
     """
-    mapping_source_dataset_id = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    mapping_namespace = mapping_namespace if mapping_namespace else DEFAULT_MAPPING_NAMESPACE
     mapping_table = mapping_table_for(domain_table)
+    client = BigQueryClient(project_id)
 
-    LOGGER.info(f"Creating mapping table {mapping_table}...")
+    append = (domain_table != PERSON and
+              client.table_exists(mapping_table, mapping_dataset_id))
+    if append:
+        LOGGER.info(f"Appending new '{domain_table}' ids to {mapping_table}. "
+                    f"Existing mappings are preserved.")
+        write_disposition = 'WRITE_APPEND'
+    else:
+        LOGGER.info(f"Creating mapping table {mapping_table}...")
+        write_disposition = 'WRITE_TRUNCATE'
+
     q = mapping_query(domain_table, input_dataset_id, project_id,
-                      pipeline_dataset_id, ct_plus_ids_view,
-                      mapping_source_dataset_id, mapping_dataset_id)
+                      pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
+                      mapping_dataset_id, append)
 
     LOGGER.info(f'Query for {mapping_table} is {q}')
     bq_utils.query(q,
                    destination_dataset_id=mapping_dataset_id,
                    destination_table_id=mapping_table,
-                   write_disposition='WRITE_TRUNCATE')
+                   write_disposition=write_disposition)
 
 
 def fact_relationship_query(input_dataset_id, project_id, mapping_dataset_id,
-                            mapping_source_dataset_id):
+                            mapping_namespace):
     """
     Returns a query that resolves fact_relationship fact ids to their new CT+ values.
 
@@ -311,7 +378,7 @@ def fact_relationship_query(input_dataset_id, project_id, mapping_dataset_id,
     :param input_dataset_id: identifies dataset containing source data
     :param project_id: identifies the GCP project
     :param mapping_dataset_id: identifies the dataset where mapping tables are stored
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: original dataset used to create the mappings
     :return: the query
     """
     case_exprs = {}
@@ -332,8 +399,7 @@ def fact_relationship_query(input_dataset_id, project_id, mapping_dataset_id,
     LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_tbl}` AS {alias}
       ON fr.fact_id_{side} = {alias}.{src_field}
      AND fr.domain_concept_id_{side} = {domain_concept_id}
-     AND {alias}.src_table_id = '{mapping_source_dataset_id}.{domain_table}' '''
-                             )
+     AND {alias}.src_table_id = '{mapping_namespace}.{domain_table}' ''')
         case_exprs[side] = '\n            '.join(whens)
 
     joins = ''.join(join_exprs)
@@ -362,7 +428,7 @@ def fact_relationship_query(input_dataset_id, project_id, mapping_dataset_id,
 
 def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
                 pipeline_dataset_id, ct_plus_ids_view, mapping_dataset_id,
-                mapping_source_dataset_id):
+                mapping_namespace):
     """
     Returns a query to retrieve all records from an input table with new IDs.
 
@@ -378,11 +444,11 @@ def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
     :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
     :param mapping_dataset_id: identifies the dataset where mapping tables are stored
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: original dataset used to create the mappings
 
     :return: the query
     """
-    mapping_source_dataset_id = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    mapping_namespace = mapping_namespace if mapping_namespace else DEFAULT_MAPPING_NAMESPACE
     person_src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
                                                       ct_plus_ids_view)
 
@@ -393,13 +459,12 @@ def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
         return f'''
         LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_tbl}` {join_alias}
           ON {src_table_alias}.{on_field} = {join_alias}.{src_field}
-         AND {join_alias}.src_table_id = '{mapping_source_dataset_id}.{join_table}'
+         AND {join_alias}.src_table_id = '{mapping_namespace}.{join_table}'
         '''
 
     if table_name == FACT_RELATIONSHIP:
         return fact_relationship_query(input_dataset_id, project_id,
-                                       mapping_dataset_id,
-                                       mapping_source_dataset_id)
+                                       mapping_dataset_id, mapping_namespace)
 
     # Fitbit tables do not have a domain-specific primary key. They only need person_id updated.
     # This logic is similar to tables without a primary key.
@@ -486,7 +551,7 @@ def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
         `{project_id}.{mapping_dataset_id}.{mapping_table}` AS m
     ON
         t.survey_conduct_id = m.src_survey_conduct_id AND
-        m.src_table_id = '{mapping_source_dataset_id}.{table_name}'
+        m.src_table_id = '{mapping_namespace}.{table_name}'
     LEFT JOIN
         `{project_id}.{mapping_dataset_id}.{mapping_person}` AS mp
     ON
@@ -674,7 +739,7 @@ def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
         mapping_survey_conduct = mapping_table_for(SURVEY_CONDUCT)
         questionnaire_response_join_expr = f'''
         LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_survey_conduct}` mqr
-            ON t.questionnaire_response_id = mqr.src_survey_conduct_id AND mqr.src_table_id = '{mapping_source_dataset_id}.{SURVEY_CONDUCT}'
+            ON t.questionnaire_response_id = mqr.src_survey_conduct_id AND mqr.src_table_id = '{mapping_namespace}.{SURVEY_CONDUCT}'
         '''
 
     if table_name == PERSON:
@@ -718,7 +783,7 @@ def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
         SELECT * EXCEPT(rn) FROM (
             SELECT *, ROW_NUMBER() OVER(PARTITION BY src_{table_name}_id ORDER BY {table_name}_id) as rn
             FROM `{project_id}.{mapping_dataset_id}.{mapping_table}`
-            WHERE src_table_id = '{mapping_source_dataset_id}.{table_name}'
+            WHERE src_table_id = '{mapping_namespace}.{table_name}'
         ) WHERE rn = 1
     ) AS m
     ON
@@ -742,7 +807,7 @@ def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
 
 def load(client, cdm_table, input_dataset_id, output_dataset_id, project_id,
          pipeline_dataset_id, ct_plus_ids_view, mapping_dataset_id,
-         mapping_source_dataset_id):
+         mapping_namespace):
     """
     Loads a single domain table into the output dataset with new IDs.
 
@@ -753,11 +818,11 @@ def load(client, cdm_table, input_dataset_id, output_dataset_id, project_id,
     :param project_id: identifies the GCP project
     :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
     :param mapping_dataset_id: identifies the dataset where mapping tables are stored
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: original dataset used to create the mappings
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
     :return:
     """
-    mapping_source_dataset_id = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    mapping_namespace = mapping_namespace if mapping_namespace else DEFAULT_MAPPING_NAMESPACE
     output_table = output_table_for(cdm_table)
     LOGGER.info(
         f'Loading {cdm_table} from {input_dataset_id} into {output_table}')
@@ -773,7 +838,7 @@ def load(client, cdm_table, input_dataset_id, output_dataset_id, project_id,
 
     q = table_query(cdm_table, input_dataset_id, output_dataset_id, project_id,
                     pipeline_dataset_id, ct_plus_ids_view, mapping_dataset_id,
-                    mapping_source_dataset_id)
+                    mapping_namespace)
     if cdm_table == 'visit_detail' or cdm_table == 'visit_occurrence':
         LOGGER.info(q)
     query_result = bq_utils.query(q,
@@ -787,7 +852,7 @@ def load(client, cdm_table, input_dataset_id, output_dataset_id, project_id,
 
 def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
                      project_id, mapping_dataset_id, pipeline_dataset_id,
-                     ct_plus_ids_view, mapping_source_dataset_id):
+                     ct_plus_ids_view, mapping_namespace):
     """
     Update an extension table with new IDs from its corresponding mapping table.
 
@@ -798,7 +863,7 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
     :param project_id: identifies the GCP project
     :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: original dataset used to create the mappings
 
     :return: query result
     """
@@ -819,7 +884,7 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
     LOGGER.info(f'Updating extension table {ext_table_name}')
 
     # Use the original source dataset for the join condition if provided, else use current input
-    source_dataset = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    source_dataset = mapping_namespace if mapping_namespace else DEFAULT_MAPPING_NAMESPACE
     person_src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
                                                       ct_plus_ids_view)
 
@@ -850,7 +915,7 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
 
 
 def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
-         ct_plus_ids_view, mapping_dataset_id, mapping_source_dataset_id):
+         ct_plus_ids_view, mapping_dataset_id, mapping_namespace):
     """
     Create a new CDM dataset with regenerated IDs
 
@@ -860,7 +925,7 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
     :param mapping_dataset_id: dataset to store/lookup mapping tables
     :param pipeline_dataset_id: dataset containing rdr_participant_research_ids_view for person mapping
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
-    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_namespace: original dataset used to create the mappings
     :returns: list of tables generated successfully
     """
     bq_client = BigQueryClient(project_id)
@@ -921,8 +986,8 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
             continue
 
         mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
-                pipeline_dataset_id, ct_plus_ids_view,
-                mapping_source_dataset_id, mapping_dataset_id)
+                pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
+                mapping_dataset_id)
 
     # Load all tables with new IDs
     for table_name in CDM_TABLES:
@@ -932,7 +997,7 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
         LOGGER.info(f'Loading table {table_name}...')
         load(bq_client, table_name, input_dataset_id, output_dataset_id,
              project_id, pipeline_dataset_id, ct_plus_ids_view,
-             mapping_dataset_id, mapping_source_dataset_id)
+             mapping_dataset_id, mapping_namespace)
 
     # Load Fitbit tables if they exist
     LOGGER.info('Processing Fitbit tables (if they exist)...')
@@ -941,7 +1006,7 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
             LOGGER.info(f'Loading Fitbit table {fitbit_table}...')
             load(bq_client, fitbit_table, input_dataset_id, output_dataset_id,
                  project_id, pipeline_dataset_id, ct_plus_ids_view,
-                 mapping_dataset_id, mapping_source_dataset_id)
+                 mapping_dataset_id, mapping_namespace)
         else:
             LOGGER.info(f'Fitbit table {fitbit_table} does not exist, skipping')
 
@@ -950,7 +1015,7 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
     for ext_table in EXT_TABLES:
         update_ext_table(ext_table, input_dataset_id, output_dataset_id,
                          project_id, mapping_dataset_id, pipeline_dataset_id,
-                         ct_plus_ids_view, mapping_source_dataset_id)
+                         ct_plus_ids_view, mapping_namespace)
 
     # Discover and process any remaining tables
     tables_to_skip = set(CDM_TABLES) | set(FITBIT_TABLES) | set(EXT_TABLES)
@@ -985,13 +1050,13 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
             # 1. Create mapping for the primary key
             LOGGER.info(f"Creating mapping for {table_name}...")
             mapping(table_name, input_dataset_id, output_dataset_id, project_id,
-                    pipeline_dataset_id, ct_plus_ids_view,
-                    mapping_source_dataset_id, mapping_dataset_id)
+                    pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
+                    mapping_dataset_id)
             # 2. Load table with remapped PK and FKs
             LOGGER.info(f"Loading table {table_name}...")
             load(bq_client, table_name, input_dataset_id, output_dataset_id,
                  project_id, pipeline_dataset_id, ct_plus_ids_view,
-                 mapping_dataset_id, mapping_source_dataset_id)
+                 mapping_dataset_id, mapping_namespace)
         elif has_person_id:
             LOGGER.info(
                 f"Table '{table_name}' has person_id. Remapping person_id only."
@@ -1066,16 +1131,18 @@ if __name__ == '__main__':
         '--mapping_dataset_id',
         dest='mapping_dataset_id',
         required=True,
-        help='Dataset to store/lookup mapping tables. Can be a sandbox dataset.'
-    )
+        help='Dataset to store/lookup mapping tables. Can be a sandbox dataset. '
+        'Use the same one for every release so ids persist between them.')
     parser.add_argument(
-        '--mapping_source_dataset_id',
-        dest='mapping_source_dataset_id',
+        '--mapping_namespace',
+        dest='mapping_namespace',
         required=False,
-        help=
-        'Original dataset mappings were created from, if different from input.')
+        default=DEFAULT_MAPPING_NAMESPACE,
+        help='Constant stamped into src_table_id on every mapping row. Leave at '
+        f"the default ('{DEFAULT_MAPPING_NAMESPACE}'); a per release value breaks "
+        'id persistence silently.')
 
     args = parser.parse_args()
     main(args.input_dataset_id, args.output_dataset_id, args.project_id,
          args.pipeline_dataset_id, args.ct_plus_ids_view,
-         args.mapping_dataset_id, args.mapping_source_dataset_id)
+         args.mapping_dataset_id, args.mapping_namespace)

--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -1294,11 +1294,19 @@ def main(input_dataset_id,
             LOGGER.info(
                 f"Table '{table_name}' has a primary key and person_id. Full remapping will be applied."
             )
-            # 1. Create mapping for the primary key
-            LOGGER.info(f"Creating mapping for {table_name}...")
-            mapping(table_name, input_dataset_id, output_dataset_id, project_id,
-                    pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
-                    mapping_dataset_id)
+            # 1. Create mapping for the primary key, unless the primary key is
+            # deliberately preserved. aou_death_id is shared with CT by program
+            # decision, so table_query() reads it straight from the source row and
+            # a mapping built here would be written on every run and never read.
+            if table_name == AOU_DEATH:
+                LOGGER.info(
+                    f"Skipping mapping for {table_name}: {table_name}_id is preserved, not regenerated."
+                )
+            else:
+                LOGGER.info(f"Creating mapping for {table_name}...")
+                mapping(table_name, input_dataset_id, output_dataset_id,
+                        project_id, pipeline_dataset_id, ct_plus_ids_view,
+                        mapping_namespace, mapping_dataset_id)
             # 2. Load table with remapped PK and FKs
             LOGGER.info(f"Loading table {table_name}...")
             load(bq_client, table_name, input_dataset_id, output_dataset_id,

--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -1112,13 +1112,29 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
     person_src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
                                                       ct_plus_ids_view)
 
+    # The mapping holds a row for every input row, including ones the load filtered
+    # out, so joining the mapping alone is not enough: the base row has to have
+    # survived into the output too. Without this, an ext row outlives the row it
+    # extends and points at a primary key that is not in the released data.
+    # visit_detail is the only table the load filters today, but keep the guard
+    # generic so a future filter cannot silently orphan its ext rows.
+    if client.table_exists(base_table, output_dataset_id):
+        base_join = f'''
+    JOIN `{project_id}.{output_dataset_id}.{base_table}` b
+        ON b.{id_field} = m.{id_field}'''
+    else:
+        LOGGER.warning(
+            f'{base_table} is not in {output_dataset_id}, so {ext_table_name} is '
+            f'loaded without checking that its base rows survived the load')
+        base_join = ''
+
     q = f'''
     SELECT
         m.{id_field},
         e.* EXCEPT({id_field})
     FROM `{project_id}.{input_dataset_id}.{ext_table_name}` e
     JOIN `{project_id}.{mapping_dataset_id}.{mapping_table}` m
-        ON e.{id_field} = m.src_{id_field} AND m.src_table_id = '{source_dataset}.{base_table}'
+        ON e.{id_field} = m.src_{id_field} AND m.src_table_id = '{source_dataset}.{base_table}'{base_join}
         '''
 
     if base_table == PERSON:
@@ -1129,7 +1145,7 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
     FROM `{project_id}.{input_dataset_id}.{ext_table_name}` e
     JOIN `{project_id}.{mapping_dataset_id}.{mapping_table}` m
         ON e.{id_field} = m.src_{id_field}
-        AND m.src_table_id = '{person_src_table_id}'
+        AND m.src_table_id = '{person_src_table_id}'{base_join}
     '''
 
     return run_query_to_table(project_id,

--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -1,0 +1,1081 @@
+"""
+Regenerate Primary Key IDs for a Controlled Tier Plus (CT+) Dataset.
+
+CT+ is built from an existing Controlled Tier (CT) dataset. Every identifier a CT+
+researcher sees has to be regenerated so CT+ rows cannot be aligned back to CT rows.
+This script is the CT+ counterpart of regenerate_rt_ids.py and differs from it in
+four ways:
+
+1) The person mapping reads controlled_tier_id -> controlled_tier_plus_id from
+   pipeline_tables.rdr_participant_research_ids_view. The input dataset is CT, so its
+   person_id is already controlled_tier_id; joining on research_id would miss every
+   row and, because all person joins are LEFT JOINs, would silently produce a full
+   dataset with person_id NULL throughout.
+
+2) Row IDs are drawn as a random permutation instead of ROW_NUMBER() ordered by the
+   source ID. An order preserving map would let a holder of both tiers align rows by
+   sorting. The random value is materialized in an inner subquery so no
+   nondeterministic function is evaluated inside a window ORDER BY. The mapping table
+   is persisted, so the draw does not need to be reproducible and no salt or long
+   lived secret is introduced. Mappings are re-cut per release rather than appended,
+   since offsetting by a running maximum reintroduces ordering.
+
+3) survey_conduct gets its provider_id, visit_occurrence_id and
+   response_visit_occurrence_id foreign keys remapped. regenerate_rt_ids.py returns
+   from its survey_conduct branch before reaching the generic foreign key loop and
+   passes those three columns through unchanged.
+
+4) fact_relationship is remapped rather than copied. It has no primary key and no
+   person_id, so regenerate_rt_ids.py lands it in the copy as is path and leaves
+   fact_id_1 and fact_id_2 pointing at CT values that dangle against every re-keyed
+   CT+ row. See DOMAIN_CONCEPT_ID_TO_TABLE below.
+
+The script otherwise behaves like regenerate_rt_ids.py:
+
+a) Creates empty output tables with proper schema, clustering, etc.
+
+b) For all tables (INCLUDING person and survey_conduct, EXCEPT death) that have
+   numeric primary key columns, creates mapping tables used to assign new IDs in
+   output.
+
+   Special handling for aou_death:
+   - aou_death_id (GUID) is preserved (not regenerated), matching CT and RT
+   - person_id foreign key is updated with new person_id from mapping
+
+   The structure of a mapping table follows this convention:
+
+   _mapping_<cdm_table> (
+     src_table_id:       STRING, -- identifies input table whose ids are to be mapped
+     src_<cdm_table>_id: INTEGER, -- original value of unique identifier in source table
+     <cdm_table>_id:     INTEGER  -- new unique identifier which will be used in output
+   )
+
+c) For all tables, composes a query to fetch records from the input dataset and save
+   the results in output with new IDs where applicable.
+
+## Notes
+Required Environment variables:
+ * GOOGLE_APPLICATION_CREDENTIALS: path to service account key json file
+ * APPLICATION_ID: GCP project ID
+ * BIGQUERY_DATASET_ID: Input/output dataset_id
+
+The mapping dataset must be empty or produced by a previous CT+ run. Pointing this
+script at a mapping dataset an RT run produced would otherwise reuse that run's
+_mapping_person and hand CT+ the RT person_ids; the script fails fast instead.
+
+Usage:
+  python regenerate_ct_plus_ids.py \
+    --project_id <project> \
+    --input_dataset_id <controlled_tier_dataset> \
+    --output_dataset_id <controlled_tier_plus_dataset> \
+    --pipeline_dataset_id <pipeline_tables_dataset> \
+    --ct_plus_ids_view <rdr_participant_research_ids_view> \
+    --mapping_dataset_id <mapping_tables_dataset> \
+    --mapping_source_dataset_id <optional_source_dataset_for_mappings>
+"""
+import argparse
+import logging
+from google.cloud.bigquery import Table
+import bq_utils
+
+from common import (AOU_DEATH, DEATH, MAPPING_PREFIX, PERSON, SURVEY_CONDUCT,
+                    VISIT_DETAIL, VISIT_OCCURRENCE, CARE_SITE, LOCATION, NOTE,
+                    NOTE_NLP, FITBIT_TABLES, VOCABULARY_TABLES, ACHILLES_TABLES,
+                    ACHILLES_HEEL_TABLES, CONDITION_OCCURRENCE, DRUG_EXPOSURE,
+                    FACT_RELATIONSHIP, MEASUREMENT, OBSERVATION,
+                    PROCEDURE_OCCURRENCE, PROVIDER,
+                    MEASUREMENT_DOMAIN_CONCEPT_ID,
+                    OBSERVATION_DOMAIN_CONCEPT_ID)
+
+from gcloud.bq import BigQueryClient
+from resources import fields_for, has_primary_key, CDM_TABLES
+from utils import pipeline_logging
+
+LOGGER = logging.getLogger(__name__)
+
+# Tables that should not have IDs regenerated
+SKIP_ID_REGEN_TABLES = [DEATH]
+
+# Column in the RDR research ids view that the CT input's person_id already carries
+CT_PERSON_ID_COLUMN = 'controlled_tier_id'
+
+# Column in the RDR research ids view holding the new CT+ person_id
+CT_PLUS_PERSON_ID_COLUMN = 'controlled_tier_plus_id'
+
+# Marks a _mapping_person built by this script, so a mapping dataset produced by an
+# RT run is not silently reused. See assert_person_mapping_is_ct_plus().
+CT_PLUS_PERSON_MAPPING_SUFFIX = 'ct_plus'
+
+# fact_relationship stores a domain concept id beside each fact id rather than a
+# foreign key column, so the remap has to switch on it. The domains below are the
+# ones observed in the CT input; anything else is left for the unmapped domain
+# handling in fact_relationship_query(). Concept ids resolve as:
+#   10 Procedure, 13 Drug, 19 Condition, 21 Measurement, 27 Observation, 57 Care site
+DOMAIN_CONCEPT_ID_TO_TABLE = {
+    10: PROCEDURE_OCCURRENCE,
+    13: DRUG_EXPOSURE,
+    19: CONDITION_OCCURRENCE,
+    MEASUREMENT_DOMAIN_CONCEPT_ID: MEASUREMENT,
+    OBSERVATION_DOMAIN_CONCEPT_ID: OBSERVATION,
+    57: CARE_SITE,
+}
+
+# Extension tables that need ID updates
+EXT_TABLES = [
+    'person_ext', 'visit_occurrence_ext', 'condition_occurrence_ext',
+    'device_exposure_ext', 'drug_exposure_ext', 'measurement_ext', 'note_ext',
+    'note_nlp_ext', 'observation_ext', 'observation_period_ext',
+    'procedure_occurrence_ext', 'survey_conduct_ext', 'condition_era_ext',
+    'drug_era_ext'
+]
+
+
+def output_table_for(table_id):
+    """
+    Get the name of the output table. For CT+ regeneration, it's the same as input.
+
+    :param table_id: name of a CDM table
+    :return: name of the table in output dataset
+    """
+    return table_id
+
+
+def mapping_table_for(domain_table):
+    """
+    Get the name of the mapping table for a given domain table.
+
+    :param domain_table: one of the domain tables (e.g. 'visit_occurrence', 'condition_occurrence')
+    :return: mapping table name
+    """
+    return f'{MAPPING_PREFIX}{domain_table}'
+
+
+def person_mapping_src_table_id(pipeline_dataset_id, ct_plus_ids_view):
+    """
+    Get the src_table_id value stamped on rows of the CT+ person mapping.
+
+    The suffix distinguishes a CT+ person mapping from the RT one, which is written to
+    the same table name from the same view. Without it, a mapping dataset shared with
+    an RT run would silently hand CT+ the RT person_ids.
+
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :return: the src_table_id literal
+    """
+    return f'{pipeline_dataset_id}.{ct_plus_ids_view}.{CT_PLUS_PERSON_MAPPING_SUFFIX}'
+
+
+def mapping_query(table_name, input_dataset_id, project_id, pipeline_dataset_id,
+                  ct_plus_ids_view, mapping_source_dataset_id,
+                  mapping_dataset_id):
+    """
+    Get the query used to generate new IDs for a CDM table.
+
+    Row IDs are a random permutation of the row set rather than a rank preserving
+    sequence, so CT+ IDs cannot be aligned to CT IDs by sorting. RAND() is
+    materialized in the inner subquery because BigQuery does not accept a
+    nondeterministic expression directly in a window ORDER BY.
+
+    :param table_name: name of CDM table
+    :param input_dataset_id: identifies the BQ dataset containing the input table
+    :param project_id: identifies the GCP project containing the dataset
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :return: the query
+    """
+    # Special handling for person table - use existing mapping from pipeline_tables.
+    # The input dataset is CT, so its person_id is already controlled_tier_id.
+    if table_name == PERSON and pipeline_dataset_id:
+        src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
+                                                   ct_plus_ids_view)
+        return f'''
+        SELECT
+            '{src_table_id}' AS src_table_id,
+            {CT_PERSON_ID_COLUMN} AS src_person_id,
+            {CT_PLUS_PERSON_ID_COLUMN} AS person_id
+        FROM `{project_id}.{pipeline_dataset_id}.{ct_plus_ids_view}`
+        WHERE {CT_PERSON_ID_COLUMN} IS NOT NULL
+          AND {CT_PLUS_PERSON_ID_COLUMN} IS NOT NULL
+        '''
+
+    id_field = f'{table_name}_id'
+
+    # For all other tables, draw a random permutation. Mapping tables are re-cut per
+    # release rather than appended: offsetting new IDs by the running maximum would
+    # place later arrivals above earlier ones and leak arrival order.
+    return f'''
+    SELECT
+        '{mapping_source_dataset_id}.{table_name}' AS src_table_id,
+        src_{id_field},
+        ROW_NUMBER() OVER (ORDER BY shuffle_key) AS {id_field}
+    FROM (
+        -- RAND() is drawn outside the DISTINCT: pulling it into the same SELECT
+        -- would make every duplicate of {id_field} a distinct row and survive it
+        SELECT src_{id_field}, RAND() AS shuffle_key
+        FROM (
+            SELECT DISTINCT {id_field} AS src_{id_field}
+            FROM `{project_id}.{input_dataset_id}.{table_name}`
+        )
+    ) t
+    '''
+
+
+def assert_person_mapping_is_ct_plus(client, project_id, mapping_dataset_id,
+                                     pipeline_dataset_id, ct_plus_ids_view):
+    """
+    Stop the run if an existing _mapping_person was not produced by a CT+ run.
+
+    regenerate_rt_ids.py writes _mapping_person under the same name into whatever
+    mapping dataset it is given. Reusing one of those would give CT+ the RT person_ids
+    with no error, so the src_table_id stamp is checked before anything is written.
+
+    :param client: BigQueryClient
+    :param project_id: identifies the GCP project
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :raises RuntimeError: if the existing mapping carries a different src_table_id
+    """
+    mapping_person = mapping_table_for(PERSON)
+    if not client.table_exists(mapping_person, mapping_dataset_id):
+        return
+
+    expected = person_mapping_src_table_id(pipeline_dataset_id,
+                                           ct_plus_ids_view)
+    q = f'''
+    SELECT DISTINCT src_table_id
+    FROM `{project_id}.{mapping_dataset_id}.{mapping_person}`
+    '''
+    found = {row['src_table_id'] for row in client.query(q).result()}
+    unexpected = found - {expected}
+    if unexpected:
+        raise RuntimeError(
+            f'{mapping_dataset_id}.{mapping_person} carries src_table_id '
+            f'{sorted(unexpected)}, which was not produced by a CT+ run. '
+            f'Expected {expected}. Point --mapping_dataset_id at an empty dataset '
+            f'or one from a previous CT+ run.')
+
+
+def mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
+            pipeline_dataset_id, ct_plus_ids_view, mapping_source_dataset_id,
+            mapping_dataset_id):
+    """
+    Create a table that assigns new ids to records.
+
+    Mappings are re-cut per release, so an existing mapping table is truncated rather
+    than appended to. Appending would offset later IDs above earlier ones and leak
+    arrival order, which defeats the random permutation.
+
+    :param domain_table: name of the CDM table
+    :param input_dataset_id: identifies dataset with source data
+    :param output_dataset_id: NOT USED. Kept for legacy compatibility.
+    :param project_id: identifies GCP project that contains the datasets
+    :param pipeline_dataset_id: identifies pipeline_tables dataset (for person mapping)
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :return:
+    """
+    mapping_source_dataset_id = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    mapping_table = mapping_table_for(domain_table)
+
+    LOGGER.info(f"Creating mapping table {mapping_table}...")
+    q = mapping_query(domain_table, input_dataset_id, project_id,
+                      pipeline_dataset_id, ct_plus_ids_view,
+                      mapping_source_dataset_id, mapping_dataset_id)
+
+    LOGGER.info(f'Query for {mapping_table} is {q}')
+    bq_utils.query(q,
+                   destination_dataset_id=mapping_dataset_id,
+                   destination_table_id=mapping_table,
+                   write_disposition='WRITE_TRUNCATE')
+
+
+def fact_relationship_query(input_dataset_id, project_id, mapping_dataset_id,
+                            mapping_source_dataset_id):
+    """
+    Returns a query that resolves fact_relationship fact ids to their new CT+ values.
+
+    fact_relationship has no primary key and no person_id, so it would otherwise be
+    copied unchanged and its fact ids would dangle against the re-keyed CT+ rows. The
+    table names no foreign key column: each fact id is qualified by the domain concept
+    id beside it, so each side needs one join per domain in DOMAIN_CONCEPT_ID_TO_TABLE.
+
+    Rows whose domain concept id is not in that map, or whose fact id has no mapping
+    row, resolve to NULL and are dropped. This matches how the combined build loads the
+    table (see constants/tools/create_combined_backup_dataset.py FACT_RELATIONSHIP_QUERY,
+    which applies the same filter after remapping measurement and observation).
+
+    :param input_dataset_id: identifies dataset containing source data
+    :param project_id: identifies the GCP project
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :return: the query
+    """
+    case_exprs = {}
+    join_exprs = []
+
+    for side in ('1', '2'):
+        whens = []
+        for index, (domain_concept_id, domain_table) in enumerate(
+                DOMAIN_CONCEPT_ID_TO_TABLE.items()):
+            alias = f'm{index}_{side}'
+            mapping_tbl = mapping_table_for(domain_table)
+            src_field = f'src_{domain_table}_id'
+            id_field = f'{domain_table}_id'
+            whens.append(
+                f'''WHEN fr.domain_concept_id_{side} = {domain_concept_id}
+              THEN {alias}.{id_field}''')
+            join_exprs.append(f'''
+    LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_tbl}` AS {alias}
+      ON fr.fact_id_{side} = {alias}.{src_field}
+     AND fr.domain_concept_id_{side} = {domain_concept_id}
+     AND {alias}.src_table_id = '{mapping_source_dataset_id}.{domain_table}' '''
+                             )
+        case_exprs[side] = '\n            '.join(whens)
+
+    joins = ''.join(join_exprs)
+
+    # The NULL filter sits outside so it can reference the resolved fact ids
+    return f'''
+    SELECT *
+    FROM (
+        SELECT
+            fr.domain_concept_id_1,
+            CASE
+            {case_exprs['1']}
+            END AS fact_id_1,
+            fr.domain_concept_id_2,
+            CASE
+            {case_exprs['2']}
+            END AS fact_id_2,
+            fr.relationship_concept_id
+        FROM `{project_id}.{input_dataset_id}.{FACT_RELATIONSHIP}` AS fr
+        {joins}
+    )
+    WHERE fact_id_1 IS NOT NULL
+      AND fact_id_2 IS NOT NULL
+    '''
+
+
+def table_query(table_name, input_dataset_id, output_dataset_id, project_id,
+                pipeline_dataset_id, ct_plus_ids_view, mapping_dataset_id,
+                mapping_source_dataset_id):
+    """
+    Returns a query to retrieve all records from an input table with new IDs.
+
+    This function constructs a query to select data from the source table and join it
+    with the necessary mapping tables to replace primary and foreign keys with newly
+    generated IDs. It handles special cases for tables like aou_death, survey_conduct,
+    and tables without primary keys.
+
+    :param table_name: one of the domain tables (e.g. 'visit_occurrence', 'condition_occurrence')
+    :param input_dataset_id: identifies dataset containing source data
+    :param output_dataset_id: identifies dataset where final results are stored
+    :param project_id: identifies the GCP project
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+
+    :return: the query
+    """
+    mapping_source_dataset_id = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    person_src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
+                                                      ct_plus_ids_view)
+
+    def _mapping_join(join_table, join_alias, on_field, src_table_alias='t'):
+        """Helper to create a LEFT JOIN expression for a mapping table."""
+        mapping_tbl = mapping_table_for(join_table)
+        src_field = f'src_{join_table}_id'
+        return f'''
+        LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_tbl}` {join_alias}
+          ON {src_table_alias}.{on_field} = {join_alias}.{src_field}
+         AND {join_alias}.src_table_id = '{mapping_source_dataset_id}.{join_table}'
+        '''
+
+    if table_name == FACT_RELATIONSHIP:
+        return fact_relationship_query(input_dataset_id, project_id,
+                                       mapping_dataset_id,
+                                       mapping_source_dataset_id)
+
+    # Fitbit tables do not have a domain-specific primary key. They only need person_id updated.
+    # This logic is similar to tables without a primary key.
+    if table_name in FITBIT_TABLES:
+        fields = fields_for(table_name)
+        col_exprs = [
+            'mp.person_id'
+            if field['name'] == 'person_id' else f"t.{field['name']}"
+            for field in fields
+        ]
+        cols = ',\n        '.join(col_exprs)
+        mapping_person = mapping_table_for(PERSON)
+        return f'''
+    SELECT {cols}
+    FROM `{project_id}.{input_dataset_id}.{table_name}` t
+    LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp ON t.person_id = mp.src_person_id
+    '''
+
+    # Special handling for aou_death - keep aou_death_id but update person_id
+    if table_name == AOU_DEATH:
+        fields = fields_for(table_name)
+        col_exprs = []
+        for field in fields:
+            field_name = field['name']
+            if field_name == 'person_id':
+                col_exprs.append('mp.person_id')
+            else:
+                col_exprs.append(f't.{field_name}')
+        cols = ',\n        '.join(col_exprs)
+        mapping_person = mapping_table_for(PERSON)
+        return f'''
+    SELECT {cols}
+    FROM `{project_id}.{input_dataset_id}.{table_name}` t
+    LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp
+        ON t.person_id = mp.src_person_id AND
+           mp.src_table_id = '{person_src_table_id}'
+    '''
+
+    # Special handling for survey_conduct - update both survey_conduct_id and
+    # survey_source_identifier. This branch returns before the generic foreign key
+    # loop below, so the foreign keys survey_conduct carries are remapped here
+    # explicitly. regenerate_rt_ids.py leaves them at their source values.
+    if table_name == SURVEY_CONDUCT:
+        fields = fields_for(table_name)
+        col_exprs = []
+        for field in fields:
+            field_name = field['name']
+            if field_name == 'survey_conduct_id':
+                col_exprs.append('m.survey_conduct_id')
+            elif field_name == 'survey_source_identifier':
+                # survey_source_identifier should match survey_conduct_id
+                col_exprs.append(
+                    'CAST(m.survey_conduct_id AS STRING) AS survey_source_identifier'
+                )
+            elif field_name == 'person_id':
+                col_exprs.append('mp.person_id')
+            elif field_name == 'provider_id':
+                col_exprs.append('mpr.provider_id')
+            elif field_name == 'visit_occurrence_id':
+                col_exprs.append('mvo.visit_occurrence_id')
+            elif field_name == 'response_visit_occurrence_id':
+                col_exprs.append(
+                    'rvo.visit_occurrence_id AS response_visit_occurrence_id')
+            else:
+                col_exprs.append(f't.{field_name}')
+        cols = ',\n        '.join(col_exprs)
+        mapping_table = mapping_table_for(table_name)
+        mapping_person = mapping_table_for(PERSON)
+        provider_join_expr = _mapping_join(PROVIDER, 'mpr', 'provider_id')
+        visit_occurrence_join_expr = _mapping_join(VISIT_OCCURRENCE, 'mvo',
+                                                   'visit_occurrence_id')
+        response_visit_join_expr = _mapping_join(
+            VISIT_OCCURRENCE, 'rvo', 'response_visit_occurrence_id')
+        return f'''
+    SELECT
+        {cols}
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (PARTITION BY nm.survey_conduct_id) AS row_num
+        FROM
+            `{project_id}.{input_dataset_id}.{table_name}` AS nm) AS t
+    JOIN
+        `{project_id}.{mapping_dataset_id}.{mapping_table}` AS m
+    ON
+        t.survey_conduct_id = m.src_survey_conduct_id AND
+        m.src_table_id = '{mapping_source_dataset_id}.{table_name}'
+    LEFT JOIN
+        `{project_id}.{mapping_dataset_id}.{mapping_person}` AS mp
+    ON
+        t.person_id = mp.src_person_id AND
+        mp.src_table_id = '{person_src_table_id}'
+    {provider_join_expr}
+    {visit_occurrence_join_expr}
+    {response_visit_join_expr}
+    WHERE
+        row_num = 1
+    '''
+
+    # Tables that don't need ID remapping (death only)
+    if table_name in SKIP_ID_REGEN_TABLES:
+        fields = fields_for(table_name)
+        col_exprs = [field['name'] for field in fields]
+        cols = ',\n        '.join(col_exprs)
+        return f'''
+    SELECT {cols} 
+    FROM `{project_id}.{input_dataset_id}.{table_name}`'''
+
+    # Tables without primary keys - copy as-is but update person_id if present
+    if not has_primary_key(table_name):
+        fields = fields_for(table_name)
+        col_exprs = []
+        has_person_id = False
+
+        for field in fields:
+            field_name = field['name']
+            if field_name == 'person_id':
+                col_exprs.append('mp.person_id')
+                has_person_id = True
+            else:
+                col_exprs.append(f't.{field_name}')
+
+        cols = ',\n        '.join(col_exprs)
+
+        if has_person_id:
+            # Join with person mapping if table has person_id
+            mapping_person = mapping_table_for(PERSON)
+            return f'''
+            SELECT {cols}
+            FROM `{project_id}.{input_dataset_id}.{table_name}` t
+            LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp
+                ON t.person_id = mp.src_person_id AND
+                   mp.src_table_id = '{person_src_table_id}'
+            '''
+        else:
+            # No person_id, just copy as-is. The column expressions are still
+            # qualified with t, so the source has to carry that alias.
+            return f'''
+    SELECT {cols}
+    FROM `{project_id}.{input_dataset_id}.{table_name}` t'''
+
+    # Tables that need ID remapping
+    mapping_table = mapping_table_for(table_name)
+    fields = fields_for(table_name)
+    id_col = f'{table_name}_id'
+    col_exprs = []
+
+    # Track which foreign keys are present
+    has_visit_occurrence_id = False
+    has_preceding_visit_occurrence_id = False
+    has_visit_detail_id = False
+    has_preceding_visit_detail_id = False
+    has_visit_detail_parent_id = False
+    has_care_site_id = False
+    has_location_id = False
+    has_note_id = False
+    has_questionnaire_response_id = False
+    has_provider_id = False
+
+    # Track if table has person_id
+    has_person_id = False
+
+    for field in fields:
+        field_name = field['name']
+
+        if field_name == id_col:
+            # Use mapping for record ID column
+            col_expr = f'm.{field_name}'
+        elif field_name == 'person_id' and table_name != PERSON:
+            # Update person_id foreign key with new person_id
+            col_expr = 'mp.person_id'
+            has_person_id = True
+        elif field_name == 'visit_occurrence_id' and table_name != VISIT_OCCURRENCE:
+            col_expr = 'mvo.visit_occurrence_id'
+            has_visit_occurrence_id = True
+        elif field_name == 'preceding_visit_occurrence_id':
+            col_expr = 'pvo.visit_occurrence_id AS preceding_visit_occurrence_id'
+            has_preceding_visit_occurrence_id = True
+        elif field_name == 'visit_detail_id' and table_name != VISIT_DETAIL:
+            col_expr = 'mvd.visit_detail_id'
+            has_visit_detail_id = True
+        elif field_name == 'preceding_visit_detail_id':
+            col_expr = 'pvd.visit_detail_id AS preceding_visit_detail_id'
+            has_preceding_visit_detail_id = True
+        elif field_name == 'visit_detail_parent_id':
+            col_expr = 'ppvd.visit_detail_id AS visit_detail_parent_id'
+            has_visit_detail_parent_id = True
+        elif field_name == 'care_site_id' and table_name != CARE_SITE:
+            col_expr = 'mcs.care_site_id'
+            has_care_site_id = True
+        elif field_name == 'provider_id' and table_name != PROVIDER:
+            # provider is re-keyed in its own table, so every reference to it has to
+            # follow. regenerate_rt_ids.py leaves these at their source values, which
+            # would point CT+ rows at the wrong provider.
+            col_expr = 'mpr.provider_id'
+            has_provider_id = True
+        elif field_name == 'location_id' and table_name != LOCATION:
+            col_expr = 'loc.location_id'
+            has_location_id = True
+        elif field_name == 'note_id' and table_name != NOTE:
+            col_expr = 'ni.note_id'
+            has_note_id = True
+        elif field_name == 'questionnaire_response_id':
+            # questionnaire_response_id maps to survey_conduct_id
+            col_expr = 'mqr.survey_conduct_id AS questionnaire_response_id'
+            has_questionnaire_response_id = True
+        elif field_name in ('snippet', 'offset') and table_name == NOTE_NLP:
+            col_expr = f'CAST({field_name} AS STRING) AS {field_name}'
+        else:
+            col_expr = field_name
+
+        col_exprs.append(col_expr)
+
+    cols = ',\n        '.join(col_exprs)
+
+    # Build JOIN expressions for foreign keys
+    person_join_expr = ''
+    visit_occurrence_join_expr = ''
+    preceding_visit_occurrence_join_expr = ''
+    visit_detail_join_expr = ''
+    preceding_visit_detail_join_expr = ''
+    visit_detail_parent_join_expr = ''
+    location_join_expr = ''
+    care_site_join_expr = ''
+    note_join_expr = ''
+    questionnaire_response_join_expr = ''
+    provider_join_expr = ''
+    visit_detail_filter_expr = ''
+
+    if has_person_id:
+        mapping_person = mapping_table_for(PERSON)
+        person_join_expr = f'''
+        LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp
+            ON t.person_id = mp.src_person_id
+            AND mp.src_table_id = '{person_src_table_id}'
+        '''
+
+    if has_visit_occurrence_id:
+        visit_occurrence_join_expr = _mapping_join(VISIT_OCCURRENCE, 'mvo',
+                                                   'visit_occurrence_id')
+
+    if has_preceding_visit_occurrence_id:
+        preceding_visit_occurrence_join_expr = _mapping_join(
+            VISIT_OCCURRENCE, 'pvo', 'preceding_visit_occurrence_id')
+
+    if has_visit_detail_id:
+        visit_detail_join_expr = _mapping_join(VISIT_DETAIL, 'mvd',
+                                               'visit_detail_id')
+
+    if has_preceding_visit_detail_id:
+        preceding_visit_detail_join_expr = _mapping_join(
+            VISIT_DETAIL, 'pvd', 'preceding_visit_detail_id')
+
+    if has_visit_detail_parent_id:
+        visit_detail_parent_join_expr = _mapping_join(VISIT_DETAIL, 'ppvd',
+                                                      'visit_detail_parent_id')
+
+    if has_care_site_id:
+        care_site_join_expr = _mapping_join(CARE_SITE, 'mcs', 'care_site_id')
+
+    if has_location_id:
+        location_join_expr = _mapping_join(LOCATION, 'loc', 'location_id')
+
+    if has_note_id:
+        note_join_expr = _mapping_join(NOTE, 'ni', 'note_id')
+
+    if has_provider_id:
+        provider_join_expr = _mapping_join(PROVIDER, 'mpr', 'provider_id')
+
+    if has_questionnaire_response_id:
+        # questionnaire_response_id maps to survey_conduct_id
+        mapping_survey_conduct = mapping_table_for(SURVEY_CONDUCT)
+        questionnaire_response_join_expr = f'''
+        LEFT JOIN `{project_id}.{mapping_dataset_id}.{mapping_survey_conduct}` mqr
+            ON t.questionnaire_response_id = mqr.src_survey_conduct_id AND mqr.src_table_id = '{mapping_source_dataset_id}.{SURVEY_CONDUCT}'
+        '''
+
+    if table_name == PERSON:
+        return f'''
+        SELECT
+            {cols}
+        FROM (
+            SELECT
+                *,
+                ROW_NUMBER() OVER (PARTITION BY nm.person_id) AS row_num
+            FROM
+                `{project_id}.{input_dataset_id}.{table_name}` AS nm) AS t
+        JOIN
+            `{project_id}.{mapping_dataset_id}.{mapping_table}` AS m
+        ON
+            t.person_id = m.src_person_id
+        AND m.src_table_id = '{person_src_table_id}'
+        {location_join_expr}
+        {care_site_join_expr}
+        {provider_join_expr}
+        WHERE
+            row_num = 1
+        '''
+
+    if table_name == VISIT_DETAIL:
+        visit_detail_filter_expr = '''
+        AND mvo.visit_occurrence_id IS NOT NULL
+        '''
+
+    # For tables with primary keys that need remapping
+    return f'''
+    SELECT
+        {cols}
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (PARTITION BY nm.{table_name}_id) AS row_num
+        FROM
+            `{project_id}.{input_dataset_id}.{table_name}` AS nm) AS t
+    JOIN (
+        SELECT * EXCEPT(rn) FROM (
+            SELECT *, ROW_NUMBER() OVER(PARTITION BY src_{table_name}_id ORDER BY {table_name}_id) as rn
+            FROM `{project_id}.{mapping_dataset_id}.{mapping_table}`
+            WHERE src_table_id = '{mapping_source_dataset_id}.{table_name}'
+        ) WHERE rn = 1
+    ) AS m
+    ON
+        t.{table_name}_id = m.src_{table_name}_id
+    {person_join_expr}
+    {visit_occurrence_join_expr}
+    {visit_detail_join_expr}
+    {care_site_join_expr}
+    {preceding_visit_occurrence_join_expr}
+    {preceding_visit_detail_join_expr}
+    {visit_detail_parent_join_expr}
+    {location_join_expr}
+    {note_join_expr}
+    {questionnaire_response_join_expr}
+    {provider_join_expr}
+    WHERE
+        row_num = 1
+    {visit_detail_filter_expr}
+    '''
+
+
+def load(client, cdm_table, input_dataset_id, output_dataset_id, project_id,
+         pipeline_dataset_id, ct_plus_ids_view, mapping_dataset_id,
+         mapping_source_dataset_id):
+    """
+    Loads a single domain table into the output dataset with new IDs.
+
+    :param client: BigQueryClient
+    :param cdm_table: name of the CDM table (e.g. 'person', 'visit_occurrence')
+    :param input_dataset_id: identifies dataset containing input data
+    :param output_dataset_id: identifies dataset where result should be output
+    :param project_id: identifies the GCP project
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :return:
+    """
+    mapping_source_dataset_id = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    output_table = output_table_for(cdm_table)
+    LOGGER.info(
+        f'Loading {cdm_table} from {input_dataset_id} into {output_table}')
+
+    # Check if the source table exists before proceeding
+    try:
+        client.get_table(f'{project_id}.{input_dataset_id}.{cdm_table}')
+    except Exception:
+        LOGGER.info(
+            f'Table {cdm_table} not found in source dataset {input_dataset_id}. Skipping.'
+        )
+        return None
+
+    q = table_query(cdm_table, input_dataset_id, output_dataset_id, project_id,
+                    pipeline_dataset_id, ct_plus_ids_view, mapping_dataset_id,
+                    mapping_source_dataset_id)
+    if cdm_table == 'visit_detail' or cdm_table == 'visit_occurrence':
+        LOGGER.info(q)
+    query_result = bq_utils.query(q,
+                                  destination_table_id=output_table,
+                                  destination_dataset_id=output_dataset_id)
+    query_job_id = query_result['jobReference']['jobId']
+    bq_utils.wait_on_jobs([query_job_id])
+    LOGGER.info(f'Job {query_job_id} completed for {cdm_table}')
+    return query_result
+
+
+def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
+                     project_id, mapping_dataset_id, pipeline_dataset_id,
+                     ct_plus_ids_view, mapping_source_dataset_id):
+    """
+    Update an extension table with new IDs from its corresponding mapping table.
+
+    :param ext_table_name: name of the extension table (e.g. 'person_ext')
+    :param input_dataset_id: identifies dataset containing source data
+    :param output_dataset_id: identifies dataset where result should be output
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param project_id: identifies the GCP project
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset (for person mapping)
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+
+    :return: query result
+    """
+    # Extract base table name (e.g. 'person' from 'person_ext')
+    base_table = ext_table_name.replace('_ext', '')
+    id_field = f'{base_table}_id'
+    mapping_table = mapping_table_for(base_table)
+
+    # Check if ext table exists
+    try:
+        client = BigQueryClient(project_id)  # Re-instantiate to be safe
+        client.get_table(f'{input_dataset_id}.{ext_table_name}')
+    except Exception:
+        LOGGER.info(
+            f'Extension table {ext_table_name} does not exist, skipping')
+        return None
+
+    LOGGER.info(f'Updating extension table {ext_table_name}')
+
+    # Use the original source dataset for the join condition if provided, else use current input
+    source_dataset = mapping_source_dataset_id if mapping_source_dataset_id else input_dataset_id
+    person_src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
+                                                      ct_plus_ids_view)
+
+    q = f'''
+    SELECT
+        m.{id_field},
+        e.* EXCEPT({id_field})
+    FROM `{project_id}.{input_dataset_id}.{ext_table_name}` e
+    JOIN `{project_id}.{mapping_dataset_id}.{mapping_table}` m
+        ON e.{id_field} = m.src_{id_field} AND m.src_table_id = '{source_dataset}.{base_table}'
+        '''
+
+    if base_table == PERSON:
+        q = f'''
+    SELECT
+        m.{id_field},
+        e.* EXCEPT({id_field})
+    FROM `{project_id}.{input_dataset_id}.{ext_table_name}` e
+    JOIN `{project_id}.{mapping_dataset_id}.{mapping_table}` m
+        ON e.{id_field} = m.src_{id_field}
+        AND m.src_table_id = '{person_src_table_id}'
+    '''
+
+    return bq_utils.query(q,
+                          destination_table_id=ext_table_name,
+                          destination_dataset_id=output_dataset_id,
+                          write_disposition='WRITE_TRUNCATE')
+
+
+def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
+         ct_plus_ids_view, mapping_dataset_id, mapping_source_dataset_id):
+    """
+    Create a new CDM dataset with regenerated IDs
+
+    :param input_dataset_id: identifies the source dataset
+    :param output_dataset_id: identifies the dataset to store the new CDM in
+    :param project_id: project containing the datasets
+    :param mapping_dataset_id: dataset to store/lookup mapping tables
+    :param pipeline_dataset_id: dataset containing rdr_participant_research_ids_view for person mapping
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_source_dataset_id: original dataset used to create the mappings
+    :returns: list of tables generated successfully
+    """
+    bq_client = BigQueryClient(project_id)
+    person_src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
+                                                      ct_plus_ids_view)
+
+    LOGGER.info('CT+ ID regeneration started')
+
+    # Create mapping dataset if it doesn't exist
+    try:
+        bq_client.get_dataset(mapping_dataset_id)
+        LOGGER.info(f'Dataset {mapping_dataset_id} already exists')
+    except Exception:
+        LOGGER.info(f'Creating dataset {mapping_dataset_id}')
+        bq_client.create_dataset(mapping_dataset_id, exists_ok=True)
+
+    # Refuse to run against a mapping dataset another tier produced. Doing so would
+    # reuse that tier's _mapping_person and give CT+ its person_ids.
+    assert_person_mapping_is_ct_plus(bq_client, project_id, mapping_dataset_id,
+                                     pipeline_dataset_id, ct_plus_ids_view)
+
+    # Create output dataset if it doesn't exist
+    try:
+        bq_client.get_dataset(output_dataset_id)
+        LOGGER.info(f'Dataset {output_dataset_id} already exists')
+    except Exception:
+        LOGGER.info(f'Creating dataset {output_dataset_id}')
+        bq_client.create_dataset(output_dataset_id, exists_ok=True)
+
+    # Create empty output tables to ensure proper schema, clustering, etc.
+    for table in CDM_TABLES:
+        result_table = output_table_for(table)
+        LOGGER.info(f'Creating {output_dataset_id}.{result_table}...')
+
+        # Get schema for the table
+        schema_list = bq_client.get_table_schema(table)
+
+        # Create table with proper schema and clustering
+        fq_table_name = f'{project_id}.{output_dataset_id}.{result_table}'
+
+        clustering_fields = None
+        # Add clustering for tables with person_id
+        if any(field.name == 'person_id' for field in schema_list):
+            clustering_fields = ['person_id']
+
+        table_to_create = Table(fq_table_name, schema=schema_list)
+        if clustering_fields:
+            table_to_create.clustering_fields = clustering_fields
+
+        bq_client.delete_table(fq_table_name, not_found_ok=True)
+        bq_client.create_table(table_to_create)
+
+    # Create mapping tables if they don't already exist
+    LOGGER.info(f'Generating mapping tables in {mapping_dataset_id}...')
+    for domain_table in CDM_TABLES:
+        if domain_table in SKIP_ID_REGEN_TABLES or not has_primary_key(
+                domain_table):
+            continue
+
+        mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
+                pipeline_dataset_id, ct_plus_ids_view,
+                mapping_source_dataset_id, mapping_dataset_id)
+
+    # Load all tables with new IDs
+    for table_name in CDM_TABLES:
+        if table_name == DEATH:
+            LOGGER.info(f'Skipping {table_name} load.')
+            continue
+        LOGGER.info(f'Loading table {table_name}...')
+        load(bq_client, table_name, input_dataset_id, output_dataset_id,
+             project_id, pipeline_dataset_id, ct_plus_ids_view,
+             mapping_dataset_id, mapping_source_dataset_id)
+
+    # Load Fitbit tables if they exist
+    LOGGER.info('Processing Fitbit tables (if they exist)...')
+    for fitbit_table in FITBIT_TABLES:
+        if bq_client.table_exists(fitbit_table, input_dataset_id):
+            LOGGER.info(f'Loading Fitbit table {fitbit_table}...')
+            load(bq_client, fitbit_table, input_dataset_id, output_dataset_id,
+                 project_id, pipeline_dataset_id, ct_plus_ids_view,
+                 mapping_dataset_id, mapping_source_dataset_id)
+        else:
+            LOGGER.info(f'Fitbit table {fitbit_table} does not exist, skipping')
+
+    # Update extension tables with new IDs
+    LOGGER.info('Updating extension tables...')
+    for ext_table in EXT_TABLES:
+        update_ext_table(ext_table, input_dataset_id, output_dataset_id,
+                         project_id, mapping_dataset_id, pipeline_dataset_id,
+                         ct_plus_ids_view, mapping_source_dataset_id)
+
+    # Discover and process any remaining tables
+    tables_to_skip = set(CDM_TABLES) | set(FITBIT_TABLES) | set(EXT_TABLES)
+    copy_only_tables = set(VOCABULARY_TABLES) | set(ACHILLES_TABLES) | set(
+        ACHILLES_HEEL_TABLES)
+
+    all_input_tables = [
+        table.table_id for table in bq_client.list_tables(input_dataset_id)
+    ]
+
+    unprocessed_tables = [
+        t for t in all_input_tables
+        if t not in tables_to_skip and t not in copy_only_tables
+    ]
+
+    LOGGER.info(
+        f"Processing other tables: {', '.join(unprocessed_tables) if unprocessed_tables else 'None'}"
+    )
+
+    for table_name in unprocessed_tables:
+        table = bq_client.get_table(
+            f'{project_id}.{input_dataset_id}.{table_name}')
+        schema = table.schema
+        id_field = f'{table_name}_id'
+        has_person_id = any(field.name == 'person_id' for field in schema)
+        has_pk = any(field.name == id_field for field in schema)
+
+        if has_person_id and has_pk:
+            LOGGER.info(
+                f"Table '{table_name}' has a primary key and person_id. Full remapping will be applied."
+            )
+            # 1. Create mapping for the primary key
+            LOGGER.info(f"Creating mapping for {table_name}...")
+            mapping(table_name, input_dataset_id, output_dataset_id, project_id,
+                    pipeline_dataset_id, ct_plus_ids_view,
+                    mapping_source_dataset_id, mapping_dataset_id)
+            # 2. Load table with remapped PK and FKs
+            LOGGER.info(f"Loading table {table_name}...")
+            load(bq_client, table_name, input_dataset_id, output_dataset_id,
+                 project_id, pipeline_dataset_id, ct_plus_ids_view,
+                 mapping_dataset_id, mapping_source_dataset_id)
+        elif has_person_id:
+            LOGGER.info(
+                f"Table '{table_name}' has person_id. Remapping person_id only."
+            )
+            col_exprs = [
+                'mp.person_id'
+                if field.name == 'person_id' else f't.{field.name}'
+                for field in schema
+            ]
+            cols = ', '.join(col_exprs)
+            mapping_person = mapping_table_for(PERSON)
+            q = f"""SELECT {cols}
+                    FROM `{project_id}.{input_dataset_id}.{table_name}` t
+                    JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp
+                        ON t.person_id = mp.src_person_id
+                        AND mp.src_table_id = '{person_src_table_id}'"""
+            bq_utils.query(q,
+                           destination_table_id=table_name,
+                           destination_dataset_id=output_dataset_id,
+                           write_disposition='WRITE_TRUNCATE')
+        else:
+            LOGGER.info(
+                f"Table '{table_name}' has no person_id. Copying as-is.")
+            bq_client.copy_table(
+                f'{project_id}.{input_dataset_id}.{table_name}',
+                f'{project_id}.{output_dataset_id}.{table_name}')
+
+    # Copy vocabulary and Achilles tables directly
+    LOGGER.info(
+        f"Copying vocabulary and Achilles tables: {', '.join(copy_only_tables)}"
+    )
+    for table_name in copy_only_tables:
+        if bq_client.table_exists(table_name, input_dataset_id):
+            bq_client.copy_table(
+                f'{project_id}.{input_dataset_id}.{table_name}',
+                f'{project_id}.{output_dataset_id}.{table_name}')
+
+    LOGGER.info('CT+ ID regeneration complete')
+
+
+if __name__ == '__main__':
+    pipeline_logging.configure(logging.INFO, add_console_handler=True)
+    parser = argparse.ArgumentParser(
+        description='Regenerate IDs in a Controlled Tier Plus dataset',
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--project_id',
+                        dest='project_id',
+                        required=True,
+                        help='Project associated with the datasets')
+    parser.add_argument('--input_dataset_id',
+                        dest='input_dataset_id',
+                        required=True,
+                        help='Dataset containing source data')
+    parser.add_argument('--output_dataset_id',
+                        dest='output_dataset_id',
+                        required=True,
+                        help='Dataset where results should be stored')
+    parser.add_argument(
+        '--pipeline_dataset_id',
+        dest='pipeline_dataset_id',
+        required=True,
+        help=
+        'Dataset containing rdr_participant_research_ids_view for person mapping'
+    )
+    parser.add_argument(
+        '--ct_plus_ids_view',
+        dest='ct_plus_ids_view',
+        required=True,
+        help=
+        'View containing controlled_tier_id to controlled_tier_plus_id mapping')
+    parser.add_argument(
+        '--mapping_dataset_id',
+        dest='mapping_dataset_id',
+        required=True,
+        help='Dataset to store/lookup mapping tables. Can be a sandbox dataset.'
+    )
+    parser.add_argument(
+        '--mapping_source_dataset_id',
+        dest='mapping_source_dataset_id',
+        required=False,
+        help=
+        'Original dataset mappings were created from, if different from input.')
+
+    args = parser.parse_args()
+    main(args.input_dataset_id, args.output_dataset_id, args.project_id,
+         args.pipeline_dataset_id, args.ct_plus_ids_view,
+         args.mapping_dataset_id, args.mapping_source_dataset_id)

--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -88,8 +88,7 @@ Usage:
 """
 import argparse
 import logging
-from google.cloud.bigquery import Table
-import bq_utils
+from google.cloud.bigquery import QueryJobConfig, Table
 
 from common import (AOU_DEATH, DEATH, MAPPING_PREFIX, PERSON, SURVEY_CONDUCT,
                     VISIT_DETAIL, VISIT_OCCURRENCE, CARE_SITE, LOCATION, NOTE,
@@ -143,12 +142,18 @@ DOMAIN_CONCEPT_ID_TO_TABLE = {
 }
 
 # Extension tables that need ID updates
+# Every _ext table whose parent gets re-keyed has to be listed here. One that is
+# missing does not fail: it falls through to the schema sniffing path at the end of
+# main(), matches 'no person_id, copy as-is', and is copied verbatim, so its ids still
+# point at the CT values while its parent has been re-keyed. specimen_ext and
+# visit_detail_ext were absent and were being copied that way, 44.8M and 48.1M rows
+# of dangling references in V9.
 EXT_TABLES = [
-    'person_ext', 'visit_occurrence_ext', 'condition_occurrence_ext',
-    'device_exposure_ext', 'drug_exposure_ext', 'measurement_ext', 'note_ext',
-    'note_nlp_ext', 'observation_ext', 'observation_period_ext',
-    'procedure_occurrence_ext', 'survey_conduct_ext', 'condition_era_ext',
-    'drug_era_ext'
+    'person_ext', 'visit_occurrence_ext', 'visit_detail_ext',
+    'condition_occurrence_ext', 'device_exposure_ext', 'drug_exposure_ext',
+    'measurement_ext', 'note_ext', 'note_nlp_ext', 'observation_ext',
+    'observation_period_ext', 'procedure_occurrence_ext', 'specimen_ext',
+    'survey_conduct_ext', 'condition_era_ext', 'drug_era_ext'
 ]
 
 
@@ -315,6 +320,53 @@ def assert_person_mapping_is_ct_plus(client, project_id, mapping_dataset_id,
             f'or one from a previous CT+ run.')
 
 
+def run_query_to_table(project_id,
+                       q,
+                       destination_dataset_id,
+                       destination_table_id,
+                       write_disposition='WRITE_TRUNCATE'):
+    """
+    Run a query into a destination table, in project_id, and wait for it to finish.
+
+    Every write in this script goes through here rather than through bq_utils.query,
+    for two reasons that together let a run destroy nothing, report success, and
+    produce an empty dataset:
+
+    bq_utils.query takes its destination project from app_identity.get_application_id(),
+    which reads $GOOGLE_CLOUD_PROJECT and ignores --project_id entirely. A run whose
+    environment points at another project submits every job there. Whether that writes
+    to the wrong project or merely fails depends on whether the destination dataset
+    happens to exist there.
+
+    It also submits with jobs().insert() and returns the handle without polling, so a
+    failed job is indistinguishable from a successful one. On 2026-08-05 a full run
+    logged 'CT+ ID regeneration complete' and exited 0 while all 90-odd of its jobs sat
+    in FAILURE state in an unrelated project.
+
+    job.result() below blocks and raises, and the destination is fully qualified with
+    project_id, so neither is possible.
+
+    :param project_id: identifies the GCP project the job runs and writes in
+    :param q: the query to run
+    :param destination_dataset_id: dataset the results are written to
+    :param destination_table_id: table the results are written to
+    :param write_disposition: WRITE_TRUNCATE, WRITE_APPEND or WRITE_EMPTY
+    :return: the completed QueryJob
+    :raises google.api_core.exceptions.GoogleAPICallError: if the job failed
+    """
+    client = BigQueryClient(project_id)
+    job = client.query(
+        q,
+        job_config=QueryJobConfig(
+            destination=
+            f'{project_id}.{destination_dataset_id}.{destination_table_id}',
+            write_disposition=write_disposition))
+    job.result()
+    LOGGER.info(f'Job {job.job_id} wrote '
+                f'{destination_dataset_id}.{destination_table_id}')
+    return job
+
+
 def assert_person_mapping_is_one_to_one(client, project_id, mapping_dataset_id):
     """
     Stop the run if _mapping_person is not one row per participant, both ways.
@@ -447,10 +499,11 @@ def mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
                       mapping_dataset_id, append)
 
     LOGGER.info(f'Query for {mapping_table} is {q}')
-    bq_utils.query(q,
-                   destination_dataset_id=mapping_dataset_id,
-                   destination_table_id=mapping_table,
-                   write_disposition=write_disposition)
+    run_query_to_table(project_id,
+                       q,
+                       destination_dataset_id=mapping_dataset_id,
+                       destination_table_id=mapping_table,
+                       write_disposition=write_disposition)
 
 
 def fact_relationship_query(input_dataset_id, project_id, mapping_dataset_id,
@@ -934,13 +987,13 @@ def load(client, cdm_table, input_dataset_id, output_dataset_id, project_id,
                     mapping_namespace)
     if cdm_table == 'visit_detail' or cdm_table == 'visit_occurrence':
         LOGGER.info(q)
-    query_result = bq_utils.query(q,
-                                  destination_table_id=output_table,
-                                  destination_dataset_id=output_dataset_id)
-    query_job_id = query_result['jobReference']['jobId']
-    bq_utils.wait_on_jobs([query_job_id])
-    LOGGER.info(f'Job {query_job_id} completed for {cdm_table}')
-    return query_result
+    # wait_on_jobs used to be called here, but it only waits: it never inspects the
+    # job's error result, so a failed load was indistinguishable from a loaded table.
+    return run_query_to_table(project_id,
+                              q,
+                              destination_dataset_id=output_dataset_id,
+                              destination_table_id=output_table,
+                              write_disposition='WRITE_EMPTY')
 
 
 def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
@@ -1001,10 +1054,11 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
         AND m.src_table_id = '{person_src_table_id}'
     '''
 
-    return bq_utils.query(q,
-                          destination_table_id=ext_table_name,
-                          destination_dataset_id=output_dataset_id,
-                          write_disposition='WRITE_TRUNCATE')
+    return run_query_to_table(project_id,
+                              q,
+                              destination_dataset_id=output_dataset_id,
+                              destination_table_id=ext_table_name,
+                              write_disposition='WRITE_TRUNCATE')
 
 
 def main(input_dataset_id,
@@ -1182,10 +1236,11 @@ def main(input_dataset_id,
                     JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp
                         ON t.person_id = mp.src_person_id
                         AND mp.src_table_id = '{person_src_table_id}'"""
-            bq_utils.query(q,
-                           destination_table_id=table_name,
-                           destination_dataset_id=output_dataset_id,
-                           write_disposition='WRITE_TRUNCATE')
+            run_query_to_table(project_id,
+                               q,
+                               destination_dataset_id=output_dataset_id,
+                               destination_table_id=table_name,
+                               write_disposition='WRITE_TRUNCATE')
         else:
             LOGGER.info(
                 f"Table '{table_name}' has no person_id. Copying as-is.")

--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -320,6 +320,80 @@ def assert_person_mapping_is_ct_plus(client, project_id, mapping_dataset_id,
             f'or one from a previous CT+ run.')
 
 
+def assert_person_ids_have_not_moved(client, project_id, mapping_dataset_id,
+                                     pipeline_dataset_id, ct_plus_ids_view):
+    """
+    Stop the run if a participant's CT+ person_id changed since the previous run.
+
+    Every other mapping table persists ids by appending: the mapping is the durable
+    record, so a source row that shifts underneath still keeps the CT+ id it was first
+    given. _mapping_person cannot work that way. It does not mint ids, it mirrors the
+    ones the RDR assigned in the ids view, so it is rebuilt with WRITE_TRUNCATE on
+    every run and whatever the view says this time simply becomes the answer.
+
+    That leaves person id persistence resting on the view alone, with nothing watching
+    it. If the view ever re-issues controlled_tier_plus_id values, every CT+ person_id
+    changes and every foreign key in every loaded table follows, while domain row ids
+    stay pinned by their own mappings. The release would ship with a row carrying the
+    same observation_id as last time attached to a different participant, and no error
+    anywhere. This check turns that into a stopped run.
+
+    A participant who has left the view is not an error: withdrawals happen and the
+    mapping simply carries a row the view no longer matches. Only a participant present
+    in both, under a changed CT+ id, fails.
+
+    :param client: BigQueryClient
+    :param project_id: identifies the GCP project
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :raises RuntimeError: if any carried over participant's CT+ id has changed
+    """
+    mapping_person = mapping_table_for(PERSON)
+    if not client.table_exists(mapping_person, mapping_dataset_id):
+        return
+
+    expected = person_mapping_src_table_id(pipeline_dataset_id,
+                                           ct_plus_ids_view)
+    # DISTINCT on the view side for the same reason mapping_query() uses it: the view
+    # has been observed carrying byte identical duplicate rows, and joining against
+    # them would multiply the comparison rather than fail it.
+    q = f'''
+    WITH v AS (
+        SELECT DISTINCT
+            {CT_PERSON_ID_COLUMN} AS src_person_id,
+            {CT_PLUS_PERSON_ID_COLUMN} AS person_id
+        FROM `{project_id}.{pipeline_dataset_id}.{ct_plus_ids_view}`
+        WHERE {CT_PERSON_ID_COLUMN} IS NOT NULL
+          AND {CT_PLUS_PERSON_ID_COLUMN} IS NOT NULL
+    )
+    SELECT
+        COUNT(*) AS shared_count,
+        COUNTIF(m.person_id != v.person_id) AS moved_count,
+        ARRAY_AGG(IF(m.person_id != v.person_id, m.src_person_id, NULL)
+                  IGNORE NULLS LIMIT 5) AS examples
+    FROM `{project_id}.{mapping_dataset_id}.{mapping_person}` m
+    JOIN v USING (src_person_id)
+    WHERE m.src_table_id = '{expected}'
+    '''
+    row = list(client.query(q).result())[0]
+    shared_count, moved_count = row['shared_count'], row['moved_count']
+    if not moved_count:
+        LOGGER.info(
+            f'{mapping_person}: {shared_count} participants carried over '
+            f'from the previous run, all with unchanged CT+ ids.')
+        return
+
+    raise RuntimeError(
+        f'{mapping_dataset_id}.{mapping_person} disagrees with '
+        f'{pipeline_dataset_id}.{ct_plus_ids_view}: {moved_count} of {shared_count} '
+        f'carried over participants have a different CT+ id than they were given '
+        f'before, for example {sorted(row["examples"])}. Rebuilding the mapping would '
+        f'adopt the new ids silently and re-key those participants across every table '
+        f'while domain row ids stay put. Establish why the view changed before '
+        f'rerunning.')
+
+
 def run_query_to_table(project_id,
                        q,
                        destination_dataset_id,
@@ -421,8 +495,12 @@ def assert_output_dataset_is_safe(client, output_dataset_id, allow_replace):
     anything, so a mistyped or stale --output_dataset_id destroys whatever is there
     with no prompt and no way back: the delete is followed immediately by a create
     under the same name, which can put the prior version out of reach of time travel.
-    Nothing else in this script is destructive, so this one check covers the whole
-    blast radius.
+
+    This check covers the output dataset only. --mapping_dataset_id is destructive too,
+    because _mapping_person is rebuilt with WRITE_TRUNCATE on every run, but that one
+    replaces a table's contents rather than dropping the table, so time travel still
+    reaches the prior version. assert_person_mapping_is_ct_plus() and
+    assert_person_ids_have_not_moved() are what guard that dataset.
 
     An empty or absent dataset passes. A non-empty one requires --allow_replace, which
     exists so re-running a release is possible but has to be typed deliberately.
@@ -1099,6 +1177,12 @@ def main(input_dataset_id,
     # Refuse to run against a mapping dataset another tier produced. Doing so would
     # reuse that tier's _mapping_person and give CT+ its person_ids.
     assert_person_mapping_is_ct_plus(bq_client, project_id, mapping_dataset_id,
+                                     pipeline_dataset_id, ct_plus_ids_view)
+
+    # Refuse to re-key participants who already have a CT+ id. This has to run before
+    # the mapping loop below, which rebuilds _mapping_person with WRITE_TRUNCATE and
+    # so destroys the evidence it compares against.
+    assert_person_ids_have_not_moved(bq_client, project_id, mapping_dataset_id,
                                      pipeline_dataset_id, ct_plus_ids_view)
 
     # Refuse to destroy an output dataset that already holds tables. This must come

--- a/data_steward/tools/regenerate_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_ct_plus_ids.py
@@ -224,8 +224,14 @@ def mapping_query(table_name,
     if table_name == PERSON and pipeline_dataset_id:
         src_table_id = person_mapping_src_table_id(pipeline_dataset_id,
                                                    ct_plus_ids_view)
+        # DISTINCT because the ids view has been observed carrying byte identical
+        # duplicate participant rows. Every person join here is a LEFT JOIN, so a
+        # second row for one participant does not fail, it doubles that participant's
+        # rows in every loaded table. DISTINCT only collapses duplicates that agree on
+        # both ids; a participant carrying two different CT+ ids still survives it, and
+        # that case is what assert_person_mapping_is_one_to_one() catches.
         return f'''
-        SELECT
+        SELECT DISTINCT
             '{src_table_id}' AS src_table_id,
             {CT_PERSON_ID_COLUMN} AS src_person_id,
             {CT_PLUS_PERSON_ID_COLUMN} AS person_id
@@ -307,6 +313,93 @@ def assert_person_mapping_is_ct_plus(client, project_id, mapping_dataset_id,
             f'{sorted(unexpected)}, which was not produced by a CT+ run. '
             f'Expected {expected}. Point --mapping_dataset_id at an empty dataset '
             f'or one from a previous CT+ run.')
+
+
+def assert_person_mapping_is_one_to_one(client, project_id, mapping_dataset_id):
+    """
+    Stop the run if _mapping_person is not one row per participant, both ways.
+
+    This is checked after the mapping is built and before any table is loaded, because
+    neither direction fails on its own. Every person join is a LEFT JOIN keyed on
+    src_person_id, so one participant holding two CT+ ids silently doubles that
+    participant's rows in every loaded table. One CT+ id held by two participants is
+    worse and just as quiet: it merges two people into one in the released data.
+
+    The DISTINCT in mapping_query() already absorbs whole row duplicates from the ids
+    view, which have been observed there and are harmless. What is left for this check
+    is the disagreeing case, which is a genuine upstream defect and must not be
+    absorbed.
+
+    :param client: BigQueryClient
+    :param project_id: identifies the GCP project
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :raises RuntimeError: if any participant or any CT+ id appears more than once
+    """
+    mapping_person = mapping_table_for(PERSON)
+    if not client.table_exists(mapping_person, mapping_dataset_id):
+        return
+
+    q = f'''
+    SELECT
+        COUNT(*) AS row_count,
+        COUNT(DISTINCT src_person_id) AS src_count,
+        COUNT(DISTINCT person_id) AS ct_plus_count
+    FROM `{project_id}.{mapping_dataset_id}.{mapping_person}`
+    '''
+    row = list(client.query(q).result())[0]
+    row_count, src_count, ct_plus_count = (row['row_count'], row['src_count'],
+                                           row['ct_plus_count'])
+    if row_count == src_count == ct_plus_count:
+        return
+
+    raise RuntimeError(
+        f'{mapping_dataset_id}.{mapping_person} is not one to one: {row_count} rows '
+        f'over {src_count} participants and {ct_plus_count} CT+ ids. '
+        f'{"Some participant carries more than one CT+ id. " if src_count < row_count else ""}'
+        f'{"Some CT+ id is shared by more than one participant. " if ct_plus_count < row_count else ""}'
+        f'Loading against this mapping would duplicate or merge participants across '
+        f'every table. Fix the ids view before rerunning.')
+
+
+def assert_output_dataset_is_safe(client, output_dataset_id, allow_replace):
+    """
+    Stop the run if the output dataset already holds tables.
+
+    main() deletes and recreates every CDM table in the output dataset before loading
+    anything, so a mistyped or stale --output_dataset_id destroys whatever is there
+    with no prompt and no way back: the delete is followed immediately by a create
+    under the same name, which can put the prior version out of reach of time travel.
+    Nothing else in this script is destructive, so this one check covers the whole
+    blast radius.
+
+    An empty or absent dataset passes. A non-empty one requires --allow_replace, which
+    exists so re-running a release is possible but has to be typed deliberately.
+
+    :param client: BigQueryClient
+    :param output_dataset_id: identifies the dataset the run would write to
+    :param allow_replace: True if the caller has accepted that existing tables go away
+    :raises RuntimeError: if the dataset holds tables and allow_replace is False
+    """
+    if allow_replace:
+        LOGGER.info(
+            f'--allow_replace given, existing tables in {output_dataset_id} '
+            f'will be replaced.')
+        return
+
+    try:
+        existing = [
+            table.table_id for table in client.list_tables(output_dataset_id)
+        ]
+    except Exception:
+        # No dataset yet. main() creates it further down.
+        return
+
+    if existing:
+        raise RuntimeError(
+            f'{output_dataset_id} already holds {len(existing)} tables, for example '
+            f'{sorted(existing)[:5]}. This run would delete every CDM table in it '
+            f'before loading. Point --output_dataset_id at a new or empty dataset, '
+            f'or pass --allow_replace if replacing them is intended.')
 
 
 def mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
@@ -914,8 +1007,14 @@ def update_ext_table(ext_table_name, input_dataset_id, output_dataset_id,
                           write_disposition='WRITE_TRUNCATE')
 
 
-def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
-         ct_plus_ids_view, mapping_dataset_id, mapping_namespace):
+def main(input_dataset_id,
+         output_dataset_id,
+         project_id,
+         pipeline_dataset_id,
+         ct_plus_ids_view,
+         mapping_dataset_id,
+         mapping_namespace,
+         allow_replace=False):
     """
     Create a new CDM dataset with regenerated IDs
 
@@ -926,6 +1025,7 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
     :param pipeline_dataset_id: dataset containing rdr_participant_research_ids_view for person mapping
     :param ct_plus_ids_view: view containing person_id to CT+ id mapping
     :param mapping_namespace: original dataset used to create the mappings
+    :param allow_replace: True to permit deleting tables already in the output dataset
     :returns: list of tables generated successfully
     """
     bq_client = BigQueryClient(project_id)
@@ -946,6 +1046,10 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
     # reuse that tier's _mapping_person and give CT+ its person_ids.
     assert_person_mapping_is_ct_plus(bq_client, project_id, mapping_dataset_id,
                                      pipeline_dataset_id, ct_plus_ids_view)
+
+    # Refuse to destroy an output dataset that already holds tables. This must come
+    # before the delete loop below, which drops every CDM table in it.
+    assert_output_dataset_is_safe(bq_client, output_dataset_id, allow_replace)
 
     # Create output dataset if it doesn't exist
     try:
@@ -988,6 +1092,11 @@ def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
         mapping(domain_table, input_dataset_id, output_dataset_id, project_id,
                 pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
                 mapping_dataset_id)
+
+    # Refuse to load against a person mapping that would duplicate or merge
+    # participants. This has to come after the mapping loop that builds it.
+    assert_person_mapping_is_one_to_one(bq_client, project_id,
+                                        mapping_dataset_id)
 
     # Load all tables with new IDs
     for table_name in CDM_TABLES:
@@ -1141,8 +1250,15 @@ if __name__ == '__main__':
         help='Constant stamped into src_table_id on every mapping row. Leave at '
         f"the default ('{DEFAULT_MAPPING_NAMESPACE}'); a per release value breaks "
         'id persistence silently.')
+    parser.add_argument(
+        '--allow_replace',
+        dest='allow_replace',
+        action='store_true',
+        help='Permit deleting the tables already in --output_dataset_id. Without '
+        'this the run stops rather than destroying them. Only needed when '
+        'rebuilding an output dataset on purpose.')
 
     args = parser.parse_args()
     main(args.input_dataset_id, args.output_dataset_id, args.project_id,
          args.pipeline_dataset_id, args.ct_plus_ids_view,
-         args.mapping_dataset_id, args.mapping_namespace)
+         args.mapping_dataset_id, args.mapping_namespace, args.allow_replace)

--- a/data_steward/tools/regenerate_etm_ct_plus_ids.py
+++ b/data_steward/tools/regenerate_etm_ct_plus_ids.py
@@ -1,0 +1,414 @@
+"""
+Regenerate Primary Key IDs in a Controlled Tier Plus (CT+) Dataset for ETM Tables.
+
+The four Explore the Mind tables (delaydiscounting, emorecog, flanker, gradcpt) are not
+in CDM_TABLES, so regenerate_ct_plus_ids.py leaves them to its runtime schema detection
+path, which remaps person_id and copies every other column through. Their sitting_id
+primary key therefore reaches CT+ identical to its CT value, and a holder of both tiers
+can join on it, align rows one to one, and recover the CT to CT+ person_id
+correspondence for every participant with ETM data. That is the alignment the whole
+re-key exists to prevent.
+
+This script is the CT+ counterpart of regenerate_etm_rt_ids.py. Run it AFTER
+regenerate_ct_plus_ids.py, against the same input, output and mapping datasets. It
+replaces the four ETM tables that run copied, and touches nothing else.
+
+It differs from regenerate_etm_rt_ids.py in five ways, each of which is a defect in that
+script rather than a tier difference:
+
+1) sitting_id is a random permutation rather than ROW_NUMBER() ORDER BY sitting_id. An
+   order preserving draw is undone by sorting, which is the whole exposure.
+
+2) The sitting_id mapping is appended to across releases rather than rebuilt, so a row
+   published once keeps its CT+ sitting_id. The RT script writes WRITE_TRUNCATE and
+   reassigns every id on every run.
+
+3) The person join matches the CT+ src_table_id stamp from person_mapping_src_table_id()
+   rather than a hardcoded Registered Tier view name. Matching the wrong stamp would
+   hand CT+ the RT person_ids with no error.
+
+4) Writes go through run_query_to_table(), so the destination project comes from
+   --project_id and a failed job fails the run. bq_utils.query does neither.
+
+5) Rows dropped by the mapping joins are counted and raise, rather than vanishing. The
+   RT script inner joins both mappings and reports nothing.
+
+Usage:
+  python regenerate_etm_ct_plus_ids.py \
+    --project_id <project> \
+    --input_dataset_id <controlled_tier_dataset> \
+    --output_dataset_id <controlled_tier_plus_dataset> \
+    --pipeline_dataset_id <pipeline_tables_dataset> \
+    --ct_plus_ids_view <rdr_participant_research_ids_view> \
+    --mapping_dataset_id <mapping_tables_dataset>
+"""
+import argparse
+import logging
+
+from google.cloud.bigquery import Table
+
+from common import PERSON
+from gcloud.bq import BigQueryClient
+from tools.regenerate_ct_plus_ids import (
+    DEFAULT_MAPPING_NAMESPACE, assert_person_ids_have_not_moved,
+    assert_person_mapping_is_ct_plus, assert_person_mapping_is_one_to_one,
+    mapping_table_for, person_mapping_src_table_id, run_query_to_table)
+from utils import pipeline_logging
+
+LOGGER = logging.getLogger(__name__)
+
+# The ETM tables, matching ETM_TABLES in regenerate_etm_rt_ids.py.
+ETM_TABLES = ['delaydiscounting', 'emorecog', 'flanker', 'gradcpt']
+
+# Every ETM table keys on this rather than on <table>_id, which is why these tables
+# cannot go through regenerate_ct_plus_ids.py's mapping loop as they stand.
+ETM_ID_COLUMN = 'sitting_id'
+
+
+def mapping_query(table_name,
+                  input_dataset_id,
+                  project_id,
+                  mapping_namespace,
+                  mapping_dataset_id,
+                  append=False):
+    """
+    Get the query that assigns new sitting_id values for one ETM table.
+
+    Mirrors the domain table branch of regenerate_ct_plus_ids.mapping_query(), including
+    the append semantics, and differs only in keying on sitting_id instead of
+    <table>_id. Kept as its own function rather than parameterising the original,
+    because the original derives its id column from the table name.
+
+    :param table_name: name of the ETM table
+    :param input_dataset_id: identifies the BQ dataset containing the input table
+    :param project_id: identifies the GCP project containing the dataset
+    :param mapping_namespace: constant stamped into src_table_id
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param append: if True, preserve existing mappings and only draw ids for new rows
+    :return: the query
+    """
+    mapping_table = mapping_table_for(table_name)
+    src_column = f'src_{ETM_ID_COLUMN}'
+
+    # When appending, start above every id already handed out and skip source ids that
+    # already have one, so previously published rows keep their CT+ sitting_id.
+    if append:
+        offset_expr = (
+            f'(SELECT COALESCE(MAX({ETM_ID_COLUMN}), 0) '
+            f'FROM `{project_id}.{mapping_dataset_id}.{mapping_table}`)')
+        where_clause = f"""
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM `{project_id}.{mapping_dataset_id}.{mapping_table}` mt
+        WHERE mt.{src_column} = t.{src_column} AND
+              mt.src_table_id = '{mapping_namespace}.{table_name}'
+    )"""
+    else:
+        offset_expr = '0'
+        where_clause = ''
+
+    return f'''
+    SELECT
+        '{mapping_namespace}.{table_name}' AS src_table_id,
+        {src_column},
+        {offset_expr} + ROW_NUMBER() OVER (ORDER BY shuffle_key) AS {ETM_ID_COLUMN}
+    FROM (
+        -- RAND() is drawn outside the DISTINCT: pulling it into the same SELECT
+        -- would make every duplicate of {ETM_ID_COLUMN} a distinct row and survive it
+        SELECT {src_column}, RAND() AS shuffle_key
+        FROM (
+            SELECT DISTINCT {ETM_ID_COLUMN} AS {src_column}
+            FROM `{project_id}.{input_dataset_id}.{table_name}`
+        )
+    ) t
+    {where_clause}
+    '''
+
+
+def mapping(table_name, input_dataset_id, project_id, mapping_namespace,
+            mapping_dataset_id):
+    """
+    Create or extend the table that assigns new sitting_id values.
+
+    :param table_name: name of the ETM table
+    :param input_dataset_id: identifies dataset with source data
+    :param project_id: identifies the GCP project that contains the datasets
+    :param mapping_namespace: constant stamped into src_table_id
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    """
+    mapping_namespace = mapping_namespace or DEFAULT_MAPPING_NAMESPACE
+    mapping_table = mapping_table_for(table_name)
+    client = BigQueryClient(project_id)
+
+    append = client.table_exists(mapping_table, mapping_dataset_id)
+    if append:
+        LOGGER.info(f"Appending new '{table_name}' ids to {mapping_table}. "
+                    f'Existing mappings are preserved.')
+        write_disposition = 'WRITE_APPEND'
+    else:
+        LOGGER.info(f'Creating mapping table {mapping_table}...')
+        write_disposition = 'WRITE_TRUNCATE'
+
+    q = mapping_query(table_name, input_dataset_id, project_id,
+                      mapping_namespace, mapping_dataset_id, append)
+    LOGGER.info(f'Query for {mapping_table} is {q}')
+    run_query_to_table(project_id,
+                       q,
+                       destination_dataset_id=mapping_dataset_id,
+                       destination_table_id=mapping_table,
+                       write_disposition=write_disposition)
+
+
+def table_query(client, table_name, input_dataset_id, project_id,
+                pipeline_dataset_id, ct_plus_ids_view, mapping_namespace,
+                mapping_dataset_id):
+    """
+    Get the query that loads one ETM table with its new ids.
+
+    Both joins are inner joins, matching the RT script. A missing mapping row therefore
+    drops the source row rather than loading it with a NULL id, which is the safer of
+    the two failures. assert_no_rows_dropped() turns any such drop into an error, so it
+    cannot pass unnoticed.
+
+    :param client: BigQueryClient, used to read the source schema
+    :param table_name: name of the ETM table
+    :param input_dataset_id: identifies dataset with source data
+    :param project_id: identifies the GCP project that contains the datasets
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_namespace: constant stamped into src_table_id
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :return: the query
+    """
+    schema = client.get_table(
+        f'{project_id}.{input_dataset_id}.{table_name}').schema
+
+    col_exprs = []
+    for field in schema:
+        if field.name == ETM_ID_COLUMN:
+            col_exprs.append(f'm.{ETM_ID_COLUMN}')
+        elif field.name == 'person_id':
+            col_exprs.append('mp.person_id')
+        else:
+            col_exprs.append(f't.{field.name}')
+
+    cols = ',\n        '.join(col_exprs)
+    mapping_table = mapping_table_for(table_name)
+    mapping_person = mapping_table_for(PERSON)
+    person_stamp = person_mapping_src_table_id(pipeline_dataset_id,
+                                               ct_plus_ids_view)
+
+    return f'''
+    SELECT
+        {cols}
+    FROM `{project_id}.{input_dataset_id}.{table_name}` t
+    JOIN `{project_id}.{mapping_dataset_id}.{mapping_table}` m
+        ON t.{ETM_ID_COLUMN} = m.src_{ETM_ID_COLUMN}
+        AND m.src_table_id = '{mapping_namespace}.{table_name}'
+    JOIN `{project_id}.{mapping_dataset_id}.{mapping_person}` mp
+        ON t.person_id = mp.src_person_id
+        AND mp.src_table_id = '{person_stamp}'
+    '''
+
+
+def assert_output_is_a_ct_plus_run(client, output_dataset_id):
+    """
+    Stop the run if the output dataset does not look like a finished CT+ run.
+
+    This script deletes and recreates the four ETM tables in the output dataset, so a
+    mistyped --output_dataset_id destroys them wherever it points. It cannot use
+    assert_output_dataset_is_safe(), which requires an empty dataset: this script is
+    meant to run into a dataset regenerate_ct_plus_ids.py has already filled. Requiring
+    person plus all four ETM tables to be present is the cheapest check that
+    distinguishes the intended target from anything else.
+
+    :param client: BigQueryClient
+    :param output_dataset_id: identifies the dataset the run would write to
+    :raises RuntimeError: if the dataset does not hold a completed CT+ run
+    """
+    try:
+        existing = {
+            table.table_id for table in client.list_tables(output_dataset_id)
+        }
+    except Exception:
+        raise RuntimeError(
+            f'{output_dataset_id} does not exist. Run regenerate_ct_plus_ids.py '
+            f'first; this script replaces the ETM tables that run produces.')
+
+    required = {PERSON} | set(ETM_TABLES)
+    missing = required - existing
+    if missing:
+        raise RuntimeError(
+            f'{output_dataset_id} is missing {sorted(missing)}, so it does not hold a '
+            f'finished CT+ run. This script would delete and recreate '
+            f'{sorted(ETM_TABLES)} in it. Point --output_dataset_id at the dataset '
+            f'regenerate_ct_plus_ids.py wrote.')
+
+
+def assert_no_rows_dropped(client, project_id, table_name, input_dataset_id,
+                           output_dataset_id):
+    """
+    Stop the run if the load lost rows to an unmatched mapping join.
+
+    Both joins in table_query() are inner joins, so a sitting_id or a participant with
+    no mapping row silently removes that row from the released data. The count is the
+    only place that becomes visible.
+
+    :param client: BigQueryClient
+    :param project_id: identifies the GCP project
+    :param table_name: name of the ETM table
+    :param input_dataset_id: identifies dataset with source data
+    :param output_dataset_id: identifies the dataset the run wrote to
+    :raises RuntimeError: if the output holds fewer rows than the input
+    """
+    q = f'''
+    SELECT
+        (SELECT COUNT(*) FROM `{project_id}.{input_dataset_id}.{table_name}`)
+            AS rows_in,
+        (SELECT COUNT(*) FROM `{project_id}.{output_dataset_id}.{table_name}`)
+            AS rows_out
+    '''
+    row = list(client.query(q).result())[0]
+    rows_in, rows_out = row['rows_in'], row['rows_out']
+    if rows_in == rows_out:
+        LOGGER.info(
+            f'{table_name}: {rows_out} rows loaded, matching the input.')
+        return
+
+    raise RuntimeError(
+        f'{table_name} lost {rows_in - rows_out} of {rows_in} rows between '
+        f'{input_dataset_id} and {output_dataset_id}. A row is dropped when its '
+        f'{ETM_ID_COLUMN} or its participant has no mapping row. Establish which '
+        f'before releasing this dataset.')
+
+
+def main(input_dataset_id, output_dataset_id, project_id, pipeline_dataset_id,
+         ct_plus_ids_view, mapping_dataset_id, mapping_namespace):
+    """
+    Replace the ETM tables in a CT+ dataset with re-keyed versions.
+
+    :param input_dataset_id: identifies dataset with source data
+    :param output_dataset_id: identifies the dataset written to
+    :param project_id: identifies the GCP project that contains the datasets
+    :param pipeline_dataset_id: identifies the pipeline_tables dataset
+    :param ct_plus_ids_view: view containing person_id to CT+ id mapping
+    :param mapping_dataset_id: identifies the dataset where mapping tables are stored
+    :param mapping_namespace: constant stamped into src_table_id
+    """
+    bq_client = BigQueryClient(project_id)
+    mapping_namespace = mapping_namespace or DEFAULT_MAPPING_NAMESPACE
+
+    LOGGER.info('ETM CT+ ID regeneration started')
+
+    # This script consumes the person mapping rather than building one, so a missing
+    # mapping dataset means regenerate_ct_plus_ids.py has not run against it.
+    mapping_person = mapping_table_for(PERSON)
+    if not bq_client.table_exists(mapping_person, mapping_dataset_id):
+        raise RuntimeError(
+            f'{mapping_dataset_id}.{mapping_person} does not exist. Run '
+            f'regenerate_ct_plus_ids.py against this mapping dataset first; this '
+            f'script reuses the person mapping it builds.')
+
+    # Same three person guards the main script applies, for the same reasons: a mapping
+    # from another tier would supply the wrong person_ids, a moved CT+ id would re-key
+    # participants silently, and a mapping that is not one to one would duplicate or
+    # merge them.
+    assert_person_mapping_is_ct_plus(bq_client, project_id, mapping_dataset_id,
+                                     pipeline_dataset_id, ct_plus_ids_view)
+    assert_person_ids_have_not_moved(bq_client, project_id, mapping_dataset_id,
+                                     pipeline_dataset_id, ct_plus_ids_view)
+    assert_person_mapping_is_one_to_one(bq_client, project_id,
+                                        mapping_dataset_id)
+
+    # Refuse to delete ETM tables out of anything that is not a finished CT+ run.
+    assert_output_is_a_ct_plus_run(bq_client, output_dataset_id)
+
+    for table_name in ETM_TABLES:
+        if not bq_client.table_exists(table_name, input_dataset_id):
+            LOGGER.info(
+                f'Table {table_name} not found in {input_dataset_id}, skipping')
+            continue
+
+        LOGGER.info(f'Recreating {output_dataset_id}.{table_name}...')
+        source_table = bq_client.get_table(
+            f'{project_id}.{input_dataset_id}.{table_name}')
+        fq_table_name = f'{project_id}.{output_dataset_id}.{table_name}'
+
+        table_to_create = Table(fq_table_name, schema=source_table.schema)
+        if any(field.name == 'person_id' for field in source_table.schema):
+            table_to_create.clustering_fields = ['person_id']
+
+        bq_client.delete_table(fq_table_name, not_found_ok=True)
+        bq_client.create_table(table_to_create)
+
+        mapping(table_name, input_dataset_id, project_id, mapping_namespace,
+                mapping_dataset_id)
+
+        LOGGER.info(f'Loading {table_name} into {output_dataset_id}...')
+        q = table_query(bq_client, table_name, input_dataset_id, project_id,
+                        pipeline_dataset_id, ct_plus_ids_view,
+                        mapping_namespace, mapping_dataset_id)
+        run_query_to_table(project_id,
+                           q,
+                           destination_dataset_id=output_dataset_id,
+                           destination_table_id=table_name,
+                           write_disposition='WRITE_EMPTY')
+
+        assert_no_rows_dropped(bq_client, project_id, table_name,
+                               input_dataset_id, output_dataset_id)
+
+    LOGGER.info('ETM CT+ ID regeneration complete')
+
+
+if __name__ == '__main__':
+    pipeline_logging.configure(logging.INFO, add_console_handler=True)
+    parser = argparse.ArgumentParser(
+        description='Regenerate ETM IDs in a Controlled Tier Plus dataset',
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--project_id',
+                        dest='project_id',
+                        required=True,
+                        help='Project associated with the datasets')
+    parser.add_argument('--input_dataset_id',
+                        dest='input_dataset_id',
+                        required=True,
+                        help='Dataset containing source data')
+    parser.add_argument(
+        '--output_dataset_id',
+        dest='output_dataset_id',
+        required=True,
+        help=
+        'Dataset regenerate_ct_plus_ids.py wrote. Its ETM tables are replaced.')
+    parser.add_argument(
+        '--pipeline_dataset_id',
+        dest='pipeline_dataset_id',
+        required=True,
+        help=
+        'Dataset containing rdr_participant_research_ids_view for person mapping'
+    )
+    parser.add_argument(
+        '--ct_plus_ids_view',
+        dest='ct_plus_ids_view',
+        required=True,
+        help=
+        'View containing controlled_tier_id to controlled_tier_plus_id mapping')
+    parser.add_argument(
+        '--mapping_dataset_id',
+        dest='mapping_dataset_id',
+        required=True,
+        help=
+        'Dataset holding the mapping tables regenerate_ct_plus_ids.py built. '
+        'Use the same one for every release so ids persist between them.')
+    parser.add_argument(
+        '--mapping_namespace',
+        dest='mapping_namespace',
+        required=False,
+        default=DEFAULT_MAPPING_NAMESPACE,
+        help='Constant stamped into src_table_id on every mapping row. Leave at '
+        f"the default ('{DEFAULT_MAPPING_NAMESPACE}'); a per release value breaks "
+        'id persistence silently.')
+
+    args = parser.parse_args()
+    main(args.input_dataset_id, args.output_dataset_id, args.project_id,
+         args.pipeline_dataset_id, args.ct_plus_ids_view,
+         args.mapping_dataset_id, args.mapping_namespace)

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -193,7 +193,7 @@ class RegenerateCtPlusIds(unittest.TestCase):
                                             self.pipeline_dataset_id,
                                             self.ids_view)
 
-    @mock.patch('tools.regenerate_ct_plus_ids.bq_utils.query')
+    @mock.patch('tools.regenerate_ct_plus_ids.run_query_to_table')
     @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
     def test_existing_domain_mapping_is_appended_to(self, mock_client,
                                                     mock_query):
@@ -206,9 +206,9 @@ class RegenerateCtPlusIds(unittest.TestCase):
 
         self.assertEqual(mock_query.call_args.kwargs['write_disposition'],
                          'WRITE_APPEND')
-        self.assertIn('NOT EXISTS', mock_query.call_args.args[0])
+        self.assertIn('NOT EXISTS', mock_query.call_args.args[1])
 
-    @mock.patch('tools.regenerate_ct_plus_ids.bq_utils.query')
+    @mock.patch('tools.regenerate_ct_plus_ids.run_query_to_table')
     @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
     def test_person_mapping_is_rebuilt_from_the_view_every_run(
             self, mock_client, mock_query):
@@ -221,7 +221,42 @@ class RegenerateCtPlusIds(unittest.TestCase):
 
         self.assertEqual(mock_query.call_args.kwargs['write_disposition'],
                          'WRITE_TRUNCATE')
-        self.assertIn(ct.CT_PLUS_PERSON_ID_COLUMN, mock_query.call_args.args[0])
+        self.assertIn(ct.CT_PLUS_PERSON_ID_COLUMN, mock_query.call_args.args[1])
+
+    @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
+    def test_writes_go_to_the_project_that_was_asked_for(self, mock_client):
+        """bq_utils.query took the project from $GOOGLE_CLOUD_PROJECT, not --project_id."""
+        ct.run_query_to_table(self.project_id, 'SELECT 1',
+                              self.mapping_dataset_id, 'some_table')
+
+        mock_client.assert_called_once_with(self.project_id)
+        destination = mock_client.return_value.query.call_args.kwargs[
+            'job_config'].destination
+        self.assertIn(self.project_id, str(destination))
+
+    @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
+    def test_a_failed_write_raises_instead_of_being_ignored(self, mock_client):
+        """A run once logged success while every one of its jobs sat in FAILURE."""
+        mock_client.return_value.query.return_value.result.side_effect = (
+            RuntimeError('job failed'))
+
+        with self.assertRaises(RuntimeError):
+            ct.run_query_to_table(self.project_id, 'SELECT 1',
+                                  self.mapping_dataset_id, 'some_table')
+
+    @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
+    def test_every_write_waits_for_its_job(self, mock_client):
+        """Submitting without polling makes a failed write look like a successful one."""
+        ct.run_query_to_table(self.project_id, 'SELECT 1',
+                              self.mapping_dataset_id, 'some_table')
+
+        mock_client.return_value.query.return_value.result.assert_called_once()
+
+    def test_every_ext_table_with_a_rekeyed_parent_is_listed(self):
+        """An unlisted _ext table is copied verbatim and its ids dangle, silently."""
+        for ext_table in ('specimen_ext', 'visit_detail_ext'):
+            with self.subTest(ext_table=ext_table):
+                self.assertIn(ext_table, ct.EXT_TABLES)
 
     @staticmethod
     def _person_mapping_client(row_count, src_count, ct_plus_count):

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -267,6 +267,40 @@ class RegenerateCtPlusIds(unittest.TestCase):
             with self.subTest(ext_table=ext_table):
                 self.assertIn(ext_table, ct.EXT_TABLES)
 
+    def _ext_query(self, ext_table, base_in_output=True):
+        """Renders update_ext_table's query without running it."""
+        with mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient') as client, \
+             mock.patch('tools.regenerate_ct_plus_ids.run_query_to_table') as write:
+            client.return_value.table_exists.return_value = base_in_output
+            ct.update_ext_table(ext_table, self.input_dataset_id,
+                                self.output_dataset_id, self.project_id,
+                                self.mapping_dataset_id, self.pipeline_dataset_id,
+                                self.ids_view, ct.DEFAULT_MAPPING_NAMESPACE)
+        return write.call_args.args[1]
+
+    def test_ext_rows_whose_base_row_was_dropped_are_not_carried_over(self):
+        """The load filters visit_detail on visit_occurrence_id, but the mapping still
+        holds the dropped rows, so the mapping join alone leaves the ext row pointing
+        at a primary key that is not in the output."""
+        query = self._ext_query('visit_detail_ext')
+
+        self.assertIn(f'{self.output_dataset_id}.visit_detail', query)
+        self.assertIn('b.visit_detail_id = m.visit_detail_id', query)
+
+    def test_the_base_row_check_covers_person_ext_too(self):
+        """person_ext takes a separate branch, which had the same gap."""
+        query = self._ext_query('person_ext')
+
+        self.assertIn(f'{self.output_dataset_id}.person', query)
+        self.assertIn('b.person_id = m.person_id', query)
+
+    def test_a_missing_base_table_does_not_break_the_ext_load(self):
+        """Joining a table that is not in the output would fail the whole run."""
+        query = self._ext_query('note_nlp_ext', base_in_output=False)
+
+        self.assertNotIn(f'{self.output_dataset_id}.note_nlp', query)
+        self.assertIn(f'{self.mapping_dataset_id}.', query)
+
     @staticmethod
     def _person_mapping_client(row_count, src_count, ct_plus_count):
         client = mock.MagicMock()

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -46,6 +46,12 @@ class RegenerateCtPlusIds(unittest.TestCase):
         self.assertNotIn('research_id AS src_person_id', actual)
         self.assertNotIn('registered_tier_id', actual)
 
+    def test_person_mapping_drops_duplicate_view_rows(self):
+        """The ids view carries byte identical duplicates; a LEFT JOIN would fan out."""
+        actual = self._mapping_query(PERSON)
+
+        self.assertIn('SELECT DISTINCT', actual)
+
     def test_person_mapping_src_table_id_is_ct_plus_specific(self):
         """An RT person mapping must not satisfy the CT+ join predicate."""
         src_table_id = ct.person_mapping_src_table_id(self.pipeline_dataset_id,
@@ -216,6 +222,86 @@ class RegenerateCtPlusIds(unittest.TestCase):
         self.assertEqual(mock_query.call_args.kwargs['write_disposition'],
                          'WRITE_TRUNCATE')
         self.assertIn(ct.CT_PLUS_PERSON_ID_COLUMN, mock_query.call_args.args[0])
+
+    @staticmethod
+    def _person_mapping_client(row_count, src_count, ct_plus_count):
+        client = mock.MagicMock()
+        client.table_exists.return_value = True
+        client.query.return_value.result.return_value = [{
+            'row_count': row_count,
+            'src_count': src_count,
+            'ct_plus_count': ct_plus_count
+        }]
+        return client
+
+    def test_one_to_one_person_mapping_is_accepted(self):
+        client = self._person_mapping_client(1000, 1000, 1000)
+
+        ct.assert_person_mapping_is_one_to_one(client, self.project_id,
+                                               self.mapping_dataset_id)
+
+    def test_participant_with_two_ct_plus_ids_stops_the_run(self):
+        """DISTINCT does not collapse these, and the LEFT JOIN would double the rows."""
+        client = self._person_mapping_client(1001, 1000, 1001)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            ct.assert_person_mapping_is_one_to_one(client, self.project_id,
+                                                   self.mapping_dataset_id)
+
+        self.assertIn('more than one CT+ id', str(ctx.exception))
+
+    def test_ct_plus_id_shared_by_two_participants_stops_the_run(self):
+        """Loading this would merge two people into one in the released data."""
+        client = self._person_mapping_client(1000, 1000, 999)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            ct.assert_person_mapping_is_one_to_one(client, self.project_id,
+                                                   self.mapping_dataset_id)
+
+        self.assertIn('shared by more than one participant', str(ctx.exception))
+
+    def test_missing_person_mapping_skips_the_one_to_one_check(self):
+        client = mock.MagicMock()
+        client.table_exists.return_value = False
+
+        ct.assert_person_mapping_is_one_to_one(client, self.project_id,
+                                               self.mapping_dataset_id)
+
+        client.query.assert_not_called()
+
+    def test_non_empty_output_dataset_stops_the_run(self):
+        """main() drops every CDM table in the output dataset before loading."""
+        client = mock.MagicMock()
+        client.list_tables.return_value = [
+            mock.Mock(table_id='observation'),
+            mock.Mock(table_id='measurement')
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            ct.assert_output_dataset_is_safe(client, self.output_dataset_id,
+                                             False)
+
+        self.assertIn(self.output_dataset_id, str(ctx.exception))
+
+    def test_empty_output_dataset_is_accepted(self):
+        client = mock.MagicMock()
+        client.list_tables.return_value = []
+
+        ct.assert_output_dataset_is_safe(client, self.output_dataset_id, False)
+
+    def test_absent_output_dataset_is_accepted(self):
+        """main() creates it further down, so a missing dataset is not an error."""
+        client = mock.MagicMock()
+        client.list_tables.side_effect = Exception('404 Not found')
+
+        ct.assert_output_dataset_is_safe(client, self.output_dataset_id, False)
+
+    def test_allow_replace_skips_the_check_without_listing(self):
+        client = mock.MagicMock()
+
+        ct.assert_output_dataset_is_safe(client, self.output_dataset_id, True)
+
+        client.list_tables.assert_not_called()
 
     def test_missing_person_mapping_is_accepted(self):
         client = mock.MagicMock()

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -24,17 +24,18 @@ class RegenerateCtPlusIds(unittest.TestCase):
         self.pipeline_dataset_id = 'fake_pipeline'
         self.ids_view = 'fake_ids_view'
 
-    def _mapping_query(self, table_name):
+    def _mapping_query(self, table_name, append=False):
         return ct.mapping_query(table_name, self.input_dataset_id,
                                 self.project_id, self.pipeline_dataset_id,
-                                self.ids_view, self.input_dataset_id,
-                                self.mapping_dataset_id)
+                                self.ids_view, ct.DEFAULT_MAPPING_NAMESPACE,
+                                self.mapping_dataset_id, append)
 
     def _table_query(self, table_name):
         return ct.table_query(table_name, self.input_dataset_id,
                               self.output_dataset_id, self.project_id,
                               self.pipeline_dataset_id, self.ids_view,
-                              self.mapping_dataset_id, self.input_dataset_id)
+                              self.mapping_dataset_id,
+                              ct.DEFAULT_MAPPING_NAMESPACE)
 
     def test_person_mapping_reads_ct_plus_columns(self):
         """The CT input's person_id is controlled_tier_id, not research_id."""
@@ -70,12 +71,31 @@ class RegenerateCtPlusIds(unittest.TestCase):
 
         self.assertNotIn('RAND()', distinct_clause)
 
-    def test_mapping_query_never_offsets_by_a_running_maximum(self):
-        """Appending would place later ids above earlier ones and leak arrival order."""
+    def test_first_release_draws_ids_without_an_offset(self):
+        """With no prior mapping there is nothing to preserve or sit above."""
         actual = self._mapping_query(MEASUREMENT)
 
         self.assertNotIn('MAX(', actual)
         self.assertNotIn('NOT EXISTS', actual)
+        self.assertIn('0 + ROW_NUMBER()', actual)
+
+    def test_later_releases_preserve_existing_ids(self):
+        """A row published in one release must keep its CT+ id in the next."""
+        actual = self._mapping_query(MEASUREMENT, append=True)
+
+        self.assertIn('COALESCE(MAX(measurement_id), 0)', actual)
+        self.assertIn('NOT EXISTS', actual)
+        self.assertIn('mt.src_measurement_id = t.src_measurement_id', actual)
+
+    def test_append_filter_and_load_filter_use_the_same_namespace(self):
+        """A per release stamp would strand earlier ids and reassign them silently."""
+        stamp = f"'{ct.DEFAULT_MAPPING_NAMESPACE}.{MEASUREMENT}'"
+
+        self.assertIn(f'mt.src_table_id = {stamp}',
+                      self._mapping_query(MEASUREMENT, append=True))
+        self.assertIn(stamp, self._table_query(MEASUREMENT))
+        self.assertNotIn(f"'{self.input_dataset_id}.{MEASUREMENT}'",
+                         self._mapping_query(MEASUREMENT, append=True))
 
     def test_survey_conduct_remaps_its_foreign_keys(self):
         actual = self._table_query(SURVEY_CONDUCT)
@@ -166,6 +186,36 @@ class RegenerateCtPlusIds(unittest.TestCase):
                                             self.mapping_dataset_id,
                                             self.pipeline_dataset_id,
                                             self.ids_view)
+
+    @mock.patch('tools.regenerate_ct_plus_ids.bq_utils.query')
+    @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
+    def test_existing_domain_mapping_is_appended_to(self, mock_client,
+                                                    mock_query):
+        """Truncating would hand every previously published row a new CT+ id."""
+        mock_client.return_value.table_exists.return_value = True
+
+        ct.mapping(MEASUREMENT, self.input_dataset_id, self.output_dataset_id,
+                   self.project_id, self.pipeline_dataset_id, self.ids_view,
+                   None, self.mapping_dataset_id)
+
+        self.assertEqual(mock_query.call_args.kwargs['write_disposition'],
+                         'WRITE_APPEND')
+        self.assertIn('NOT EXISTS', mock_query.call_args.args[0])
+
+    @mock.patch('tools.regenerate_ct_plus_ids.bq_utils.query')
+    @mock.patch('tools.regenerate_ct_plus_ids.BigQueryClient')
+    def test_person_mapping_is_rebuilt_from_the_view_every_run(
+            self, mock_client, mock_query):
+        """Skipping it would leave participants new in a later release unmapped."""
+        mock_client.return_value.table_exists.return_value = True
+
+        ct.mapping(PERSON, self.input_dataset_id, self.output_dataset_id,
+                   self.project_id, self.pipeline_dataset_id, self.ids_view,
+                   None, self.mapping_dataset_id)
+
+        self.assertEqual(mock_query.call_args.kwargs['write_disposition'],
+                         'WRITE_TRUNCATE')
+        self.assertIn(ct.CT_PLUS_PERSON_ID_COLUMN, mock_query.call_args.args[0])
 
     def test_missing_person_mapping_is_accepted(self):
         client = mock.MagicMock()

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -274,8 +274,9 @@ class RegenerateCtPlusIds(unittest.TestCase):
             client.return_value.table_exists.return_value = base_in_output
             ct.update_ext_table(ext_table, self.input_dataset_id,
                                 self.output_dataset_id, self.project_id,
-                                self.mapping_dataset_id, self.pipeline_dataset_id,
-                                self.ids_view, ct.DEFAULT_MAPPING_NAMESPACE)
+                                self.mapping_dataset_id,
+                                self.pipeline_dataset_id, self.ids_view,
+                                ct.DEFAULT_MAPPING_NAMESPACE)
         return write.call_args.args[1]
 
     def test_ext_rows_whose_base_row_was_dropped_are_not_carried_over(self):

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -1,0 +1,179 @@
+"""Unit tests for the CT+ ID regeneration query builders."""
+import unittest
+from unittest import mock
+
+from common import (CARE_SITE, CONDITION_OCCURRENCE, DRUG_EXPOSURE, MEASUREMENT,
+                    OBSERVATION, PERSON, PROCEDURE_OCCURRENCE, PROVIDER,
+                    SURVEY_CONDUCT, VISIT_OCCURRENCE)
+from tools import regenerate_ct_plus_ids as ct
+
+
+class RegenerateCtPlusIds(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'fake_project'
+        self.input_dataset_id = 'fake_controlled_tier'
+        self.output_dataset_id = 'fake_controlled_tier_plus'
+        self.mapping_dataset_id = 'fake_mapping'
+        self.pipeline_dataset_id = 'fake_pipeline'
+        self.ids_view = 'fake_ids_view'
+
+    def _mapping_query(self, table_name):
+        return ct.mapping_query(table_name, self.input_dataset_id,
+                                self.project_id, self.pipeline_dataset_id,
+                                self.ids_view, self.input_dataset_id,
+                                self.mapping_dataset_id)
+
+    def _table_query(self, table_name):
+        return ct.table_query(table_name, self.input_dataset_id,
+                              self.output_dataset_id, self.project_id,
+                              self.pipeline_dataset_id, self.ids_view,
+                              self.mapping_dataset_id, self.input_dataset_id)
+
+    def test_person_mapping_reads_ct_plus_columns(self):
+        """The CT input's person_id is controlled_tier_id, not research_id."""
+        actual = self._mapping_query(PERSON)
+
+        self.assertIn('controlled_tier_id AS src_person_id', actual)
+        self.assertIn('controlled_tier_plus_id AS person_id', actual)
+        self.assertNotIn('research_id AS src_person_id', actual)
+        self.assertNotIn('registered_tier_id', actual)
+
+    def test_person_mapping_src_table_id_is_ct_plus_specific(self):
+        """An RT person mapping must not satisfy the CT+ join predicate."""
+        src_table_id = ct.person_mapping_src_table_id(self.pipeline_dataset_id,
+                                                      self.ids_view)
+
+        self.assertTrue(src_table_id.endswith(ct.CT_PLUS_PERSON_MAPPING_SUFFIX))
+        self.assertNotEqual(src_table_id,
+                            f'{self.pipeline_dataset_id}.{self.ids_view}')
+        self.assertIn(src_table_id, self._table_query(OBSERVATION))
+
+    def test_row_ids_are_a_random_permutation(self):
+        """Ordering by the source id would let CT and CT+ be aligned by sorting."""
+        actual = self._mapping_query(MEASUREMENT)
+
+        self.assertIn('ROW_NUMBER() OVER (ORDER BY shuffle_key)', actual)
+        self.assertIn('RAND() AS shuffle_key', actual)
+        self.assertNotIn('ORDER BY src_measurement_id', actual)
+
+    def test_row_id_shuffle_key_is_drawn_outside_the_distinct(self):
+        """RAND() inside the DISTINCT would let duplicate source ids survive it."""
+        actual = self._mapping_query(MEASUREMENT)
+        distinct_clause = actual.split('SELECT DISTINCT')[1].split('FROM')[0]
+
+        self.assertNotIn('RAND()', distinct_clause)
+
+    def test_mapping_query_never_offsets_by_a_running_maximum(self):
+        """Appending would place later ids above earlier ones and leak arrival order."""
+        actual = self._mapping_query(MEASUREMENT)
+
+        self.assertNotIn('MAX(', actual)
+        self.assertNotIn('NOT EXISTS', actual)
+
+    def test_survey_conduct_remaps_its_foreign_keys(self):
+        actual = self._table_query(SURVEY_CONDUCT)
+
+        self.assertIn('m.survey_conduct_id', actual)
+        self.assertIn('CAST(m.survey_conduct_id AS STRING)', actual)
+        self.assertIn('mpr.provider_id', actual)
+        self.assertIn('mvo.visit_occurrence_id', actual)
+        self.assertIn('rvo.visit_occurrence_id AS response_visit_occurrence_id',
+                      actual)
+        self.assertNotIn('t.provider_id,', actual)
+        self.assertNotIn('t.visit_occurrence_id,', actual)
+        self.assertNotIn('t.response_visit_occurrence_id,', actual)
+
+    def test_questionnaire_response_id_follows_survey_conduct(self):
+        actual = self._table_query(OBSERVATION)
+
+        self.assertIn('mqr.survey_conduct_id AS questionnaire_response_id',
+                      actual)
+        self.assertIn(ct.mapping_table_for(SURVEY_CONDUCT), actual)
+
+    def test_provider_id_is_remapped_wherever_it_is_referenced(self):
+        for table_name in (VISIT_OCCURRENCE, MEASUREMENT, CONDITION_OCCURRENCE):
+            with self.subTest(table_name=table_name):
+                actual = self._table_query(table_name)
+
+                self.assertIn('mpr.provider_id', actual)
+                self.assertIn(ct.mapping_table_for(PROVIDER), actual)
+
+    def test_fact_relationship_resolves_both_sides_per_domain(self):
+        actual = self._table_query(ct.FACT_RELATIONSHIP)
+
+        for domain_concept_id, domain_table in ct.DOMAIN_CONCEPT_ID_TO_TABLE.items(
+        ):
+            with self.subTest(domain_table=domain_table):
+                self.assertIn(ct.mapping_table_for(domain_table), actual)
+                self.assertIn(f'domain_concept_id_1 = {domain_concept_id}',
+                              actual)
+                self.assertIn(f'domain_concept_id_2 = {domain_concept_id}',
+                              actual)
+
+        self.assertIn('WHERE fact_id_1 IS NOT NULL', actual)
+        self.assertIn('AND fact_id_2 IS NOT NULL', actual)
+
+    def test_fact_relationship_domain_map_covers_the_observed_domains(self):
+        """Domains seen in the CT input. Anything else resolves to NULL and is dropped."""
+        expected = {
+            10: PROCEDURE_OCCURRENCE,
+            13: DRUG_EXPOSURE,
+            19: CONDITION_OCCURRENCE,
+            21: MEASUREMENT,
+            27: OBSERVATION,
+            57: CARE_SITE,
+        }
+
+        self.assertDictEqual(ct.DOMAIN_CONCEPT_ID_TO_TABLE, expected)
+
+    def test_aou_death_id_is_preserved(self):
+        """aou_death_id is a GUID and is shared with CT, matching RT."""
+        actual = self._table_query('aou_death')
+
+        self.assertIn('t.aou_death_id', actual)
+        self.assertIn('mp.person_id', actual)
+
+    def test_person_mapping_from_another_tier_is_rejected(self):
+        client = mock.MagicMock()
+        client.table_exists.return_value = True
+        client.query.return_value.result.return_value = [{
+            'src_table_id': f'{self.pipeline_dataset_id}.{self.ids_view}'
+        }]
+
+        with self.assertRaises(RuntimeError):
+            ct.assert_person_mapping_is_ct_plus(client, self.project_id,
+                                                self.mapping_dataset_id,
+                                                self.pipeline_dataset_id,
+                                                self.ids_view)
+
+    def test_person_mapping_from_a_previous_ct_plus_run_is_accepted(self):
+        client = mock.MagicMock()
+        client.table_exists.return_value = True
+        client.query.return_value.result.return_value = [{
+            'src_table_id':
+                ct.person_mapping_src_table_id(self.pipeline_dataset_id,
+                                               self.ids_view)
+        }]
+
+        ct.assert_person_mapping_is_ct_plus(client, self.project_id,
+                                            self.mapping_dataset_id,
+                                            self.pipeline_dataset_id,
+                                            self.ids_view)
+
+    def test_missing_person_mapping_is_accepted(self):
+        client = mock.MagicMock()
+        client.table_exists.return_value = False
+
+        ct.assert_person_mapping_is_ct_plus(client, self.project_id,
+                                            self.mapping_dataset_id,
+                                            self.pipeline_dataset_id,
+                                            self.ids_view)
+
+        client.query.assert_not_called()

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -1,4 +1,5 @@
 """Unit tests for the CT+ ID regeneration query builders."""
+import inspect
 import unittest
 from unittest import mock
 
@@ -303,6 +304,63 @@ class RegenerateCtPlusIds(unittest.TestCase):
                                                self.mapping_dataset_id)
 
         client.query.assert_not_called()
+
+    @staticmethod
+    def _person_drift_client(shared_count, moved_count, examples=()):
+        client = mock.MagicMock()
+        client.table_exists.return_value = True
+        client.query.return_value.result.return_value = [{
+            'shared_count': shared_count,
+            'moved_count': moved_count,
+            'examples': list(examples)
+        }]
+        return client
+
+    def _assert_ids_have_not_moved(self, client):
+        ct.assert_person_ids_have_not_moved(client, self.project_id,
+                                            self.mapping_dataset_id,
+                                            self.pipeline_dataset_id,
+                                            self.ids_view)
+
+    def test_unchanged_person_ids_are_accepted(self):
+        self._assert_ids_have_not_moved(self._person_drift_client(1000, 0))
+
+    def test_a_reissued_ct_plus_person_id_stops_the_run(self):
+        """The view moving would re-key participants while row ids stay pinned."""
+        client = self._person_drift_client(1000, 3, examples=[11, 22, 33])
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self._assert_ids_have_not_moved(client)
+
+        message = str(ctx.exception)
+        self.assertIn('3 of 1000', message)
+        self.assertIn('11', message)
+
+    def test_first_run_skips_the_person_drift_check(self):
+        """There is no previous mapping to disagree with."""
+        client = mock.MagicMock()
+        client.table_exists.return_value = False
+
+        self._assert_ids_have_not_moved(client)
+
+        client.query.assert_not_called()
+
+    def test_person_drift_check_is_scoped_to_the_ct_plus_namespace(self):
+        """A mapping dataset can hold rows another tier's run wrote."""
+        client = self._person_drift_client(1000, 0)
+
+        self._assert_ids_have_not_moved(client)
+
+        q = client.query.call_args.args[0]
+        self.assertIn(
+            ct.person_mapping_src_table_id(self.pipeline_dataset_id,
+                                           self.ids_view), q)
+
+    def test_person_drift_check_runs_before_the_mapping_is_rebuilt(self):
+        """_mapping_person is WRITE_TRUNCATE, so the check must precede the loop."""
+        source = inspect.getsource(ct.main)
+        self.assertLess(source.index('assert_person_ids_have_not_moved'),
+                        source.index('Generating mapping tables'))
 
     def test_non_empty_output_dataset_stops_the_run(self):
         """main() drops every CDM table in the output dataset before loading."""

--- a/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_ct_plus_ids_test.py
@@ -167,6 +167,14 @@ class RegenerateCtPlusIds(unittest.TestCase):
         self.assertIn('t.aou_death_id', actual)
         self.assertIn('mp.person_id', actual)
 
+    def test_no_mapping_is_built_for_the_preserved_aou_death_id(self):
+        """table_query() reads aou_death_id from the source row, so a mapping
+        built for it is written on every run and never read."""
+        source = inspect.getsource(ct.main)
+        self.assertIn('if table_name == AOU_DEATH', source)
+        self.assertLess(source.index('if table_name == AOU_DEATH'),
+                        source.index('Creating mapping for'))
+
     def test_person_mapping_from_another_tier_is_rejected(self):
         client = mock.MagicMock()
         client.table_exists.return_value = True

--- a/tests/unit_tests/data_steward/tools/regenerate_etm_ct_plus_ids_test.py
+++ b/tests/unit_tests/data_steward/tools/regenerate_etm_ct_plus_ids_test.py
@@ -1,0 +1,190 @@
+"""Unit tests for the ETM CT+ ID regeneration query builders."""
+import unittest
+from unittest import mock
+
+from common import PERSON
+from tools import regenerate_ct_plus_ids as ct
+from tools import regenerate_etm_ct_plus_ids as etm
+
+
+class RegenerateEtmCtPlusIds(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print('**************************************************************')
+        print(cls.__name__)
+        print('**************************************************************')
+
+    def setUp(self):
+        self.project_id = 'fake_project'
+        self.input_dataset_id = 'fake_controlled_tier'
+        self.output_dataset_id = 'fake_controlled_tier_plus'
+        self.mapping_dataset_id = 'fake_mapping'
+        self.pipeline_dataset_id = 'fake_pipeline'
+        self.ids_view = 'fake_ids_view'
+
+    def _mapping_query(self, table_name, append=False):
+        return etm.mapping_query(table_name, self.input_dataset_id,
+                                 self.project_id, ct.DEFAULT_MAPPING_NAMESPACE,
+                                 self.mapping_dataset_id, append)
+
+    @staticmethod
+    def _schema(*names):
+        # name cannot be passed to the MagicMock constructor: it sets the mock's own
+        # name rather than an attribute, and field.name would return a repr instead.
+        fields = []
+        for field_name in names:
+            field = mock.MagicMock()
+            field.name = field_name
+            fields.append(field)
+        return fields
+
+    def _table_query(self, table_name, schema=None):
+        client = mock.MagicMock()
+        client.get_table.return_value.schema = schema or self._schema(
+            'sitting_id', 'person_id', 'src_id')
+        return etm.table_query(client, table_name, self.input_dataset_id,
+                               self.project_id, self.pipeline_dataset_id,
+                               self.ids_view, ct.DEFAULT_MAPPING_NAMESPACE,
+                               self.mapping_dataset_id)
+
+    def test_the_four_etm_tables_are_covered(self):
+        self.assertEqual(sorted(etm.ETM_TABLES),
+                         ['delaydiscounting', 'emorecog', 'flanker', 'gradcpt'])
+
+    def test_sitting_ids_are_shuffled_not_order_preserving(self):
+        """An order preserving draw is undone by sorting, which is the whole exposure."""
+        for table in etm.ETM_TABLES:
+            with self.subTest(table=table):
+                q = self._mapping_query(table)
+                self.assertIn('ORDER BY shuffle_key', q)
+                self.assertNotIn('ORDER BY sitting_id', q)
+
+    def test_rand_is_drawn_outside_the_distinct(self):
+        """Inside it, every duplicate sitting_id becomes a distinct row and survives."""
+        q = self._mapping_query('gradcpt')
+        rand_at = q.index('RAND() AS shuffle_key')
+        distinct_at = q.index('SELECT DISTINCT sitting_id')
+        self.assertLess(rand_at, distinct_at)
+
+    def test_a_first_run_draws_from_zero(self):
+        q = self._mapping_query('flanker', append=False)
+        self.assertIn('0 + ROW_NUMBER()', q)
+        self.assertNotIn('NOT EXISTS', q)
+
+    def test_a_later_run_preserves_existing_ids(self):
+        """Persistence: previously published rows keep their CT+ sitting_id."""
+        q = self._mapping_query('flanker', append=True)
+        self.assertIn('NOT EXISTS', q)
+        self.assertIn('COALESCE(MAX(sitting_id), 0)', q)
+        self.assertIn('mt.src_sitting_id = t.src_sitting_id', q)
+
+    def test_the_load_takes_sitting_id_from_the_mapping(self):
+        q = self._table_query('emorecog')
+        self.assertIn('m.sitting_id', q)
+        self.assertIn('t.sitting_id = m.src_sitting_id', q)
+
+    def test_the_load_takes_person_id_from_the_ct_plus_mapping(self):
+        """Matching an RT stamp here would hand CT+ the RT person_ids with no error."""
+        q = self._table_query('emorecog')
+        expected = ct.person_mapping_src_table_id(self.pipeline_dataset_id,
+                                                  self.ids_view)
+        self.assertIn('mp.person_id', q)
+        self.assertIn(f"mp.src_table_id = '{expected}'", q)
+
+    def test_other_columns_come_from_the_source_row(self):
+        q = self._table_query('gradcpt',
+                              schema=self._schema('sitting_id', 'person_id',
+                                                  'src_id', 'score'))
+        self.assertIn('t.src_id', q)
+        self.assertIn('t.score', q)
+
+    def test_a_mistyped_output_dataset_stops_the_run(self):
+        """This script deletes the ETM tables wherever --output_dataset_id points."""
+        client = mock.MagicMock()
+        client.list_tables.return_value = [
+            mock.MagicMock(**{'table_id': t}) for t in ('person', 'observation')
+        ]
+
+        with self.assertRaises(RuntimeError) as ctx:
+            etm.assert_output_is_a_ct_plus_run(client, self.output_dataset_id)
+
+        self.assertIn('does not hold a finished CT+ run', str(ctx.exception))
+
+    def test_a_finished_ct_plus_output_is_accepted(self):
+        client = mock.MagicMock()
+        client.list_tables.return_value = [
+            mock.MagicMock(**{'table_id': t}) for t in [PERSON] + etm.ETM_TABLES
+        ]
+
+        etm.assert_output_is_a_ct_plus_run(client, self.output_dataset_id)
+
+    def test_a_missing_output_dataset_stops_the_run(self):
+        client = mock.MagicMock()
+        client.list_tables.side_effect = Exception('no such dataset')
+
+        with self.assertRaises(RuntimeError) as ctx:
+            etm.assert_output_is_a_ct_plus_run(client, self.output_dataset_id)
+
+        self.assertIn('does not exist', str(ctx.exception))
+
+    @staticmethod
+    def _counts_client(rows_in, rows_out):
+        client = mock.MagicMock()
+        client.query.return_value.result.return_value = [{
+            'rows_in': rows_in,
+            'rows_out': rows_out
+        }]
+        return client
+
+    def test_matching_row_counts_are_accepted(self):
+        etm.assert_no_rows_dropped(self._counts_client(74, 74), self.project_id,
+                                   'gradcpt', self.input_dataset_id,
+                                   self.output_dataset_id)
+
+    def test_rows_lost_to_an_unmatched_join_stop_the_run(self):
+        """Both joins are inner, so an unmapped row leaves the released data silently."""
+        client = self._counts_client(74, 70)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            etm.assert_no_rows_dropped(client, self.project_id, 'gradcpt',
+                                       self.input_dataset_id,
+                                       self.output_dataset_id)
+
+        self.assertIn('lost 4 of 74 rows', str(ctx.exception))
+
+    @mock.patch('tools.regenerate_etm_ct_plus_ids.run_query_to_table')
+    @mock.patch('tools.regenerate_etm_ct_plus_ids.BigQueryClient')
+    def test_an_existing_mapping_is_appended_to(self, mock_client, mock_write):
+        mock_client.return_value.table_exists.return_value = True
+
+        etm.mapping('flanker', self.input_dataset_id, self.project_id,
+                    ct.DEFAULT_MAPPING_NAMESPACE, self.mapping_dataset_id)
+
+        self.assertEqual(mock_write.call_args.kwargs['write_disposition'],
+                         'WRITE_APPEND')
+
+    @mock.patch('tools.regenerate_etm_ct_plus_ids.run_query_to_table')
+    @mock.patch('tools.regenerate_etm_ct_plus_ids.BigQueryClient')
+    def test_a_first_mapping_is_created(self, mock_client, mock_write):
+        mock_client.return_value.table_exists.return_value = False
+
+        etm.mapping('flanker', self.input_dataset_id, self.project_id,
+                    ct.DEFAULT_MAPPING_NAMESPACE, self.mapping_dataset_id)
+
+        self.assertEqual(mock_write.call_args.kwargs['write_disposition'],
+                         'WRITE_TRUNCATE')
+
+    def test_writes_go_through_the_checked_helper(self):
+        """bq_utils.query ignores --project_id and does not inspect the job result."""
+        import inspect
+        # Import lines only: the module docstring names bq_utils when explaining why
+        # this script does not use it, so searching the whole source matches prose.
+        imports = [
+            line for line in inspect.getsource(etm).splitlines()
+            if line.startswith(('import ', 'from '))
+        ]
+        self.assertFalse([line for line in imports if 'bq_utils' in line])
+        # The binding, not the import line: run_query_to_table arrives on a
+        # continuation line of a multi-line import and would not be matched above.
+        self.assertIs(etm.run_query_to_table, ct.run_query_to_table)


### PR DESCRIPTION
What

- Two standalone tools, mirroring the RT pair: regenerate_ct_plus_ids.py (CDM tables, forked from regenerate_rt_ids.py) and regenerate_etm_ct_plus_ids.py (the four EtM tables, modelled on regenerate_etm_rt_ids.py). Run in sequence after deid_clean, last step before publication.

Where to look

- Row IDs are a random permutation, not ORDER BY src_<table>_id. The RT form leaks CT ordering, so anyone holding both tiers realigns rows by sorting. RAND() is drawn outside the DISTINCT; inside it, duplicate source IDs survive.
- The src_table_id stamp is the constant ct_plus, not the input dataset name. Both the append filter and the load-side join match on it, so a per-release value would silently reassign every ID and defeat persistence.
- Two guards abort the run before writing: a person mapping from a different run, and any already-published participant who would be issued a new CT+ ID.

Refinement from validation

- update_ext_table now resolves _ext IDs against the loaded base table as well as the mapping, so _ext rows stay in step with a base table the load has filtered.

Notes

- The person mapping has been exercised against a mock rdr_participant_research_ids_view, using real CT person_id values with placeholder CT+ ids. The real values arrive with DL-2396, after which the pipeline can run end to end.
- Expect row count differences on two tables: visit_detail (9.65%) and fact_relationship (92%), where source rows carry references these scripts have no target to map to. The filters are intentional and the source of those rows is upstream of this work.
- 56 unit tests cover the query builders for both scripts. Validated against preprod scratch datasets only; nothing live was written to.

CI

- integration_test fails at gcloud auth activate-service-account with invalid_grant: Invalid JWT Signature. The CircleCI service-account key is stale or revoked, zero tests ran, unrelated to these commits. unit_test and Codacy pass.
